### PR TITLE
feat(crd): upgrade script for refactoring the CRD

### DIFF
--- a/upgrade/cleanup.sh
+++ b/upgrade/cleanup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+kubectl get zfsvolumes.openebs.io -n openebs -oyaml > volumes.yaml
+
+# remove the finalizer from the old CR
+sed -i "/zfs.openebs.io\/finalizer/d" volumes.yaml
+kubectl apply -f volumes.yaml
+
+# delete the old CR
+kubectl delete -f volumes.yaml
+
+# delete the CRD definition
+kubectl delete crd zfsvolumes.openebs.io
+
+
+kubectl get zfssnapshots.openebs.io -n openebs -oyaml > snapshots.yaml
+
+# remove the finalizer from the old CR
+sed -i "/zfs.openebs.io\/finalizer/d" snapshots.yaml
+kubectl apply -f snapshots.yaml
+
+# delete the old CR
+kubectl delete -f snapshots.yaml
+
+# delete the CRD definition
+kubectl delete crd zfssnapshots.openebs.io

--- a/upgrade/crd.yaml
+++ b/upgrade/crd.yaml
@@ -1,0 +1,68 @@
+##############################################
+###########                       ############
+###########   ZFSVolume CRD       ############
+###########                       ############
+##############################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumes.zfs.openebs.io
+spec:
+  group: zfs.openebs.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: volumes
+    singular: volume
+    kind: Volume
+    shortNames:
+    - zfsvol
+    - zv
+  additionalPrinterColumns:
+  - JSONPath: .spec.poolName
+    name: ZPool
+    description: ZFS Pool where the volume is created
+    type: string
+  - JSONPath: .spec.ownerNodeID
+    name: Node
+    description: Node where the volume is created
+    type: string
+  - JSONPath: .spec.capacity
+    name: Size
+    description: Size of the volume
+    type: string
+  - JSONPath: .spec.volblocksize
+    name: volblocksize
+    description: volblocksize for the created zvol
+    type: string
+  - JSONPath: .spec.recordsize
+    name: recordsize
+    description: recordsize for the created zfs dataset
+    type: string
+  - JSONPath: .spec.fsType
+    name: Filesystem
+    description: filesystem created on the volume
+    type: string
+---
+##############################################
+###########                       ############
+###########   Snapshot CRD        ############
+###########                       ############
+##############################################
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: snapshots.zfs.openebs.io
+spec:
+  group: zfs.openebs.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: snapshots
+    singular: snapshot
+    kind: Snapshot
+    shortNames:
+    - zfssnapshot
+    - zfssnap
+---

--- a/upgrade/crd.yaml
+++ b/upgrade/crd.yaml
@@ -6,15 +6,15 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: volumes.zfs.openebs.io
+  name: zfsvolumes.zfs.openebs.io
 spec:
   group: zfs.openebs.io
   version: v1alpha1
   scope: Namespaced
   names:
-    plural: volumes
-    singular: volume
-    kind: Volume
+    plural: zfsvolumes
+    singular: zfsvolume
+    kind: ZFSVolume
     shortNames:
     - zfsvol
     - zv
@@ -53,15 +53,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: snapshots.zfs.openebs.io
+  name: zfssnapshots.zfs.openebs.io
 spec:
   group: zfs.openebs.io
   version: v1alpha1
   scope: Namespaced
   names:
-    plural: snapshots
-    singular: snapshot
-    kind: Snapshot
+    plural: zfssnapshots
+    singular: zfssnapshot
+    kind: ZFSSnapshot
     shortNames:
     - zfssnapshot
     - zfssnap

--- a/upgrade/upgrade.sh
+++ b/upgrade/upgrade.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+# ZFSVolumes: create the new CR with apiVersion as zfs.openebs.io and kind as Volume
+
+kubectl get zfsvolumes.openebs.io -n openebs -oyaml > volumes.yaml
+
+
+# update the group name to zfs.openebs.io
+sed -i "s/apiVersion: openebs.io/apiVersion: zfs.openebs.io/g" volumes.yaml
+# update the kind to Volume
+sed -i "s/kind: ZFSVolume/kind: Volume/g" volumes.yaml
+# create the new CR
+kubectl apply -f volumes.yaml
+
+rm volumes.yaml
+
+
+# ZFSSnapshots: create the new CR with apiVersion as zfs.openebs.io and kind as Snapshot
+
+kubectl get zfssnapshots.openebs.io -n openebs -oyaml > snapshots.yaml
+
+
+# update the group name to zfs.openebs.io
+sed -i "s/apiVersion: openebs.io/apiVersion: zfs.openebs.io/g" snapshots.yaml
+# update the kind to Snapshot
+sed -i "s/kind: ZFSSnapshot/kind: Snapshot/g" snapshots.yaml
+# create the new CR
+kubectl apply -f snapshots.yaml
+
+rm snapshots.yaml

