### PR TITLE
feat(print): removing unnecessary printer columns

### DIFF
--- a/deploy/yamls/zfsvolume-crd.yaml
+++ b/deploy/yamls/zfsvolume-crd.yaml
@@ -36,23 +36,12 @@ spec:
     description: Status of the volume
     name: Status
     type: string
-  - JSONPath: .spec.volblocksize
-    description: volblocksize of volume
-    name: volblocksize
-    type: string
-  - JSONPath: .spec.recordsize
-    description: recordsize of created zfs dataset
-    name: recordsize
-    type: string
   - JSONPath: .spec.fsType
     description: filesystem created on the volume
     name: Filesystem
     type: string
-  - JSONPath: .status.creationTime
-    description: Timestamp when the volume has been created.
-    name: CreationTime
-    type: date
   - JSONPath: .metadata.creationTimestamp
+    description: Age of the volume
     name: Age
     type: date
   group: zfs.openebs.io

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -57,23 +57,12 @@ spec:
     description: Status of the volume
     name: Status
     type: string
-  - JSONPath: .spec.volblocksize
-    description: volblocksize of volume
-    name: volblocksize
-    type: string
-  - JSONPath: .spec.recordsize
-    description: recordsize of created zfs dataset
-    name: recordsize
-    type: string
   - JSONPath: .spec.fsType
     description: filesystem created on the volume
     name: Filesystem
     type: string
-  - JSONPath: .status.creationTime
-    description: Timestamp when the volume has been created.
-    name: CreationTime
-    type: date
   - JSONPath: .metadata.creationTimestamp
+    description: Age of the volume
     name: Age
     type: date
   group: zfs.openebs.io

--- a/pkg/apis/openebs.io/zfs/v1alpha1/zfsvolume.go
+++ b/pkg/apis/openebs.io/zfs/v1alpha1/zfsvolume.go
@@ -31,11 +31,8 @@ import (
 // +kubebuilder:printcolumn:name="Node",type=string,JSONPath=`.spec.ownerNodeID`,description="Node where the volume is created"
 // +kubebuilder:printcolumn:name="Size",type=string,JSONPath=`.spec.capacity`,description="Size of the volume"
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.state`,description="Status of the volume"
-// +kubebuilder:printcolumn:name="volblocksize",type=string,JSONPath=`.spec.volblocksize`,description="volblocksize of volume"
-// +kubebuilder:printcolumn:name="recordsize",type=string,JSONPath=`.spec.recordsize`,description="recordsize of created zfs dataset"
 // +kubebuilder:printcolumn:name="Filesystem",type=string,JSONPath=`.spec.fsType`,description="filesystem created on the volume"
-// +kubebuilder:printcolumn:name="CreationTime",type=date,JSONPath=`.status.creationTime`,description="Timestamp when the volume has been created."
-// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age of the volume"
 type ZFSVolume struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Creation time Stamp is not useful information as we already have the Age, Also volblocksize and Recordsize can not co-exist, feeling it is better to remove them(open for suggestion) as we can get the info from the storageclass.

Signed-off-by: Pawan <pawan@mayadata.io>
