### PR TITLE
fix(version): use the travis tag for the version

### DIFF
--- a/buildscripts/build.sh
+++ b/buildscripts/build.sh
@@ -34,7 +34,7 @@ fi
 
 # Get the version details
 if [ -n "$TRAVIS_TAG" ]; then
-	VERSION="$(git describe --tags `git rev-list --tags --max-count=1`)"
+	VERSION="$TRAVIS_TAG"
 else
 	BUILDDATE=`date +%m-%d-%Y`
 	SHORT_COMMIT="$(git rev-parse --short HEAD)"


### PR DESCRIPTION
Cherry-Pick to v0.7.x banch: https://github.com/openebs/zfs-localpv/pull/114

if there are no changes then `git describe --tags `git rev-list --tags --max-count=1`
may return older tag as there will be two tags referring to the same commit.

Using travis tag here to clearly differentiate the versions.

Signed-off-by: Pawan <pawan@mayadata.io>
