### PR TITLE
feat(zfspv): handling unmounted volume

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -119,8 +119,8 @@ func CreateZFSVolume(req *csi.CreateVolumeRequest) (string, error) {
 
 	err = zfs.ProvisionVolume(volObj)
 	if err != nil {
-		return "", status.Error(codes.Internal,
-			"not able to provision the volume")
+		return "", status.Errorf(codes.Internal,
+			"not able to provision the volume %s", err.Error())
 	}
 
 	return selected, nil
@@ -168,8 +168,8 @@ func CreateZFSClone(req *csi.CreateVolumeRequest, snapshot string) (string, erro
 
 	err = zfs.ProvisionVolume(volObj)
 	if err != nil {
-		return "", status.Error(codes.Internal,
-			"not able to provision the volume")
+		return "", status.Errorf(codes.Internal,
+			"not able to provision the clone volume %s", err.Error())
 	}
 
 	return selected, nil


### PR DESCRIPTION
Cherry-pick to v0.6.x : https://github.com/openebs/zfs-localpv/pull/76
There can be cases where openebs namespace has been accidentally deleted. If that happens, the volume CRs deletion will be triggered. Volume CR deletion will trigger dataset deletion process. Prior to the actual deletion of the data, the driver will attempt to do the following:

Unmount the dataset(not the case with zvol as it will be unmounted via NodeUnPublish) Unmounting the dataset will Set the mount="no"
Delete the zvol or dataset
But since the volume is actively consumed by a pod, the destroy will fail, as the volume is busy. The zvols continue to operate. However with datasets, it is umounted resulting in the setting of mount="no", but then delete will fail.

Now, there are two actions that the user can take:
(a) Continue to clean-up, so that setup can be re-created
(b) Reinstall openebs and try to create volumes and point to the underlying datasets.

In case (a), the user will have to go delete the application pods and then start deleting the PVCs. However, the PV deletion will fail, because the steps to clean up do not find that volume is mounted and will be aborted.

Let us assume case (b), and prior to actually reinstalling, as the volumes are still intact, applications are expected to continue to access the data.

However, if a node restart occurs, due to the mount being set to no, the pods will not be able to access the volume. The data stored by the pod will not persist as it is not backed by persistence storage.

To recover from the partial clean up steps. the following needs to be done on each of the nodes:

zfs get mounted : check if there is any unmounted dataset with this option as "no".
For all the datasets that showed mounted as no, do the following:
zfs mount <dataset name>
The above commands will result in mounting the dataset.
Here in this PR :

automating the manual steps performed above to check that volume can be mounted, even if a manual operation left it in a non-mountable state.
helping with the case (a), by into NodeUnPublish operation - that continues to destroy in whatever state the volume may be in.
add helpful debug messages.
Signed-off-by: Pawan pawan@mayadata.io