--- a/upgrade/upgrade.sh
+++ b/upgrade/upgrade.sh
@@ -9,8 +9,6 @@ kubectl get zfsvolumes.openebs.io -n openebs -oyaml > volumes.yaml
 
 # update the group name to zfs.openebs.io
 sed -i "s/apiVersion: openebs.io/apiVersion: zfs.openebs.io/g" volumes.yaml
-# update the kind to Volume
-sed -i "s/kind: ZFSVolume/kind: Volume/g" volumes.yaml
 # create the new CR
 kubectl apply -f volumes.yaml
 
@@ -24,8 +22,6 @@ kubectl get zfssnapshots.openebs.io -n openebs -oyaml > snapshots.yaml
 
 # update the group name to zfs.openebs.io
 sed -i "s/apiVersion: openebs.io/apiVersion: zfs.openebs.io/g" snapshots.yaml
-# update the kind to Snapshot
-sed -i "s/kind: ZFSSnapshot/kind: Snapshot/g" snapshots.yaml
 # create the new CR
 kubectl apply -f snapshots.yaml
 


### PR DESCRIPTION
steps to upgrade :-
1. apply the new CRD
```
$ kubectl apply -f upgrade/crd.yaml
customresourcedefinition.apiextensions.k8s.io/zfsvolumes.zfs.openebs.io created
customresourcedefinition.apiextensions.k8s.io/zfssnapshots.zfs.openebs.io created
```
2. run upgrade.sh
```
$ sh upgrade/upgrade.sh
zfsvolume.zfs.openebs.io/pvc-086a8608-9057-42df-b684-ee4ae8d35f71 created
zfsvolume.zfs.openebs.io/pvc-5286d646-c93d-4413-9707-fd95ebaae8c0 created
zfsvolume.zfs.openebs.io/pvc-74abefb8-8423-4b13-a607-7184ef088fb5 created
zfsvolume.zfs.openebs.io/pvc-82368c44-eee8-47ee-85a6-633a8023faa8 created
zfssnapshot.zfs.openebs.io/snapshot-dc61a056-f495-482b-8e6e-e7ddc4c13f47 created
zfssnapshot.zfs.openebs.io/snapshot-f9db91ea-529e-4dac-b2b8-ead045c612da created
```
3. upgrade the driver to v0.6 (tag to be created)
```
$ kubectl apply -f https://github.com/openebs/zfs-localpv/blob/v0.6.x/deploy/zfs-operator.yaml
```
Check everything is good. Then run

4. run cleanup.sh
```
$ sh upgrade/cleanup.sh
Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
zfsvolume.openebs.io/pvc-086a8608-9057-42df-b684-ee4ae8d35f71 configured
Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
zfsvolume.openebs.io/pvc-5286d646-c93d-4413-9707-fd95ebaae8c0 configured
Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
zfsvolume.openebs.io/pvc-74abefb8-8423-4b13-a607-7184ef088fb5 configured
Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
  svolume.openebs.io/pvc-82368c44-eee8-47ee-85a6-633a8023faa8 configured
zfsvolume.openebs.io "pvc-086a8608-9057-42df-b684-ee4ae8d35f71" deleted
zfsvolume.openebs.io "pvc-5286d646-c93d-4413-9707-fd95ebaae8c0" deleted
zfsvolume.openebs.io "pvc-74abefb8-8423-4b13-a607-7184ef088fb5" deleted
zfsvolume.openebs.io "pvc-82368c44-eee8-47ee-85a6-633a8023faa8" deleted
customresourcedefinition.apiextensions.k8s.io "zfsvolumes.openebs.io" deleted
Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
zfssnapshot.openebs.io/snapshot-dc61a056-f495-482b-8e6e-e7ddc4c13f47 configured
Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
zfssnapshot.openebs.io/snapshot-f9db91ea-529e-4dac-b2b8-ead045c612da configured
zfssnapshot.openebs.io "snapshot-dc61a056-f495-482b-8e6e-e7ddc4c13f47" deleted
zfssnapshot.openebs.io "snapshot-f9db91ea-529e-4dac-b2b8-ead045c612da" deleted
customresourcedefinition.apiextensions.k8s.io "zfssnapshots.openebs.io" deleted
```
Signed-off-by: Pawan <pawan@mayadata.io>