### PR TITLE
fix(zfspv): do not destroy the dataset with -R option

### DIFF
--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -197,7 +197,7 @@ func buildVolumeDestroyArgs(vol *apis.ZFSVolume) []string {
 
 	volume := vol.Spec.PoolName + "/" + vol.Name
 
-	ZFSVolArg = append(ZFSVolArg, ZFSDestroyArg, "-R", volume)
+	ZFSVolArg = append(ZFSVolArg, ZFSDestroyArg, volume)
 
 	return ZFSVolArg
 }


### PR DESCRIPTION
With "zfs destroy -R" we will delete snapshot and clones also. We should
not use that for deleting the volumes.

Signed-off-by: Pawan <pawan@mayadata.io>