### PR TITLE
refactor(zfspv): renamed watcher to mgmt package

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,7 +10,7 @@ import (
 	config "github.com/openebs/zfs-localpv/pkg/config"
 	"github.com/openebs/zfs-localpv/pkg/driver"
 	"github.com/openebs/zfs-localpv/pkg/version"
-	zvol "github.com/openebs/zfs-localpv/pkg/zfs"
+	zfs "github.com/openebs/zfs-localpv/pkg/zfs"
 	"github.com/spf13/cobra"
 )
 
@@ -39,7 +39,7 @@ func main() {
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 
 	cmd.PersistentFlags().StringVar(
-		&config.NodeID, "nodeid", zvol.NodeID, "NodeID to identify the node running this driver",
+		&config.NodeID, "nodeid", zfs.NodeID, "NodeID to identify the node running this driver",
 	)
 
 	cmd.PersistentFlags().StringVar(

--- a/pkg/builder/build.go
+++ b/pkg/builder/build.go
@@ -200,7 +200,7 @@ func (b *Builder) WithLabels(labels map[string]string) *Builder {
 	if len(labels) == 0 {
 		b.errs = append(
 			b.errs,
-			errors.New("failed to build cstorvolume object: missing labels"),
+			errors.New("failed to build zfs volume object: missing labels"),
 		)
 		return b
 	}

--- a/pkg/driver/agent.go
+++ b/pkg/driver/agent.go
@@ -19,9 +19,9 @@ package driver
 import (
 	"github.com/Sirupsen/logrus"
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	ctrl "github.com/openebs/zfs-localpv/cmd/controller"
 	apis "github.com/openebs/zfs-localpv/pkg/apis/openebs.io/core/v1alpha1"
 	"github.com/openebs/zfs-localpv/pkg/builder"
+	"github.com/openebs/zfs-localpv/pkg/mgmt"
 	zfs "github.com/openebs/zfs-localpv/pkg/zfs"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
@@ -42,9 +42,9 @@ func NewNode(d *CSIDriver) csi.NodeServer {
 	var ControllerMutex = sync.RWMutex{}
 	// start the zfsvolume watcher
 	go func() {
-		err := ctrl.Start(&ControllerMutex)
+		err := mgmt.Start(&ControllerMutex)
 		if err != nil {
-			logrus.Errorf("Failed to start cstorvolume claim controller: %s", err.Error())
+			logrus.Fatalf("Failed to start ZFS volume management controller: %s", err.Error())
 		}
 	}()
 

--- a/pkg/driver/scheduler.go
+++ b/pkg/driver/scheduler.go
@@ -24,7 +24,7 @@ import (
 	"github.com/openebs/zfs-localpv/pkg/builder"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	zvol "github.com/openebs/zfs-localpv/pkg/zfs"
+	zfs "github.com/openebs/zfs-localpv/pkg/zfs"
 )
 
 // scheduling algorithm constants
@@ -41,7 +41,7 @@ func volumeWeightedScheduler(topo *csi.TopologyRequirement, pool string) string 
 	var selected string
 
 	zvlist, err := builder.NewKubeclient().
-		WithNamespace(zvol.OpenEBSNamespace).
+		WithNamespace(zfs.OpenEBSNamespace).
 		List(metav1.ListOptions{})
 
 	if err != nil {
@@ -63,7 +63,7 @@ func volumeWeightedScheduler(topo *csi.TopologyRequirement, pool string) string 
 	// schedule it on the node which has less
 	// number of volume for the given pool
 	for _, prf := range topo.Preferred {
-		node := prf.Segments[zvol.ZFSTopologyKey]
+		node := prf.Segments[zfs.ZFSTopologyKey]
 		if volmap[node] < numVol {
 			selected = node
 			numVol = volmap[node]
@@ -83,7 +83,7 @@ func scheduler(topo *csi.TopologyRequirement, schld string, pool string) string 
 	}
 	// if there is a single node, schedule it on that
 	if len(topo.Preferred) == 1 {
-		return topo.Preferred[0].Segments[zvol.ZFSTopologyKey]
+		return topo.Preferred[0].Segments[zfs.ZFSTopologyKey]
 	}
 
 	switch schld {

--- a/pkg/mgmt/builder.go
+++ b/pkg/mgmt/builder.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package mgmt
 
 import (
 	"github.com/Sirupsen/logrus"

--- a/pkg/mgmt/start.go
+++ b/pkg/mgmt/start.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package mgmt
 
 import (
 	"sync"


### PR DESCRIPTION
as it does the management task also corrected few logs
and renamed zvol to zfs(as we support zvol and dataset both)

Signed-off-by: Pawan <pawan@mayadata.io>