### PR TITLE
feat(ZFSPV): adding support for applications to create "zfs" flesystem

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -80,7 +80,7 @@ func (c *ZVController) syncZV(zv *apis.ZFSVolume) error {
 	var err error
 	// ZFS Volume should be deleted. Check if deletion timestamp is set
 	if c.isDeletionCandidate(zv) {
-		err = zvol.DestroyZvol(zv)
+		err = zvol.DestroyVolume(zv)
 		if err == nil {
 			zvol.RemoveZvolFinalizer(zv)
 		}
@@ -91,7 +91,7 @@ func (c *ZVController) syncZV(zv *apis.ZFSVolume) error {
 		if zv.Finalizers != nil {
 			err = zvol.SetZvolProp(zv)
 		} else {
-			err = zvol.CreateZvol(zv)
+			err = zvol.CreateVolume(zv)
 			if err == nil {
 				err = zvol.UpdateZvolInfo(zv)
 			}

--- a/deploy/sample/fio.yaml
+++ b/deploy/sample/fio.yaml
@@ -11,6 +11,7 @@ parameters:
   #encryption: "on"
   #keyformat: "raw"
   #keylocation: "file:///home/pawan/key"
+  fstype: "zfs"
   poolname: "zfspv-pool"
 provisioner: zfs.csi.openebs.io
 allowedTopologies:

--- a/deploy/sample/fio.yaml
+++ b/deploy/sample/fio.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openebs-zfspv
 allowVolumeExpansion: true
 parameters:
-  blocksize: "4k"
+  recordsize: "4k"
   compression: "on"
   dedup: "on"
   thinprovision: "yes"

--- a/deploy/sample/fio.yaml
+++ b/deploy/sample/fio.yaml
@@ -32,22 +32,33 @@ spec:
     requests:
       storage: 4Gi
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: fio
+  labels:
+    name: fio
 spec:
-  restartPolicy: Never
-  containers:
-  - name: perfrunner
-    image: openebs/tests-fio
-    command: ["/bin/bash"]
-    args: ["-c", "while true ;do sleep 50; done"]
-    volumeMounts:
-       - mountPath: /datadir
-         name: fio-vol
-    tty: true
-  volumes:
-  - name: fio-vol
-    persistentVolumeClaim:
-      claimName: csi-zfspv
+  replicas: 1
+  selector:
+    matchLabels:
+      name: fio
+  template:
+    metadata:
+      labels:
+        name: fio
+    spec:
+      containers:
+        - resources:
+          name: perfrunner
+          image: openebs/tests-fio
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash"]
+          args: ["-c", "while true ;do sleep 50; done"]
+          volumeMounts:
+            - mountPath: /datadir
+              name: fio-vol
+      volumes:
+        - name: fio-vol
+          persistentVolumeClaim:
+            claimName: csi-zfspv

--- a/deploy/sample/mongo-statefulset.yaml
+++ b/deploy/sample/mongo-statefulset.yaml
@@ -7,7 +7,7 @@ kind: StorageClass
 metadata:
   name: mongo-pv-az
 parameters:
-  blocksize: "4k"
+  recordsize: "4k"
   poolname: "zfspv-pool"
   fsType: "xfs"
 provisioner: zfs.csi.openebs.io

--- a/deploy/sample/mongo-statefulset.yaml
+++ b/deploy/sample/mongo-statefulset.yaml
@@ -9,7 +9,7 @@ metadata:
 parameters:
   recordsize: "4k"
   poolname: "zfspv-pool"
-  fsType: "xfs"
+  fstype: "xfs"
 provisioner: zfs.csi.openebs.io
 ---
 # Headless service for stable DNS entries of StatefulSet members.

--- a/deploy/sample/mongo-statefulset.yaml
+++ b/deploy/sample/mongo-statefulset.yaml
@@ -7,7 +7,7 @@ kind: StorageClass
 metadata:
   name: mongo-pv-az
 parameters:
-  recordsize: "4k"
+  volblocksize: "4k"
   poolname: "zfspv-pool"
   fstype: "xfs"
 provisioner: zfs.csi.openebs.io

--- a/deploy/sample/percona.yaml
+++ b/deploy/sample/percona.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openebs-zfspv
 allowVolumeExpansion: true
 parameters:
-  recordsize: "4k"
+  volblocksize: "4k"
   compression: "on"
   dedup: "on"
   thinprovision: "yes"

--- a/deploy/sample/percona.yaml
+++ b/deploy/sample/percona.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openebs-zfspv
 allowVolumeExpansion: true
 parameters:
-  blocksize: "4k"
+  recordsize: "4k"
   compression: "on"
   dedup: "on"
   thinprovision: "yes"

--- a/deploy/sample/zfspvcr.yaml
+++ b/deploy/sample/zfspvcr.yaml
@@ -4,7 +4,6 @@ metadata:
   name: pvc-37b07ad6-db68-11e9-bbb6-000c296e38d9
   namespace: openebs
 spec:
-  blocksize: 4k
   capacity: "4294967296"
   compression: "off"
   dedup: "off"
@@ -13,5 +12,6 @@ spec:
   keylocation: ""
   ownerNodeID: zfspv-node1
   poolName: zfspv-pool
+  recordsize: 8k
   thinProvision: "off"
-
+  volumeType: DATASET

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -35,6 +35,10 @@ spec:
     name: Size
     description: Size of the volume
     type: string
+  - JSONPath: .spec.fsType
+    name: Filesystem
+    description: filesystem created on the volume
+    type: string
 
 ---
 ##############################################

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -35,6 +35,14 @@ spec:
     name: Size
     description: Size of the volume
     type: string
+  - JSONPath: .spec.volblocksize
+    name: volblocksize
+    description: volblocksize for the created zvol
+    type: string
+  - JSONPath: .spec.recordsize
+    name: recordsize
+    description: recordsize for the created zfs dataset
+    type: string
   - JSONPath: .spec.fsType
     name: Filesystem
     description: filesystem created on the volume

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -20,7 +20,7 @@ spec:
     singular: zfsvolume
     kind: ZFSVolume
     shortNames:
-    - zvol
+    - zfsvol
     - zv
   additionalPrinterColumns:
   - JSONPath: .spec.poolName

--- a/pkg/apis/openebs.io/core/v1alpha1/zfsvolume.go
+++ b/pkg/apis/openebs.io/core/v1alpha1/zfsvolume.go
@@ -82,9 +82,10 @@ type VolumeInfo struct {
 	// Capacity of the volume
 	Capacity string `json:"capacity"`
 
-	// BlockSize specifies the blocksize
-	// which we should use to create the zvol
-	BlockSize string `json:"blocksize"`
+	// RecordSize specifies the record size
+	// for the zfs dataset, if we are creating
+	// a zvol then it specifies blocksize for that zvol
+	RecordSize string `json:"recordsize"`
 
 	// Compression specifies if the it should
 	// enabled on the zvol

--- a/pkg/apis/openebs.io/core/v1alpha1/zfsvolume.go
+++ b/pkg/apis/openebs.io/core/v1alpha1/zfsvolume.go
@@ -110,7 +110,7 @@ type VolumeInfo struct {
 	// thin provisioned the volume or not
 	ThinProvision string `json:"thinProvision"`
 
-	//VolumeType specifies where the volume is
+	// VolumeType specifies whether the volume is
 	// zvol or a dataset
 	VolumeType string `json:"volumeType"`
 }

--- a/pkg/apis/openebs.io/core/v1alpha1/zfsvolume.go
+++ b/pkg/apis/openebs.io/core/v1alpha1/zfsvolume.go
@@ -85,33 +85,37 @@ type VolumeInfo struct {
 	// RecordSize specifies the record size
 	// for the zfs dataset, if we are creating
 	// a zvol then it specifies blocksize for that zvol
-	RecordSize string `json:"recordsize"`
+	RecordSize string `json:"recordsize,omitempty"`
 
 	// Compression specifies if the it should
 	// enabled on the zvol
-	Compression string `json:"compression"`
+	Compression string `json:"compression,omitempty"`
 
 	// Dedup specifies the deduplication
 	// should be enabled on the zvol
-	Dedup string `json:"dedup"`
+	Dedup string `json:"dedup,omitempty"`
 
 	// Encryption specifies the encryption
 	// should be enabled on the zvol
-	Encryption string `json:"encryption"`
+	Encryption string `json:"encryption,omitempty"`
 
 	// KeyLocation is the location of key
 	// for the encryption
-	KeyLocation string `json:"keylocation"`
+	KeyLocation string `json:"keylocation,omitempty"`
 
 	// KeyFormat specifies format of the
 	// encryption key
-	KeyFormat string `json:"keyformat"`
+	KeyFormat string `json:"keyformat,omitempty"`
 
 	// Thinprovision specifies if we should
 	// thin provisioned the volume or not
-	ThinProvision string `json:"thinProvision"`
+	ThinProvision string `json:"thinProvision,omitempty"`
 
 	// VolumeType specifies whether the volume is
 	// zvol or a dataset
 	VolumeType string `json:"volumeType"`
+
+	// FsType specifies filesystem type for the
+	// zfs volume/dataset
+	FsType string `json:"fsType,omitempty"`
 }

--- a/pkg/apis/openebs.io/core/v1alpha1/zfsvolume.go
+++ b/pkg/apis/openebs.io/core/v1alpha1/zfsvolume.go
@@ -109,4 +109,8 @@ type VolumeInfo struct {
 	// Thinprovision specifies if we should
 	// thin provisioned the volume or not
 	ThinProvision string `json:"thinProvision"`
+
+	//VolumeType specifies where the volume is
+	// zvol or a dataset
+	VolumeType string `json:"volumeType"`
 }

--- a/pkg/apis/openebs.io/core/v1alpha1/zfsvolume.go
+++ b/pkg/apis/openebs.io/core/v1alpha1/zfsvolume.go
@@ -83,9 +83,11 @@ type VolumeInfo struct {
 	Capacity string `json:"capacity"`
 
 	// RecordSize specifies the record size
-	// for the zfs dataset, if we are creating
-	// a zvol then it specifies blocksize for that zvol
+	// for the zfs dataset
 	RecordSize string `json:"recordsize,omitempty"`
+
+	// VolBlockSize specifies the block size for the zvol
+	VolBlockSize string `json:"volblocksize,omitempty"`
 
 	// Compression specifies if the it should
 	// enabled on the zvol

--- a/pkg/builder/build.go
+++ b/pkg/builder/build.go
@@ -143,12 +143,14 @@ func (b *Builder) WithOwnerNode(host string) *Builder {
 }
 
 // WithBlockSize sets blocksize of ZFSVolume
-func (b *Builder) WithBlockSize(blockSize string) *Builder {
-	bs := "4k"
-	if len(blockSize) > 0 {
-		bs = blockSize
-	}
+func (b *Builder) WithBlockSize(bs string) *Builder {
 	b.volume.Object.Spec.BlockSize = bs
+	return b
+}
+
+// WithVolumeType sets if ZFSVolume needs to be thin provisioned
+func (b *Builder) WithVolumeType(vtype string) *Builder {
+	b.volume.Object.Spec.VolumeType = vtype
 	return b
 }
 

--- a/pkg/builder/build.go
+++ b/pkg/builder/build.go
@@ -142,9 +142,9 @@ func (b *Builder) WithOwnerNode(host string) *Builder {
 	return b
 }
 
-// WithBlockSize sets blocksize of ZFSVolume
-func (b *Builder) WithBlockSize(bs string) *Builder {
-	b.volume.Object.Spec.BlockSize = bs
+// WithRecordSize sets the recordsize of ZFSVolume
+func (b *Builder) WithRecordSize(rs string) *Builder {
+	b.volume.Object.Spec.RecordSize = rs
 	return b
 }
 

--- a/pkg/builder/build.go
+++ b/pkg/builder/build.go
@@ -154,6 +154,12 @@ func (b *Builder) WithVolumeType(vtype string) *Builder {
 	return b
 }
 
+// WithFsType sets filesystem for the ZFSVolume
+func (b *Builder) WithFsType(fstype string) *Builder {
+	b.volume.Object.Spec.FsType = fstype
+	return b
+}
+
 func (b *Builder) WithPoolName(pool string) *Builder {
 	if pool == "" {
 		b.errs = append(

--- a/pkg/builder/build.go
+++ b/pkg/builder/build.go
@@ -148,6 +148,12 @@ func (b *Builder) WithRecordSize(rs string) *Builder {
 	return b
 }
 
+// WithVolBlockSize sets the volblocksize of ZFSVolume
+func (b *Builder) WithVolBlockSize(bs string) *Builder {
+	b.volume.Object.Spec.VolBlockSize = bs
+	return b
+}
+
 // WithVolumeType sets if ZFSVolume needs to be thin provisioned
 func (b *Builder) WithVolumeType(vtype string) *Builder {
 	b.volume.Object.Spec.VolumeType = vtype

--- a/pkg/driver/agent.go
+++ b/pkg/driver/agent.go
@@ -157,6 +157,9 @@ func (ns *node) NodeUnpublishVolume(
 	}
 
 NodeUnpublishResponse:
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	logrus.Infof("hostpath: volume %s path: %s has been unmounted.",
 		volumeID, targetPath)
 

--- a/pkg/driver/agent.go
+++ b/pkg/driver/agent.go
@@ -96,7 +96,7 @@ func (ns *node) NodePublishVolume(
 	if err != nil {
 		goto PublishVolumeResponse
 	}
-	// Create the zfs volume and attempt mount operation on the requested path
+	// attempt mount operation on the requested path
 	if err = zfs.MountVolume(vol, mountInfo); err != nil {
 		goto PublishVolumeResponse
 	}

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -78,7 +78,7 @@ func (cs *controller) CreateVolume(
 	pool := req.GetParameters()["poolname"]
 	tp := req.GetParameters()["thinprovision"]
 	schld := req.GetParameters()["scheduler"]
-	fstype := req.GetParameters()["fsType"]
+	fstype := req.GetParameters()["fstype"]
 
 	vtype := zfs.GetVolumeType(fstype)
 

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -69,7 +69,7 @@ func (cs *controller) CreateVolume(
 
 	volName := req.GetName()
 	size := req.GetCapacityRange().RequiredBytes
-	bs := req.GetParameters()["blocksize"]
+	rs := req.GetParameters()["recordsize"]
 	compression := req.GetParameters()["compression"]
 	dedup := req.GetParameters()["dedup"]
 	encr := req.GetParameters()["encryption"]
@@ -79,14 +79,8 @@ func (cs *controller) CreateVolume(
 	tp := req.GetParameters()["thinprovision"]
 	schld := req.GetParameters()["scheduler"]
 	fstype := req.GetParameters()["fsType"]
-	vtype := zfs.VOLTYPE_ZVOL
 
-	// if fstype is provided as zfs then a zfs dataset will be created
-	// if nothing is provided, then by default dataset will be created
-	if fstype == "zfs" ||
-		fstype == "" {
-		vtype = zfs.VOLTYPE_DATASET
-	}
+	vtype := zfs.GetVolumeType(fstype)
 
 	selected := scheduler(req.AccessibilityRequirements, schld, pool)
 
@@ -99,7 +93,7 @@ func (cs *controller) CreateVolume(
 	volObj, err := builder.NewBuilder().
 		WithName(volName).
 		WithCapacity(strconv.FormatInt(int64(size), 10)).
-		WithBlockSize(bs).
+		WithRecordSize(rs).
 		WithPoolName(pool).
 		WithDedup(dedup).
 		WithEncryption(encr).

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -102,6 +102,7 @@ func (cs *controller) CreateVolume(
 		WithThinProv(tp).
 		WithOwnerNode(selected).
 		WithVolumeType(vtype).
+		WithFsType(fstype).
 		WithCompression(compression).Build()
 
 	if err != nil {

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -70,6 +70,7 @@ func (cs *controller) CreateVolume(
 	volName := req.GetName()
 	size := req.GetCapacityRange().RequiredBytes
 	rs := req.GetParameters()["recordsize"]
+	bs := req.GetParameters()["volblocksize"]
 	compression := req.GetParameters()["compression"]
 	dedup := req.GetParameters()["dedup"]
 	encr := req.GetParameters()["encryption"]
@@ -94,6 +95,7 @@ func (cs *controller) CreateVolume(
 		WithName(volName).
 		WithCapacity(strconv.FormatInt(int64(size), 10)).
 		WithRecordSize(rs).
+		WithVolBlockSize(bs).
 		WithPoolName(pool).
 		WithDedup(dedup).
 		WithEncryption(encr).

--- a/pkg/driver/scheduler.go
+++ b/pkg/driver/scheduler.go
@@ -76,7 +76,8 @@ func volumeWeightedScheduler(topo *csi.TopologyRequirement, pool string) string 
 // the given zfs pool.
 func scheduler(topo *csi.TopologyRequirement, schld string, pool string) string {
 
-	if len(topo.Preferred) == 0 {
+	if topo == nil ||
+		len(topo.Preferred) == 0 {
 		logrus.Errorf("topology information not provided")
 		return ""
 	}

--- a/pkg/zfs/mount.go
+++ b/pkg/zfs/mount.go
@@ -57,8 +57,8 @@ func UmountVolume(vol *apis.ZFSVolume, targetPath string,
 				"zfspv failed to umount dataset: path %s Error: %v",
 				targetPath, err,
 			)
+			return err
 		}
-		return err
 	} else {
 		if err = mounter.Unmount(targetPath); err != nil {
 			logrus.Errorf(

--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -27,7 +27,7 @@ import (
 // zfs related constants
 const (
 	ZFS_DEVPATH = "/dev/zvol/"
-	ZFS_FSTYPE  = "zfs"
+	FSTYPE_ZFS  = "zfs"
 )
 
 // zfs command related constants
@@ -60,13 +60,11 @@ func PropertyChanged(oldVol *apis.ZFSVolume, newVol *apis.ZFSVolume) bool {
 // whether it is a zvol or dataset
 func GetVolumeType(fstype string) string {
 	/*
-	 * if fstype is provided as zfs or it is empty then a zfs dataset will be created
+	 * if fstype is provided as zfs then a zfs dataset will be created
 	 * otherwise a zvol will be created
 	 */
 	switch fstype {
-	case ZFS_FSTYPE:
-		return VOLTYPE_DATASET
-	case "":
+	case FSTYPE_ZFS:
 		return VOLTYPE_DATASET
 	default:
 		return VOLTYPE_ZVOL
@@ -278,7 +276,9 @@ func SetZvolProp(vol *apis.ZFSVolume) error {
 	volume := vol.Spec.PoolName + "/" + vol.Name
 
 	if len(vol.Spec.Compression) == 0 &&
-		len(vol.Spec.Dedup) == 0 {
+		len(vol.Spec.Dedup) == 0 &&
+		(vol.Spec.VolumeType != VOLTYPE_DATASET ||
+			len(vol.Spec.RecordSize) == 0) {
 		//nothing to set, just return
 		return nil
 	}

--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -36,7 +36,6 @@ const (
 	ZFSCreateArg  = "create"
 	ZFSDestroyArg = "destroy"
 	ZFSSetArg     = "set"
-	ZFSMountArg   = "mount"
 	ZFSListArg    = "list"
 )
 
@@ -198,8 +197,7 @@ func getVolume(volume string) error {
 	ZFSVolArg = append(ZFSVolArg, ZFSListArg, volume)
 
 	cmd := exec.Command(ZFSVolCmd, ZFSVolArg...)
-	out, err := cmd.CombinedOutput()
-	logrus.Infof("getVolume out %v", out)
+	_, err := cmd.CombinedOutput()
 	return err
 }
 
@@ -227,8 +225,6 @@ func CreateVolume(vol *apis.ZFSVolume) error {
 		logrus.Infof("created volume %s", volume)
 	} else if err == nil {
 		logrus.Infof("using existing volume %v", volume)
-	} else {
-		return err
 	}
 
 	return nil
@@ -250,31 +246,18 @@ func SetDatasetMountProp(volume string, mountpath string) error {
 	return err
 }
 
-// MountZFSVolume mounts the volume
-func MountZFSVolume(volume string) error {
-	var ZFSVolArg []string
-
-	ZFSVolArg = append(ZFSVolArg, ZFSMountArg, volume)
-	cmd := exec.Command(ZFSVolCmd, ZFSVolArg...)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		logrus.Errorf("zfs: could not mount the dataset %v cmd %v error: %s",
-			volume, ZFSVolArg, string(out))
-	}
-	return err
-}
-
 // MountZFSDataset mounts the dataset to the given mountpoint
 func MountZFSDataset(vol *apis.ZFSVolume, mountpath string) error {
 	volume := vol.Spec.PoolName + "/" + vol.Name
 
-	err := SetDatasetMountProp(volume, mountpath)
+	return SetDatasetMountProp(volume, mountpath)
+}
 
-	if err != nil {
-		return err
-	}
+// UmountZFSDataset umounts the dataset
+func UmountZFSDataset(vol *apis.ZFSVolume) error {
+	volume := vol.Spec.PoolName + "/" + vol.Name
 
-	return MountZFSVolume(volume)
+	return SetDatasetMountProp(volume, "none")
 }
 
 // SetZvolProp sets the volume property

--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -46,6 +46,12 @@ const (
 )
 
 func PropertyChanged(oldVol *apis.ZFSVolume, newVol *apis.ZFSVolume) bool {
+	if oldVol.Spec.VolumeType == VOLTYPE_DATASET &&
+		newVol.Spec.VolumeType == VOLTYPE_DATASET &&
+		oldVol.Spec.RecordSize != newVol.Spec.RecordSize {
+		return true
+	}
+
 	return oldVol.Spec.Compression != newVol.Spec.Compression ||
 		oldVol.Spec.Dedup != newVol.Spec.Dedup
 }
@@ -165,6 +171,12 @@ func buildVolumeSetArgs(vol *apis.ZFSVolume) []string {
 	volume := vol.Spec.PoolName + "/" + vol.Name
 
 	ZFSVolArg = append(ZFSVolArg, ZFSSetArg)
+
+	if vol.Spec.VolumeType == VOLTYPE_DATASET &&
+		len(vol.Spec.RecordSize) != 0 {
+		recordsizeProperty := "recordsize=" + vol.Spec.RecordSize
+		ZFSVolArg = append(ZFSVolArg, recordsizeProperty)
+	}
 
 	if len(vol.Spec.Dedup) != 0 {
 		dedupProperty := "dedup=" + vol.Spec.Dedup

--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -85,8 +85,8 @@ func buildZvolCreateArgs(vol *apis.ZFSVolume) []string {
 	if len(vol.Spec.Capacity) != 0 {
 		ZFSVolArg = append(ZFSVolArg, "-V", vol.Spec.Capacity)
 	}
-	if len(vol.Spec.RecordSize) != 0 {
-		ZFSVolArg = append(ZFSVolArg, "-b", vol.Spec.RecordSize)
+	if len(vol.Spec.VolBlockSize) != 0 {
+		ZFSVolArg = append(ZFSVolArg, "-b", vol.Spec.VolBlockSize)
 	}
 	if len(vol.Spec.Dedup) != 0 {
 		dedupProperty := "dedup=" + vol.Spec.Dedup

--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -282,6 +282,20 @@ func SetZvolProp(vol *apis.ZFSVolume) error {
 		//nothing to set, just return
 		return nil
 	}
+	/* Case: Restart =>
+	 * In this case we get the add event but here we don't know which
+	 * property has changed when we were down, so firing the zfs set
+	 * command with the all property present on the ZFSVolume.
+
+	 * Case: Property Change =>
+	 * TODO(pawan) When we get the update event, we make sure at least
+	 * one property has changed before adding it to the event queue for
+	 * handling. At this stage, since we haven't stored the
+	 * ZFSVolume object as it will be too heavy, we are firing the set
+	 * command with the all property preset in the ZFSVolume object since
+	 * it is guaranteed that at least one property has changed.
+	 */
+
 	args := buildVolumeSetArgs(vol)
 	cmd := exec.Command(ZFSVolCmd, args...)
 	out, err := cmd.CombinedOutput()


### PR DESCRIPTION
Application can now create a storageclass to create zfs filesystem

apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-zfspv
allowVolumeExpansion: true
parameters:
  recordsize: "4k"
  fstype: "zfs"
  poolname: "zfspv-pool"
provisioner: zfs.csi.openebs.io

ZFSPV was supporting ext2/3/4 and xfs filesystem only which
adds one extra filesystem layer on top of ZFS filesystem. So now
we can directly write to the ZFS filesystem and get the optimal performance
by directly creating ZFS filesystem for storage.

Renamed the blocksize to volblocksize, which will be used for creating the zvols and if it is provided for dataset, it will be ignored and recordsize will be used for creating the zfs datasets, if it is provided for zvol, it will be ignored

Also added support to change the recordsize for zfs datasets. 

Signed-off-by: Pawan <pawan@mayadata.io>