### PR TITLE
fix(zfspv): fixing data loss in case of pod deletion

### DIFF
--- a/pkg/zfs/mount.go
+++ b/pkg/zfs/mount.go
@@ -78,9 +78,8 @@ func UmountVolume(vol *apis.ZFSVolume, targetPath string,
 		}
 	}
 
-	if err := os.RemoveAll(targetPath); err != nil {
+	if err := os.Remove(targetPath); err != nil {
 		logrus.Errorf("zfspv: failed to remove mount path Error: %v", err)
-		return err
 	}
 
 	logrus.Infof("umount done path %v", targetPath)


### PR DESCRIPTION
fixes: https://github.com/openebs/zfs-localpv/issues/88

looks like a bug in ZFS as when you change the mountpoint property to none,
ZFS automatically umounts the file system. When we delete the pod, we get the 
unmount request for the old pod and mount request for the new pod. Unmount
is done by the driver by setting mountpoint to none and the driver assumes that
unmount has done and proceeded to delete the mountpath, but here zfs has not unmounted
the dataset

```
$ sudo zfs get all zfspv-pool/pvc-3fe69b0e-9f91-4c6e-8e5c-eb4218468765 | grep mount
zfspv-pool/pvc-3fe69b0e-9f91-4c6e-8e5c-eb4218468765  mounted               yes                                                                                                -
zfspv-pool/pvc-3fe69b0e-9f91-4c6e-8e5c-eb4218468765  mountpoint            none                                                                                               local
zfspv-pool/pvc-3fe69b0e-9f91-4c6e-8e5c-eb4218468765  canmount              on
```
The above output is saying that dataset is mounted (mounted = yes) and mountpoint is none, which is not possible

And system is also saying that dataset is mounted 
```
$ sudo mount | grep pvc-3fe69b0e-9f91-4c6e-8e5c-eb4218468765
zfspv-pool/pvc-3fe69b0e-9f91-4c6e-8e5c-eb4218468765 on /var/lib/kubelet/pods/3dbd0a03-c7e5-44f1-9f94-407f6ac96316/volumes/kubernetes.io~csi/pvc-3fe69b0e-9f91-4c6e-8e5c-eb4218468765/mount type zfs (rw,xattr,noacl)
```

here, the driver will assume that dataset has been unmouted and proceed to delete the 
mountpath and it will delete the data as part of cleaning up for the NodeUnPublish request.

Shifting to use zfs umount instead of doing zfs set mountpoint=none for umounting the dataset.
Also the driver is using os.RemoveAll which is very risky as it will clean
child also, since the mountpoint is not supposed to have anything,
just os.Remove is sufficient and it will fail if there is anything there.


This is the log we got from the node agent.
```
43212 time="2020-04-21T17:01:06Z" level=error msg="zfspv: failed to remove mount path Error: unlinkat /var/lib/kubelet/pods/2f9fe907-53b9-46c0-9b9b-d6bed9467836/volumes/ kubernetes.io~csi/pvc-8120d443-c6a7-4f2a-9240-05deb3e05850/mount: device or resource busy
```



Signed-off-by: Pawan <pawan@mayadata.io>