### PR TITLE
fix(doc): updating sample ZFSVolume CR

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ parameters:
   blocksize: "4k"
   compression: "off"
   dedup: "off"
-  thinprovision: "yes"
+  thinprovision: "no"
   poolname: "zfspv-pool"
 provisioner: zfs.csi.openebs.io
 allowedTopologies:
@@ -146,7 +146,7 @@ Create a PVC using the storage class created for the ZFS driver.
 ```
 $ kubectl get zv -n openebs
 NAME                                       ZPOOL        NODE          SIZE
-pvc-642803c4-012c-11ea-86d0-42010a800177   zfspv-pool   zfspv-node1   4294967296
+pvc-37b07ad6-db68-11e9-bbb6-000c296e38d9   zfspv-pool   zfspv-node1   4294967296
 ```
 
 The ZFS driver will create a ZFS dataset(zvol) on the node zfspv-node1 for the mentioned ZFS pool and the dataset name will same as PV name.
@@ -178,7 +178,7 @@ parameters:
   blocksize: "4k"
   compression: "on"
   dedup: "on"
-  thinprovision: "yes"
+  thinprovision: "no"
   poolname: "zfspv-pool"
 provisioner: zfs.csi.openebs.io
 volumeBindingMode: WaitForFirstConsumer

--- a/deploy/sample/mongo-statefulset.yaml
+++ b/deploy/sample/mongo-statefulset.yaml
@@ -27,7 +27,7 @@ spec:
  selector:
    role: mongo
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
  name: mongo

--- a/deploy/sample/zfspvcr.yaml
+++ b/deploy/sample/zfspvcr.yaml
@@ -1,19 +1,17 @@
-apiVersion: v1
-items:
-- apiVersion: openebs.io/v1alpha1
-  kind: ZFSVolume
-  metadata:
-    name: pvc-a6855135-c70e-11e9-8fa2-42010a80012d
-    namespace: openebs
-  spec:
-    blocksize: 4k
-    capacity: "4294967296"
-    compression: "on"
-    dedup: "on"
-    ownerNodeID: gke-pawan-zfspv-default-pool-354050c7-wl8v
-    poolName: zfspv-pool
-    thinprovison: "yes"
-kind: List
+apiVersion: openebs.io/v1alpha1
+kind: ZFSVolume
 metadata:
-  resourceVersion: ""
-  selfLink: ""
+  name: pvc-37b07ad6-db68-11e9-bbb6-000c296e38d9
+  namespace: openebs
+spec:
+  blocksize: 4k
+  capacity: "4294967296"
+  compression: "off"
+  dedup: "off"
+  encryption: ""
+  keyformat: ""
+  keylocation: ""
+  ownerNodeID: zfspv-node1
+  poolName: zfspv-pool
+  thinProvison: "off"
+


### PR DESCRIPTION
updating sample ZFSVolume CR, also changed  the API version for mongo-statefulset.yaml to make it run on kubernetes 1.16 and updated few minor details in README to make it consistent.
 
Signed-off-by: Pawan <pawan@mayadata.io>