### PR TITLE
fix(xfs): fixing xfs duplicate uuid for cloned volumes

### DIFF
--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -361,6 +361,16 @@ func CreateClone(vol *apis.ZFSVolume) error {
 		logrus.Infof("using existing clone volume %v", volume)
 	}
 
+	if vol.Spec.FsType == "xfs" {
+		// for mounting the cloned volume for xfs, a new UUID has to be generated
+		device := ZFS_DEVPATH + volume
+		cmd := exec.Command("xfs_admin", "-U", "generate", device)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			logrus.Errorf("zfspv: Clone XFS uuid generate failed error: %s", string(out))
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
fixes : https://github.com/openebs/zfs-localpv/issues/56

for mounting the cloned volume for xfs, a new UUID has to be generated.
We are generating a new UUID for the cloned volumes which are formatted
as xfs using xfs_admin command.

Signed-off-by: Pawan <pawan@mayadata.io>