### PR TITLE
fix(test): fixing resize flaky test case

### DIFF
--- a/ci/ci-test.sh
+++ b/ci/ci-test.sh
@@ -75,7 +75,7 @@ echo "get all the pods"
 kubectl get pods -owide --all-namespaces
 
 echo "get pvc and pv details"
-kubectl get pvc,pv --all-namespaces
+kubectl get pvc,pv -oyaml --all-namespaces
 
 echo "get sc details"
 kubectl get sc --all-namespaces -oyaml

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -59,7 +59,7 @@ var (
 	appPod           *corev1.PodList
 	accessModes      = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
 	capacity         = "5368709120" // 5Gi
-	NewCapacity      = "8589934592" // 8Gi, for testing resize
+	NewCapacity      = "8Gi"        // 8Gi, for testing resize
 	KubeConfigPath   string
 	OpenEBSNamespace string
 )

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -51,7 +51,7 @@ func IsPVCBoundEventually(pvcName string) bool {
 
 // IsPVCResizedEventually checks if the pvc is bound or not eventually
 func IsPVCResizedEventually(pvcName string, newCapacity string) bool {
-	newStorage, err := resource.ParseQuantity(NewCapacity)
+	newStorage, err := resource.ParseQuantity(newCapacity)
 	if err != nil {
 		return false
 	}
@@ -59,10 +59,10 @@ func IsPVCResizedEventually(pvcName string, newCapacity string) bool {
 		volume, err := PVCClient.
 			Get(pvcName, metav1.GetOptions{})
 		Expect(err).ShouldNot(HaveOccurred())
-		pvcStorage := volume.Spec.Resources.Requests[corev1.ResourceName(corev1.ResourceStorage)]
+		pvcStorage := volume.Status.Capacity[corev1.ResourceName(corev1.ResourceStorage)]
 		return pvcStorage == newStorage
 	},
-		60, 5).
+		120, 5).
 		Should(BeTrue())
 }
 


### PR DESCRIPTION
We are comparing the desired size to the wrong field
because of that resize test is not executing correctly
and sometimes causing test case failure in travis.

The update call is failing sometimes while executing the zfs
property update test cases as for resize also the object
is getting modified. The test case will fail when object updation
happens between volume GET and UPDATE call while performing
zfs property update test case to set various properties on
ZFSVolume resource.

Signed-off-by: Pawan <pawan@mayadata.io>