### PR TITLE
feat(zfspv): adding poolname info to the PV volumeattributes

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -185,6 +185,7 @@ func (cs *controller) CreateVolume(
 	var selected string
 
 	volName := req.GetName()
+	pool := req.GetParameters()["poolname"]
 	size := req.GetCapacityRange().RequiredBytes
 
 	if err = cs.validateVolumeCreateReq(req); err != nil {
@@ -207,11 +208,13 @@ func (cs *controller) CreateVolume(
 	sendEventOrIgnore(volName, strconv.FormatInt(int64(size), 10), "zfs-localpv", analytics.VolumeProvision)
 
 	topology := map[string]string{zfs.ZFSTopologyKey: selected}
+	cntx := map[string]string{zfs.PoolNameKey: pool}
 
 	return csipayload.NewCreateVolumeResponseBuilder().
 		WithName(volName).
 		WithCapacity(size).
 		WithTopology(topology).
+		WithContext(cntx).
 		WithContentSource(contentSource).
 		Build(), nil
 }

--- a/pkg/zfs/volume.go
+++ b/pkg/zfs/volume.go
@@ -37,6 +37,8 @@ const (
 	ZFSFinalizer string = "zfs.openebs.io/finalizer"
 	// ZFSVolKey for the ZfsSnapshot CR to store Persistence Volume name
 	ZFSVolKey string = "openebs.io/persistent-volume"
+	// PoolNameKey is key for ZFS pool name
+	PoolNameKey string = "openebs.io/poolname"
 	// ZFSNodeKey will be used to insert Label in ZfsVolume CR
 	ZFSNodeKey string = "kubernetes.io/nodename"
 	// ZFSTopologyKey is supported topology key for the zfs driver


### PR DESCRIPTION
Now PV will have poolname/parent-dataset info in volume attributes.
It will help to identify that PV has been create in which zpool.

```
$ kubectl describe pv pvc-22d55c56-0c52-4fd5-894c-1f54c4dac5b7
Name:              pvc-22d55c56-0c52-4fd5-894c-1f54c4dac5b7
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: zfs.csi.openebs.io
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      openebs-zfspv
Status:            Bound
Claim:             default/pvcname208
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          4Gi
Node Affinity:
  Required Terms:
    Term 0:        kubernetes.io/hostname in [pawan-2]
Message:
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            zfs.csi.openebs.io
    VolumeHandle:      pvc-22d55c56-0c52-4fd5-894c-1f54c4dac5b7
    ReadOnly:          false
    VolumeAttributes:      openebs.io/poolname=zfspv-pool
                           storage.kubernetes.io/csiProvisionerIdentity=1586765686638-8081-zfs.csi.openebs.io
Events:                <none>
```
Signed-off-by: Pawan <pawan@mayadata.io>