### PR TITLE
feat(ZFSPV): adding encryption in ZFSVolume CR

### DIFF
--- a/deploy/sample/fio.yaml
+++ b/deploy/sample/fio.yaml
@@ -8,6 +8,9 @@ parameters:
   compression: "on"
   dedup: "on"
   thinprovision: "yes"
+  #encryption: "on"
+  #keyformat: "raw"
+  #keylocation: "file:///home/pawan/key"
   poolname: "zfspv-pool"
 provisioner: openebs.io/zfs
 volumeBindingMode: WaitForFirstConsumer

--- a/deploy/sample/percona.yaml
+++ b/deploy/sample/percona.yaml
@@ -1,0 +1,131 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-zfspv
+allowVolumeExpansion: true
+parameters:
+  blocksize: "4k"
+  compression: "on"
+  dedup: "on"
+  thinprovision: "yes"
+  poolname: "zfspv-pool"
+provisioner: openebs.io/zfs
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: csi-zfspv
+spec:
+  storageClassName: openebs-zfspv
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4Gi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+  name: sqltest
+  namespace: default
+data:
+  sql-test.sh: |
+    #!/bin/bash
+
+    DB_PREFIX="Inventory"
+    DB_SUFFIX=`echo $(mktemp) | cut -d '.' -f 2`
+    DB_NAME="${DB_PREFIX}_${DB_SUFFIX}"
+
+
+    echo -e "\nWaiting for mysql server to start accepting connections.."
+    retries=10;wait_retry=30
+    for i in `seq 1 $retries`; do
+      mysql -uroot -pk8sDem0 -e 'status' > /dev/null 2>&1
+      rc=$?
+      [ $rc -eq 0 ] && break
+      sleep $wait_retry
+    done
+
+    if [ $rc -ne 0 ];
+    then
+      echo -e "\nFailed to connect to db server after trying for $(($retries * $wait_retry))s, exiting\n"
+      exit 1
+    fi
+    mysql -uroot -pk8sDem0 -e "CREATE DATABASE $DB_NAME;"
+    mysql -uroot -pk8sDem0 -e "CREATE TABLE Hardware (id INTEGER, name VARCHAR(20), owner VARCHAR(20),description VARCHAR(20));" $DB_NAME
+    mysql -uroot -pk8sDem0 -e "INSERT INTO Hardware (id, name, owner, description) values (1, "dellserver", "basavaraj", "controller");" $DB_NAME
+    mysql -uroot -pk8sDem0 -e "DROP DATABASE $DB_NAME;"
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: percona
+  labels:
+    name: percona
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: percona
+  template:
+    metadata:
+      labels:
+        name: percona
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values:
+                - gke-pawan-zfspv-default-pool-26f2b9a9-5fqd
+      containers:
+        - resources:
+          name: percona
+          image: openebs/tests-custom-percona:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--ignore-db-dir"
+            - "lost+found"
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: k8sDem0
+          ports:
+            - containerPort: 3306
+              name: percona
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: demo-vol1
+            - mountPath: /sql-test.sh
+              subPath: sql-test.sh
+              name: sqltest-configmap
+          livenessProbe:
+            exec:
+              command: ["bash", "sql-test.sh"]
+            initialDelaySeconds: 30
+            periodSeconds: 1
+            timeoutSeconds: 10
+      volumes:
+        - name: demo-vol1
+          persistentVolumeClaim:
+            claimName: csi-zfspv
+        - name: sqltest-configmap
+          configMap:
+            name: sqltest
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: percona-mysql
+  labels:
+    name: percona-mysql
+spec:
+  ports:
+    - port: 3306
+      targetPort: 3306
+  selector:
+      name: percona

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -396,6 +396,8 @@ spec:
               mountPath: /plugin
             - name: device-dir
               mountPath: /dev
+            - name: encr-keys
+              mountPath: /home/keys
             - name: zfs-bin
               mountPath: /sbin/zfs
             - name: libzpool
@@ -418,6 +420,10 @@ spec:
           hostPath:
             path: /dev
             type: Directory
