### PR TITLE
refact(build): make the docker images configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,17 @@
+# Copyright 2019-2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # list only csi source code directories
 PACKAGES = $(shell go list ./... | grep -v 'vendor\|pkg/generated')
 
@@ -18,27 +32,69 @@ EXTERNAL_TOOLS=\
 	github.com/onsi/ginkgo/ginkgo \
 	github.com/onsi/gomega/...
 
+
+# The images can be pushed to any docker/image registeries
+# like docker hub, quay. The registries are specified in
+# the `build/push` script.
+#
+# The images of a project or company can then be grouped
+# or hosted under a unique organization key like `openebs`
+#
+# Each component (container) will be pushed to a unique
+# repository under an organization.
+# Putting all this together, an unique uri for a given
+# image comprises of:
+#   <registry url>/<image org>/<image repo>:<image-tag>
+#
+# IMAGE_ORG can be used to customize the organization
+# under which images should be pushed.
+# By default the organization name is `openebs`.
+
+ifeq (${IMAGE_ORG}, )
+  IMAGE_ORG="openebs"
+  export IMAGE_ORG
+endif
+
+# Specify the date of build
+DBUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+# Specify the docker arg for repository url
+ifeq (${DBUILD_REPO_URL}, )
+  DBUILD_REPO_URL="https://github.com/openebs/zfs-localpv"
+  export DBUILD_REPO_URL
+endif
+
+# Specify the docker arg for website url
+ifeq (${DBUILD_SITE_URL}, )
+  DBUILD_SITE_URL="https://openebs.io"
+  export DBUILD_SITE_URL
+endif
+
+
 ifeq (${IMAGE_TAG}, )
   IMAGE_TAG = ci
   export IMAGE_TAG
 endif
 
-ifeq (${TRAVIS_TAG}, )
-  BASE_TAG = ci
-  export BASE_TAG
-else
-  BASE_TAG = ${TRAVIS_TAG}
-  export BASE_TAG
+# Determine the arch/os
+ifeq (${XC_OS}, )
+  XC_OS:=$(shell go env GOOS)
 endif
+export XC_OS
+ifeq (${XC_ARCH}, )
+  XC_ARCH:=$(shell go env GOARCH)
+endif
+export XC_ARCH
+ARCH:=${XC_OS}_${XC_ARCH}
+export ARCH
+
+export DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL} --build-arg ARCH=${ARCH}
 
 # Specify the name for the binary
 CSI_DRIVER=zfs-driver
 
-# Specify the date o build
-BUILD_DATE = $(shell date +'%Y%m%d%H%M%S')
-
 .PHONY: all
-all: test zfs-driver-image
+all: test manifests zfs-driver-image
 
 .PHONY: clean
 clean:
@@ -155,7 +211,7 @@ zfs-driver-image: zfs-driver
 	@echo "+ Generating ${CSI_DRIVER} image"
 	@echo "--------------------------------"
 	@cp bin/${CSI_DRIVER}/${CSI_DRIVER} buildscripts/${CSI_DRIVER}/
-	cd buildscripts/${CSI_DRIVER} && sudo docker build -t openebs/${CSI_DRIVER}:${IMAGE_TAG} --build-arg BUILD_DATE=${BUILD_DATE} . && sudo docker tag openebs/${CSI_DRIVER}:${IMAGE_TAG} quay.io/openebs/${CSI_DRIVER}:${IMAGE_TAG}
+	cd buildscripts/${CSI_DRIVER} && sudo docker build -t ${IMAGE_ORG}/${CSI_DRIVER}:${IMAGE_TAG} ${DBUILD_ARGS} . && sudo docker tag ${IMAGE_ORG}/${CSI_DRIVER}:${IMAGE_TAG} quay.io/${IMAGE_ORG}/${CSI_DRIVER}:${IMAGE_TAG}
 	@rm buildscripts/${CSI_DRIVER}/${CSI_DRIVER}
 
 .PHONY: ci
@@ -164,5 +220,5 @@ ci:
 	$(PWD)/ci/ci-test.sh
 # Push images
 deploy-images:
-	@DIMAGE="openebs/zfs-driver" ./buildscripts/push
+	@DIMAGE="${IMAGE_ORG}/zfs-driver" ./buildscripts/push
 

--- a/buildscripts/push
+++ b/buildscripts/push
@@ -1,4 +1,19 @@
 #!/bin/bash
+
+# Copyright 2019-2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 
 if [ -z ${DIMAGE} ];
@@ -27,7 +42,7 @@ else
   CURRENT_BRANCH=${TRAVIS_BRANCH}
 fi
 
-#Depending on the branch where builds are generated,
+# Depending on the branch where builds are generated,
 # set the tag CI (fixed) and build tags.
 BUILD_TAG="${CURRENT_BRANCH}-${BUILD_ID}"
 CI_TAG="${CURRENT_BRANCH}-ci"
@@ -40,9 +55,18 @@ echo "Set the build/unique image tag as: ${BUILD_TAG}"
 
 function TagAndPushImage() {
   REPO="$1"
-  TAG="$2"
 
-  IMAGE_URI="${REPO}:${TAG}";
+  # Trim the `v` from the TAG if it exists
+  # Example: v1.10.0 maps to 1.10.0
+  # Example: 1.10.0 maps to 1.10.0
+  # Example: v1.10.0-custom maps to 1.10.0-custom
+  TAG="$2#v"
+
+  # Add an option to specify a custom TAG_SUFFIX
+  # via environment variable. Default is no tag.
+  # Example suffix could be "-debug" of "-dev"
+  IMAGE_URI="${REPO}:${TAG}${TAG_SUFFIX}";
+
   sudo docker tag ${IMAGEID} ${IMAGE_URI};
   echo " push ${IMAGE_URI}";
   sudo docker push ${IMAGE_URI};

--- a/buildscripts/zfs-driver/Dockerfile
+++ b/buildscripts/zfs-driver/Dockerfile
@@ -1,25 +1,38 @@
+# Copyright 2019-2020 The OpenEBS Authors. All rights reserved.
 #
-# This Dockerfile builds a recent volume-mgmt using the latest binary from
-# volume-mgmt  releases.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 FROM ubuntu:19.10
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN apt-get update; exit 0
 RUN apt-get -y install rsyslog libssl-dev xfsprogs ca-certificates
 
+ARG ARCH
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
+
 COPY zfs-driver /usr/local/bin/
 COPY entrypoint.sh /usr/local/bin/
 
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-ARG BUILD_DATE
 LABEL org.label-schema.name="zfs-driver"
-LABEL org.label-schema.description="OpenEBS"
-LABEL org.label-schema.url="http://www.openebs.io/"
-LABEL org.label-schema.vcs-url="https://github.com/openebs/zfs-localpv"
+LABEL org.label-schema.description="OpenEBS ZFS LocalPV Driver"
 LABEL org.label-schema.schema-version="1.0"
-LABEL org.label-schema.build-date=$BUILD_DATE
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
 
 ENTRYPOINT ["/usr/local/bin/zfs-driver"]
 EXPOSE 7676 7777


### PR DESCRIPTION

Signed-off-by: Pawan <pawan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
This PR makes the docker images configurable and removes the leading v from image tags. This is required to make the image name consistent with other openebs images

**What this PR does?**:
 make the docker images configurable and  trim leading v from image tag.

*Does this PR require any upgrade changes?**:
NA
**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on 