### PR TITLE
feat(HA): adding support to have controller in HA

### DIFF
--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -82,6 +82,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
   - apiGroups: ["*"]
     resources: ["zfsvolumes"]
     verbs: ["*"]
@@ -112,7 +115,7 @@ spec:
       app: openebs-zfs-controller
       role: openebs-zfs
   serviceName: "openebs-zfs"
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:
@@ -130,6 +133,8 @@ spec:
             - "--v=5"
             - "--feature-gates=Topology=true"
             - "--strict-topology"
+            - "--enable-leader-election"
+            - "--leader-election-type=leases"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -142,6 +147,7 @@ spec:
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -201,7 +207,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments", "csinodes"]
     verbs: ["get", "list", "watch", "update", "patch"]
-
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -115,13 +115,23 @@ spec:
       app: openebs-zfs-controller
       role: openebs-zfs
   serviceName: "openebs-zfs"
-  replicas: 2
+  replicas: 1
   template:
     metadata:
       labels:
         app: openebs-zfs-controller
         role: openebs-zfs
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - openebs-zfs-controller
+            topologyKey: "kubernetes.io/hostname"
       priorityClassName: system-cluster-critical
       serviceAccount: openebs-zfs-controller-sa
       containers:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -67,4 +67,24 @@ The above storage class tells that ZFS pool "zfspv-pool" is available on nodes z
 Please note that the provisioner name for ZFS driver is "zfs.csi.openebs.io", we have to use this while creating the storage class so that the volume provisioning/deprovisioning request can come to ZFS driver.
 
 
+### 3. How to install the provisioner in HA
 
+To have HA for the provisioner(controller), we can update the replica count to 2(or more as per need) and deploy the yaml. Once yaml is deployed, you can see 2(or more) controller pod running. At a time only one will be active and once it is down, the other will take over. They will use lease mechanism to decide who is active/master. Please note that it has anti affinity rules, so on one node only one pod will be running, that means, if you are using 2 replicas on a single node cluster, the other pod will be in pending state because of the anti-affinity rule. So, before changing the replica count, please make sure you have sufficient nodes.
+
+here is the yaml snippet to do that :-
+
+```yaml
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: openebs-zfs-controller
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: openebs-zfs-controller
+      role: openebs-zfs
+  serviceName: "openebs-zfs"
+  replicas: 2
+---
+```


### PR DESCRIPTION
We can have more than one controller in the system, but only one will
be the master and others will be slave. Once master is down, one of the slave will
take over via lease mechanism and start provisioning/deprovisioning the volumes.

controller pod will have anti-affinity so that no two pods get scheduled on the same node. Also keeping the default replica to 1, if HA feature is required, we can change replica count to 2(or more).

Signed-off-by: Pawan <pawan@mayadata.io>