+        - name: encr-keys
+          hostPath:
+            path: /home/keys
+            type: DirectoryOrCreate
         - name: zfs-bin
           hostPath:
             path: /sbin/zfs

--- a/pkg/apis/openebs.io/core/v1alpha1/zfsvolume.go
+++ b/pkg/apis/openebs.io/core/v1alpha1/zfsvolume.go
@@ -98,6 +98,14 @@ type VolumeInfo struct {
 	// should be enabled on the zvol
 	Encryption string `json:"encryption"`
 
+	// KeyLocation is the location of key
+	// for the encryption
+	KeyLocation string `json:"keylocation"`
+
+	// KeyFormat specifies format of the
+	// encryption key
+	KeyFormat string `json:"keyformat"`
+
 	// Thinprovision specifies if we should
 	// thin provisioned the volume or not
 	ThinProvision string `json:"thinProvison"`

--- a/pkg/apis/openebs.io/core/v1alpha1/zfsvolume.go
+++ b/pkg/apis/openebs.io/core/v1alpha1/zfsvolume.go
@@ -91,8 +91,12 @@ type VolumeInfo struct {
 	Compression string `json:"compression"`
 
 	// Dedup specifies the deduplication
-	// should be enabledd on the zvol
+	// should be enabled on the zvol
 	Dedup string `json:"dedup"`
+
+	// Encryption specifies the encryption
+	// should be enabled on the zvol
+	Encryption string `json:"encryption"`
 
 	// Thinprovision specifies if we should
 	// thin provisioned the volume or not

--- a/pkg/builder/build.go
+++ b/pkg/builder/build.go
@@ -106,6 +106,18 @@ func (b *Builder) WithEncryption(encr string) *Builder {
 	return b
 }
 
+// WithKeyLocation sets the encryption key location on ZFSVolume
+func (b *Builder) WithKeyLocation(kl string) *Builder {
+	b.volume.Object.Spec.KeyLocation = kl
+	return b
+}
+
+// WithKeyFormat sets the encryption key format on ZFSVolume
+func (b *Builder) WithKeyFormat(kf string) *Builder {
+	b.volume.Object.Spec.KeyFormat = kf
+	return b
+}
+
 // WithCompression sets compression of ZFSVolume
 func (b *Builder) WithCompression(compression string) *Builder {
 	b.volume.Object.Spec.Compression = compression

--- a/pkg/builder/build.go
+++ b/pkg/builder/build.go
@@ -54,7 +54,7 @@ func BuildFrom(volume *apis.ZFSVolume) *Builder {
 	}
 }
 
-// WithNamespace sets the namespace of csi volume
+// WithNamespace sets the namespace of  ZFSVolume
 func (b *Builder) WithNamespace(namespace string) *Builder {
 	if namespace == "" {
 		b.errs = append(
@@ -69,7 +69,7 @@ func (b *Builder) WithNamespace(namespace string) *Builder {
 	return b
 }
 
-// WithName sets the name of csi volume
+// WithName sets the name of ZFSVolume
 func (b *Builder) WithName(name string) *Builder {
 	if name == "" {
 		b.errs = append(
@@ -100,42 +100,32 @@ func (b *Builder) WithCapacity(capacity string) *Builder {
 	return b
 }
 
-// WithCompression sets compression of CStorVolumeClaim
+// WithEncryption sets the encryption on ZFSVolume
+func (b *Builder) WithEncryption(encr string) *Builder {
+	b.volume.Object.Spec.Encryption = encr
+	return b
+}
+
+// WithCompression sets compression of ZFSVolume
 func (b *Builder) WithCompression(compression string) *Builder {
-
-	comp := "off"
-	if compression == "on" {
-		comp = "on"
-	}
-	b.volume.Object.Spec.Compression = comp
+	b.volume.Object.Spec.Compression = compression
 	return b
 }
 
-// WithDedup sets compression of CStorVolumeClaim
+// WithDedup sets dedup property of ZFSVolume
 func (b *Builder) WithDedup(dedup string) *Builder {
-
-	dp := "off"
-	if dedup == "on" {
-		dp = "on"
-	}
-	b.volume.Object.Spec.Dedup = dp
+	b.volume.Object.Spec.Dedup = dedup
 	return b
 }
 
-// WithThinProv sets compression of CStorVolumeClaim
+// WithThinProv sets if ZFSVolume needs to be thin provisioned
 func (b *Builder) WithThinProv(thinprov string) *Builder {
-
-	tp := "no"
-	if thinprov == "yes" {
-		tp = "yes"
-	}
-	b.volume.Object.Spec.ThinProvision = tp
+	b.volume.Object.Spec.ThinProvision = thinprov
 	return b
 }
 
-// WithBlockSize sets blocksize of CStorVolumeClaim
+// WithBlockSize sets blocksize of ZFSVolume
 func (b *Builder) WithBlockSize(blockSize string) *Builder {
-
 	bs := "4k"
 	if len(blockSize) > 0 {
 		bs = blockSize

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -73,6 +73,7 @@ func (cs *controller) CreateVolume(
 	bs := req.GetParameters()["blocksize"]
 	compression := req.GetParameters()["compression"]
 	dedup := req.GetParameters()["dedup"]
+	encr := req.GetParameters()["encryption"]
 	pool := req.GetParameters()["poolname"]
 	tp := req.GetParameters()["thinprovision"]
 
@@ -82,6 +83,7 @@ func (cs *controller) CreateVolume(
 		WithBlockSize(bs).
 		WithPoolName(pool).
 		WithDedup(dedup).
+		WithEncryption(encr).
 		WithThinProv(tp).
 		WithCompression(compression).Build()
 

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -74,6 +74,8 @@ func (cs *controller) CreateVolume(
 	compression := req.GetParameters()["compression"]
 	dedup := req.GetParameters()["dedup"]
 	encr := req.GetParameters()["encryption"]
+	kf := req.GetParameters()["keyformat"]
+	kl := req.GetParameters()["keylocation"]
 	pool := req.GetParameters()["poolname"]
 	tp := req.GetParameters()["thinprovision"]
 
@@ -84,6 +86,8 @@ func (cs *controller) CreateVolume(
 		WithPoolName(pool).
 		WithDedup(dedup).
 		WithEncryption(encr).
+		WithKeyFormat(kf).
+		WithKeyLocation(kl).
 		WithThinProv(tp).
 		WithCompression(compression).Build()
 

--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -67,6 +67,14 @@ func buildVolumeCreateArgs(vol *apis.ZFSVolume) []string {
 		encryptionProperty := "encryption=" + vol.Spec.Encryption
 		ZFSVolCmd = append(ZFSVolCmd, "-o", encryptionProperty)
 	}
+	if len(vol.Spec.KeyLocation) != 0 {
+		keyLocation := "keylocation=" + vol.Spec.KeyLocation
+		ZFSVolCmd = append(ZFSVolCmd, "-o", keyLocation)
+	}
+	if len(vol.Spec.KeyFormat) != 0 {
+		keyFormat := "keyformat=" + vol.Spec.KeyFormat
+		ZFSVolCmd = append(ZFSVolCmd, "-o", keyFormat)
+	}
 
 	ZFSVolCmd = append(ZFSVolCmd, zvol)
 


### PR DESCRIPTION
Also adding support to inherit the properties from ZPOOL
which are not listed in the storage class, ZFS driver will
not pass default values while creating the volume. Those
properties will be inherited from the ZPOOL.

we can use the encryption option in storage class 
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-zfspv
allowVolumeExpansion: true
parameters:
  blocksize: "4k"
  compression: "on"
  dedup: "on"
  thinprovision: "yes"
  encryption: "on"
  keyformat: "raw"
  keylocation: "file:///home/keys/key"
  poolname: "zfspv-pool"
provisioner: openebs.io/zfs
```

Just a note, the key file should be mounted inside the node-agent container so that we can use that file while provisioning the volume. keyformat can be raw, hex or passphrase.

Signed-off-by: Pawan <pawan@mayadata.io>