### PR TITLE
feat(block): adding block volume support for ZFSPV

### DIFF
--- a/deploy/sample/fio-block.yaml
+++ b/deploy/sample/fio-block.yaml
@@ -1,0 +1,50 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: zfspv-block
+allowVolumeExpansion: true
+parameters:
+  poolname: "zfspv-pool"
+provisioner: zfs.csi.openebs.io
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: block-claim
+spec:
+  volumeMode: Block
+  storageClassName: zfspv-block
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fiob
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: fiob
+  template:
+    metadata:
+      labels:
+        name: fiob
+    spec:
+      containers:
+        - resources:
+          name: perfrunner
+          image: openebs/tests-fio
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash"]
+          args: ["-c", "while true ;do sleep 50; done"]
+          volumeDevices:
+            - devicePath: /dev/xvda
+              name: storage
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: block-claim

--- a/deploy/yamls/zfs-driver.yaml
+++ b/deploy/yamls/zfs-driver.yaml
@@ -791,7 +791,7 @@ spec:
             - name: libnvpair
               mountPath: /lib/libnvpair.so.1
             - name: pods-mount-dir
-              mountPath: /var/lib/kubelet/pods
+              mountPath: /var/lib/kubelet/
               # needed so that any mounts setup inside this container are
               # propagated back to the host machine.
               mountPropagation: "Bidirectional"
@@ -838,6 +838,6 @@ spec:
             type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
-            path: /var/lib/kubelet/pods
+            path: /var/lib/kubelet/
             type: Directory
 ---

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -1248,7 +1248,7 @@ spec:
             - name: libnvpair
               mountPath: /lib/libnvpair.so.1
             - name: pods-mount-dir
-              mountPath: /var/lib/kubelet/pods
+              mountPath: /var/lib/kubelet/
               # needed so that any mounts setup inside this container are
               # propagated back to the host machine.
               mountPropagation: "Bidirectional"
@@ -1295,6 +1295,6 @@ spec:
             type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
-            path: /var/lib/kubelet/pods
+            path: /var/lib/kubelet/
             type: Directory
 ---

--- a/pkg/driver/agent.go
+++ b/pkg/driver/agent.go
@@ -110,7 +110,7 @@ func (ns *node) NodePublishVolume(
 
 	vol, mountInfo, err := GetVolAndMountInfo(req)
 	if err != nil {
-		return nil, err
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 	// If the access type is block, do nothing for stage
 	switch req.GetVolumeCapability().GetAccessType().(type) {

--- a/tests/container/container.go
+++ b/tests/container/container.go
@@ -254,6 +254,29 @@ func (b *Builder) WithVolumeMountsNew(volumeMounts []corev1.VolumeMount) *Builde
 	return b
 }
 
+// WithVolumeDevicesNew sets the command arguments of the container
+func (b *Builder) WithVolumeDevicesNew(volumeDevices []corev1.VolumeDevice) *Builder {
+	if volumeDevices == nil {
+		b.errors = append(
+			b.errors,
+			errors.New("failed to build container object: nil volumeDevices"),
+		)
+		return b
+	}
+
+	if len(volumeDevices) == 0 {
+		b.errors = append(
+			b.errors,
+			errors.New("failed to build container object: missing volumeDevices"),
+		)
+		return b
+	}
+	newvolumeDevices := []corev1.VolumeDevice{}
+	newvolumeDevices = append(newvolumeDevices, volumeDevices...)
+	b.con.VolumeDevices = newvolumeDevices
+	return b
+}
+
 // WithImagePullPolicy sets the image pull policy of the container
 func (b *Builder) WithImagePullPolicy(policy corev1.PullPolicy) *Builder {
 	if len(policy) == 0 {

--- a/tests/provision_test.go
+++ b/tests/provision_test.go
@@ -57,7 +57,20 @@ func zvolCreationTest() {
 	By("Deleting storage class", deleteStorageClass)
 }
 
+func blockVolCreationTest() {
+	By("Creating default storage class", createStorageClass)
+	By("creating and verifying PVC bound status", createAndVerifyBlockPVC)
+
+	By("Creating and deploying app pod", createDeployVerifyBlockApp)
+	By("verifying ZFSVolume object", VerifyZFSVolume)
+	By("verifying ZFSVolume property change", VerifyZFSVolumePropEdit)
+	By("Deleting application deployment", deleteAppDeployment)
+	By("Deleting pvc", deletePVC)
+	By("Deleting storage class", deleteStorageClass)
+}
+
 func volumeCreationTest() {
 	By("Running dataset creation test", datasetCreationTest)
 	By("Running zvol creation test", zvolCreationTest)
+	By("Running block volume creation test", blockVolCreationTest)
 }

--- a/tests/pvc/build.go
+++ b/tests/pvc/build.go
@@ -179,3 +179,13 @@ func (b *Builder) Build() (*corev1.PersistentVolumeClaim, error) {
 	}
 	return b.pvc.object, nil
 }
+
+// WithVolumeMode sets the VolumeMode field in PVC with provided arguments
+func (b *Builder) WithVolumeMode(volumemode *corev1.PersistentVolumeMode) *Builder {
+	if volumemode == nil {
+		b.errs = append(b.errs, errors.New("failed to build PVC object: missing volumemode"))
+		return b
+	}
+	b.pvc.object.Spec.VolumeMode = volumemode
+	return b
+}

--- a/unreleased/102-pawanpraka1
+++ b/unreleased/102-pawanpraka1
@@ -1,0 +1,1 @@
+adding RAW Block Volume support for ZFSPV


### PR DESCRIPTION
Fixes: https://github.com/openebs/openebs/issues/2971

We can create a Raw Block Volume request using volumemode as block in PVC :-

```
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: block-claim
spec:
  volumeMode: Block
  storageClassName: zfspv-block
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 5Gi
```
we can use the below storageclass for RAW block volume:
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: zfspv-block
allowVolumeExpansion: true
parameters:
  poolname: "zfspv-pool"
provisioner: zfs.csi.openebs.io
```
The driver will create a zvol for this volume and bind mount the block  device at the given path.

Signed-off-by: Pawan <pawan@mayadata.io>

