### PR TITLE
feat(stats): adding volume stats

### DIFF
--- a/pkg/driver/agent.go
+++ b/pkg/driver/agent.go
@@ -273,9 +273,13 @@ func (ns *node) NodeGetVolumeStats(
 		return nil, status.Error(codes.InvalidArgument, "path is not provided")
 	}
 
+	if zfs.IsMountPath(path) == false {
+		return nil, status.Error(codes.InvalidArgument, "path is not a mount path")
+	}
+
 	var sfs unix.Statfs_t
 	if err := unix.Statfs(path, &sfs); err != nil {
-		return nil, status.Errorf(codes.Internal, "statfs on %s was failed: %v", path, err)
+		return nil, status.Errorf(codes.Internal, "statfs on %s failed: %v", path, err)
 	}
 
 	var usage []*csi.VolumeUsage

--- a/pkg/zfs/mount.go
+++ b/pkg/zfs/mount.go
@@ -101,6 +101,27 @@ func GetMounts(dev string) ([]string, error) {
 	return currentMounts, nil
 }
 
+// IsMountPath returns true if path is a mount path
+func IsMountPath(path string) bool {
+
+	var (
+		err       error
+		mountList []mount.MountPoint
+	)
+
+	mounter := mount.New("")
+	// Get list of mounted paths present with the node
+	if mountList, err = mounter.List(); err != nil {
+		return false
+	}
+	for _, mntInfo := range mountList {
+		if mntInfo.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
 func verifyMountRequest(vol *apis.ZFSVolume, mountpath string) error {
 	if len(mountpath) == 0 {
 		return status.Error(codes.InvalidArgument, "mount path missing in request")


### PR DESCRIPTION
```
$ curl localhost:10255/metrics | grep volume_stats

# TYPE kubelet_volume_stats_available_bytes gauge
kubelet_volume_stats_available_bytes{namespace="default",persistentvolumeclaim="csi-zfspv"} 3.053129728e+09
kubelet_volume_stats_available_bytes{namespace="default",persistentvolumeclaim="csi-zfspv1"} 4.294836224e+09
# HELP kubelet_volume_stats_capacity_bytes Capacity in bytes of the volume
# TYPE kubelet_volume_stats_capacity_bytes gauge
kubelet_volume_stats_capacity_bytes{namespace="default",persistentvolumeclaim="csi-zfspv"} 4.160421888e+09
kubelet_volume_stats_capacity_bytes{namespace="default",persistentvolumeclaim="csi-zfspv1"} 4.294967296e+09
# HELP kubelet_volume_stats_inodes Maximum number of inodes in the volume
# TYPE kubelet_volume_stats_inodes gauge
kubelet_volume_stats_inodes{namespace="default",persistentvolumeclaim="csi-zfspv"} 262144
kubelet_volume_stats_inodes{namespace="default",persistentvolumeclaim="csi-zfspv1"} 8.388422e+06
# HELP kubelet_volume_stats_inodes_free Number of free inodes in the volume
# TYPE kubelet_volume_stats_inodes_free gauge
kubelet_volume_stats_inodes_free{namespace="default",persistentvolumeclaim="csi-zfspv"} 262132
kubelet_volume_stats_inodes_free{namespace="default",persistentvolumeclaim="csi-zfspv1"} 8.388416e+06
# HELP kubelet_volume_stats_inodes_used Number of used inodes in the volume
# TYPE kubelet_volume_stats_inodes_used gauge
kubelet_volume_stats_inodes_used{namespace="default",persistentvolumeclaim="csi-zfspv"} 12
kubelet_volume_stats_inodes_used{namespace="default",persistentvolumeclaim="csi-zfspv1"} 6
# HELP kubelet_volume_stats_used_bytes Number of used bytes in the volume
# TYPE kubelet_volume_stats_used_bytes gauge
kubelet_volume_stats_used_bytes{namespace="default",persistentvolumeclaim="csi-zfspv"} 1.090514944e+09
kubelet_volume_stats_used_bytes{namespace="default",persistentvolumeclaim="csi-zfspv1"} 131072


$ curl localhost:10255/stats/summary
---
     {
      "time": "2019-12-18T09:52:26Z",
      "availableBytes": 4294836224,
      "capacityBytes": 4294967296,
      "usedBytes": 131072,
      "inodesFree": 8388416,
      "inodes": 8388422,
      "inodesUsed": 6,
      "name": "fio-vol",
      "pvcRef": {
       "name": "csi-zfspv1",
       "namespace": "default"
      }
---
```
Signed-off-by: Pawan <pawan@mayadata.io>