### PR TITLE
fix(operator): update provisioner image to support snapshot datasource

### DIFF
--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -597,7 +597,7 @@ spec:
             - "--leader-election=false"
           imagePullPolicy: IfNotPresent
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.4.0
+          image: quay.io/k8scsi/csi-provisioner:v1.5.0
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
changes fix the zfs operator yaml with 1.5.0 csi-provisioner
image to support volumesnapshot as datasource type to
create clone volumes.

cherry-pick: #45 
Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>