### PR TITLE
feat(image): updating operator file with v0.5 image tag

### DIFF
--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -657,7 +657,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: openebs-zfs-plugin
-          image: quay.io/openebs/zfs-driver:ci
+          image: quay.io/openebs/zfs-driver:v0.5
           imagePullPolicy: IfNotPresent
           env:
             - name: OPENEBS_CONTROLLER_DRIVER
@@ -898,7 +898,7 @@ spec:
             capabilities:
               add: ["CAP_MKNOD", "CAP_SYS_ADMIN", "SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/openebs/zfs-driver:ci
+          image: quay.io/openebs/zfs-driver:v0.5
           imagePullPolicy: IfNotPresent
           args:
             - "--nodeid=$(OPENEBS_NODE_ID)"


### PR DESCRIPTION
Now we have started creating a branch for each release,
it is better that each branch's operator file points
to the right release tag instead of ci. After this we
can directly apply the operator files from each branch
to upgrade to the desired release version. This will
not be needed once ZFSPV is the part of openebs installer.

Signed-off-by: Pawan <pawan@mayadata.io>