### PR TITLE
feat(resize): adding Online volume expansion support for ZFSPV

### DIFF
--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -517,10 +517,13 @@ rules:
     verbs: ["*"]
   - apiGroups: [""]
     resources: ["persistentvolumes", "services"]
-    verbs: ["get", "list", "watch", "create", "delete"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses", "csinodes"]
     verbs: ["get", "list", "watch"]
@@ -580,6 +583,19 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: openebs-zfs-controller-sa
       containers:
+        - name: csi-resizer
+          image: quay.io/k8scsi/csi-resizer:v0.4.0
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
           image: quay.io/k8scsi/csi-snapshotter:v2.0.1
           imagePullPolicy: IfNotPresent

--- a/pkg/response/resize.go
+++ b/pkg/response/resize.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The OpenEBS Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"github.com/container-storage-interface/spec/lib/go/csi"
+)
+
+// ControllerExpandVolumeResponseBuilder helps building an
+// instance of csi ControllerExpandVolumeResponse
+type ControllerExpandVolumeResponseBuilder struct {
+	response *csi.ControllerExpandVolumeResponse
+}
+
+// NewControllerExpandVolumeResponseBuilder returns a new
+// instance of ControllerExpandVolumeResponse
+func NewControllerExpandVolumeResponseBuilder() *ControllerExpandVolumeResponseBuilder {
+	return &ControllerExpandVolumeResponseBuilder{
+		response: &csi.ControllerExpandVolumeResponse{},
+	}
+}
+
+// WithCapacityBytes sets the CapacityBytes against the
+// ControllerExpandVolumeResponse instance
+func (b *ControllerExpandVolumeResponseBuilder) WithCapacityBytes(
+	capacity int64) *ControllerExpandVolumeResponseBuilder {
+	b.response.CapacityBytes = capacity
+	return b
+}
+
+// WithNodeExpansionRequired sets the NodeExpansionRequired against the
+// ControllerExpandVolumeResponse instance
+func (b *ControllerExpandVolumeResponseBuilder) WithNodeExpansionRequired(
+	nodeExpansionRequired bool) *ControllerExpandVolumeResponseBuilder {
+	b.response.NodeExpansionRequired = nodeExpansionRequired
+	return b
+}
+
+// Build returns the constructed instance
+// of csi ControllerExpandVolumeResponse
+func (b *ControllerExpandVolumeResponseBuilder) Build() *csi.ControllerExpandVolumeResponse {
+	return b.response
+}

--- a/pkg/zfs/resize.go
+++ b/pkg/zfs/resize.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package zfs
+
+import (
+	"github.com/Sirupsen/logrus"
+	apis "github.com/openebs/zfs-localpv/pkg/apis/openebs.io/core/v1alpha1"
+	"k8s.io/kubernetes/pkg/util/mount"
+	"os/exec"
+)
+
+// ResizeExtn can be used to run a resize command on the ext2/3/4 filesystem
+// to expand the filesystem to the actual size of the device
+func ResizeExtn(devpath string) error {
+	cmd := exec.Command("resize2fs", devpath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		logrus.Errorf("zfspv: ResizeExtn failed error: %s", string(out))
+		return err
+	}
+	return nil
+}
+
+// ResizeXFS can be used to run a resize command on the xfs filesystem
+// to expand the filesystem to the actual size of the device
+func ResizeXFS(path string) error {
+	cmd := exec.Command("xfs_growfs", path)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		logrus.Errorf("zfspv: ResizeXFS failed error: %s", string(out))
+		return err
+	}
+	return nil
+}
+
+// handleVolResize resizes the filesystem, it is called after quota
+// has been set on the volume. It takes care of expanding the filesystem.
+func handleVolResize(vol *apis.ZFSVolume, volumePath string) error {
+	var err error
+
+	devpath, err := GetVolumeDevPath(vol)
+	if err != nil {
+		return err
+	}
+
+	fsType := vol.Spec.FsType
+
+	mounter := mount.New("")
+	list, _ := mounter.List()
+	for _, mpt := range list {
+		if mpt.Path == volumePath {
+			switch fsType {
+			case "xfs":
+				err = ResizeXFS(volumePath)
+			case "zfs":
+				// just setting the quota is suffcient
+				// nothing to handle here
+				err = nil
+			default:
+				err = ResizeExtn(devpath)
+			}
+			if err != nil {
+				return err
+			}
+			break
+		}
+	}
+	return nil
+}

--- a/pkg/zfs/volume.go
+++ b/pkg/zfs/volume.go
@@ -17,6 +17,7 @@ package zfs
 import (
 	"github.com/Sirupsen/logrus"
 	"os"
+	"strconv"
 
 	apis "github.com/openebs/zfs-localpv/pkg/apis/openebs.io/core/v1alpha1"
 	"github.com/openebs/zfs-localpv/pkg/builder/snapbuilder"
@@ -82,6 +83,15 @@ func ProvisionVolume(
 		logrus.Infof("provisioned volume %s", vol.Name)
 	}
 
+	return err
+}
+
+// ResizeVolume resizes the zfs volume
+func ResizeVolume(vol *apis.ZFSVolume, newSize int64) error {
+
+	vol.Spec.Capacity = strconv.FormatInt(int64(newSize), 10)
+
+	_, err := volbuilder.NewKubeclient().WithNamespace(OpenEBSNamespace).Update(vol)
 	return err
 }
 


### PR DESCRIPTION
We can resize the volume by updating the PVC yaml to
the desired size and apply it. The ZFS Driver will take care
of updating the quota in case of dataset. If we are using a
Zvol and have mounted it as ext4 or xfs filesystem, the driver will take
care of expanding the volume via reize2fs/xfs_growfs binaries.

For resize, storageclass that provisions the pvc must support resize. We should have allowVolumeExpansion as true in storageclass
    
    ```yaml
    apiVersion: storage.k8s.io/v1
    kind: StorageClass
    metadata:
      name: openebs-zfspv
    allowVolumeExpansion: true
    parameters:
      poolname: "zfspv-pool"
    provisioner: zfs.csi.openebs.io
    
    ```

Signed-off-by: Pawan <pawan@mayadata.io>