### PR TITLE
feat(topology): adding support for custom topology keys

### DIFF
--- a/deploy/yamls/zfs-driver.yaml
+++ b/deploy/yamls/zfs-driver.yaml
@@ -562,7 +562,7 @@ spec:
             - "--leader-election=true"
           imagePullPolicy: IfNotPresent
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.5.0
+          image: quay.io/k8scsi/csi-provisioner:v1.6.0
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -1019,7 +1019,7 @@ spec:
             - "--leader-election=true"
           imagePullPolicy: IfNotPresent
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.5.0
+          image: quay.io/k8scsi/csi-provisioner:v1.6.0
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"

--- a/pkg/client/k8s/v1alpha1/node.go
+++ b/pkg/client/k8s/v1alpha1/node.go
@@ -68,6 +68,28 @@ func NumberOfNodes() (int, error) {
 	}
 }
 
+// GetNode returns a node instance from kubernetes cluster
+func GetNode(name string) (*corev1.Node, error) {
+	n := Node()
+	node, err := n.Get(name, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get node")
+	} else {
+		return node, nil
+	}
+}
+
+// ListNodes returns list of node instance from kubernetes cluster
+func ListNodes(options metav1.ListOptions) (*corev1.NodeList, error) {
+	n := Node()
+	nodelist, err := n.List(options)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to list node")
+	} else {
+		return nodelist, nil
+	}
+}
+
 // GetOSAndKernelVersion gets us the OS,Kernel version
 func GetOSAndKernelVersion() (string, error) {
 	nodes := Node()

--- a/pkg/driver/agent.go
+++ b/pkg/driver/agent.go
@@ -177,9 +177,27 @@ func (ns *node) NodeGetInfo(
 		logrus.Errorf("failed to get the node %s", ns.driver.config.NodeID)
 		return nil, err
 	}
+	/*
+	 * The driver will support all the keys and values defined in the node's label.
+	 * if nodes are labeled with the below keys and values
+	 * map[beta.kubernetes.io/arch:amd64 beta.kubernetes.io/os:linux kubernetes.io/arch:amd64 kubernetes.io/hostname:pawan-node-1 kubernetes.io/os:linux node-role.kubernetes.io/worker:true openebs.io/zone:zone1 openebs.io/zpool:ssd]
+	 * The driver will support below key and values
+	 * {
+	 *	beta.kubernetes.io/arch:amd64
+	 *	beta.kubernetes.io/os:linux
+	 *	kubernetes.io/arch:amd64
+	 *	kubernetes.io/hostname:pawan-node-1
+	 *	kubernetes.io/os:linux
+	 *	node-role.kubernetes.io/worker:true
+	 *	openebs.io/zone:zone1
+	 *	openebs.io/zpool:ssd
+	 * }
+	 */
 
 	// support all the keys that node has
 	topology := node.Labels
+
+	// add driver's topology key
 	topology[zfs.ZFSTopologyKey] = ns.driver.config.NodeID
 
 	return &csi.NodeGetInfoResponse{

--- a/pkg/driver/scheduler.go
+++ b/pkg/driver/scheduler.go
@@ -107,16 +107,16 @@ func scheduler(topo *csi.TopologyRequirement, schld string, pool string) string 
 
 	if topo == nil ||
 		len(topo.Preferred) == 0 {
-		logrus.Errorf("topology information not provided")
+		logrus.Errorf("scheduler: topology information not provided")
 		return ""
 	}
 
 	nodelist, err := GetNodeList(topo)
 	if err != nil {
-		logrus.Errorf("can not get the ndelist err : %v", err.Error())
+		logrus.Errorf("scheduler: can not get the nodelist err : %v", err.Error())
 		return ""
 	} else if len(nodelist) == 0 {
-		logrus.Errorf("nodelist is empty")
+		logrus.Errorf("scheduler: nodelist is empty")
 		return ""
 	}
 

--- a/pkg/driver/scheduler.go
+++ b/pkg/driver/scheduler.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/openebs/zfs-localpv/pkg/builder/volbuilder"
+	k8sapi "github.com/openebs/zfs-localpv/pkg/client/k8s/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	zfs "github.com/openebs/zfs-localpv/pkg/zfs"
@@ -34,10 +35,39 @@ const (
 	VolumeWeighted = "VolumeWeighted"
 )
 
+// GetNodeList gets the nodelist which satisfies the topology info
+func GetNodeList(topo *csi.TopologyRequirement) ([]string, error) {
+
+	var nodelist []string
+
+	list, err := k8sapi.ListNodes(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, node := range list.Items {
+		for _, prf := range topo.Preferred {
+			nodeFiltered := false
+			for key, value := range prf.Segments {
+				if node.Labels[key] != value {
+					nodeFiltered = true
+					break
+				}
+			}
+			if nodeFiltered == false {
+				nodelist = append(nodelist, node.Name)
+				break
+			}
+		}
+	}
+
+	return nodelist, nil
+}
+
 // volumeWeightedScheduler goes through all the pools on the nodes mentioned
 // in the topology and picks the node which has less volume on
 // the given zfs pool.
-func volumeWeightedScheduler(topo *csi.TopologyRequirement, pool string) string {
+func volumeWeightedScheduler(nodelist []string, pool string) string {
 	var selected string
 
 	zvlist, err := volbuilder.NewKubeclient().
@@ -62,8 +92,7 @@ func volumeWeightedScheduler(topo *csi.TopologyRequirement, pool string) string 
 
 	// schedule it on the node which has less
 	// number of volume for the given pool
-	for _, prf := range topo.Preferred {
-		node := prf.Segments[zfs.ZFSTopologyKey]
+	for _, node := range nodelist {
 		if volmap[node] < numVol {
 			selected = node
 			numVol = volmap[node]
@@ -81,16 +110,26 @@ func scheduler(topo *csi.TopologyRequirement, schld string, pool string) string 
 		logrus.Errorf("topology information not provided")
 		return ""
 	}
+
+	nodelist, err := GetNodeList(topo)
+	if err != nil {
+		logrus.Errorf("can not get the ndelist err : %v", err.Error())
+		return ""
+	} else if len(nodelist) == 0 {
+		logrus.Errorf("nodelist is empty")
+		return ""
+	}
+
 	// if there is a single node, schedule it on that
-	if len(topo.Preferred) == 1 {
-		return topo.Preferred[0].Segments[zfs.ZFSTopologyKey]
+	if len(nodelist) == 1 {
+		return nodelist[0]
 	}
 
 	switch schld {
 	case VolumeWeighted:
-		return volumeWeightedScheduler(topo, pool)
+		return volumeWeightedScheduler(nodelist, pool)
 	default:
-		return volumeWeightedScheduler(topo, pool)
+		return volumeWeightedScheduler(nodelist, pool)
 	}
 
 	return ""

--- a/unreleased/94-pawanpraka1
+++ b/unreleased/94-pawanpraka1
@@ -1,0 +1,1 @@
+adding support to configure custom topology key


### PR DESCRIPTION
fixes :- https://github.com/openebs/zfs-localpv/issues/84

Now user can label the nodes with the required topology, the ZFSPV
driver will support all the node labels as topology keys.

We should label the nodes first and then deploy the driver to make it aware of
all the labels that node has. If we want to add labels after ZFS-LocalPV driver
has been deployed, a restart all the node agents are required so that the driver
can pick the labels and add them as supported topology keys.

Note that if storageclass is using Immediate binding mode and topology key is not mentioned then all the nodes should be labeled using same key, that means, same key should be present on all nodes, nodes can have different values for those keys. If nodes are labeled with different keys i.e.
some nodes are having different keys, then ZFSPV's default scheduler can not effictively
do the volume count based scheduling. In this case the CSI provisioner will pick keys from
any random node and then prepare the preferred topology list using the nodes which has those
keys defined. And ZFSPV scheduler will schedule the PV among those nodes only.


Changed the csi-provisioner image to 1.6.0 as this has the upstream fix https://github.com/kubernetes-csi/external-provisioner/pull/421.

Signed-off-by: Pawan <pawan@mayadata.io>