### PR TITLE
bug(zfspv): not able to deploy on rancher with ZFS 0.8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,5 +152,10 @@ zfspv-pool/pvc-f52058b7-da1c-11e9-80e0-42010a800fcd  4.25G  96.4G  5.69M  -
 
 4. for deprovisioning the volume we can delete the application which is using
    the volume and then we can go ahead and delete the pv, as part of deletion of
-   pv this volume will also be deleted from the ZFS pool and data will be free.
+   pv this volume will also be deleted from the ZFS pool and data will be freed.
 
+### Supported System
+
+K8S : 1.14+
+OS : ubuntu 18.04
+ZFS : 0.7, 0.8

--- a/buildscripts/zfs-driver/Dockerfile
+++ b/buildscripts/zfs-driver/Dockerfile
@@ -3,9 +3,9 @@
 # volume-mgmt  releases.
 #
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 RUN apt-get update; exit 0
-RUN apt-get -y install rsyslog
+RUN apt-get -y install rsyslog libssl-dev
 #RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY zfs-driver /usr/local/bin/

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -398,15 +398,15 @@ spec:
               mountPath: /dev
             - name: zfs-bin
               mountPath: /sbin/zfs
-            - name: lib1
+            - name: libzpool
               mountPath: /lib/libzpool.so.2
-            - name: lib2
+            - name: libzfscore
               mountPath: /lib/libzfs_core.so.1
-            - name: lib3
+            - name: libzfs
               mountPath: /lib/libzfs.so.2
-            - name: lib4
+            - name: libuutil
               mountPath: /lib/libuutil.so.1
-            - name: lib5
+            - name: libnvpair
               mountPath: /lib/libnvpair.so.1
             - name: pods-mount-dir
               mountPath: /var/lib/kubelet/pods
@@ -421,27 +421,21 @@ spec:
         - name: zfs-bin
           hostPath:
             path: /sbin/zfs
-            type: File
-        - name: lib1
+        - name: libzpool
           hostPath:
             path: /lib/libzpool.so.2.0.0
-            type: File
-        - name: lib2
+        - name: libzfscore
           hostPath:
             path: /lib/libzfs_core.so.1.0.0
-            type: File
-        - name: lib3
+        - name: libzfs
           hostPath:
             path: /lib/libzfs.so.2.0.0
-            type: File
-        - name: lib4
+        - name: libuutil
           hostPath:
             path: /lib/libuutil.so.1.0.1
-            type: File
-        - name: lib5
+        - name: libnvpair
           hostPath:
             path: /lib/libnvpair.so.1.0.1
-            type: File
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry/


### PR DESCRIPTION
The ZFS 0.8 has dependency on libcrypto.so.1.1 which in turn
requires GLIBC_2.25 supported by the system. Changed the docker
image to 18:04 as 16:04 has glibc version 2.23.

Also updated the README with the supported system details.

Signed-off-by: Pawan <pawan@mayadata.io>