### PR TITLE
[WIP] make zfs provisioner set sharenfs property

### DIFF
--- a/deploy/sample/nfs-tester.yaml
+++ b/deploy/sample/nfs-tester.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: zfs-dataset
+allowedTopologies:
+  - matchLabelExpressions:
+      - key: openebs.io/node
+        values:
+          - storage
+allowVolumeExpansion: true
+parameters:
+  compression: "lz4"
+  dedup: "off"
+  fstype: "nfs"
+  poolname: "tank"
+  sharenfs: "rw=@192.168.0.0/16,rw=@127.0.0.0/8,no_root_squash"
+provisioner: zfs.csi.openebs.io
+
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: zfspv-001
+spec:
+  storageClassName: zfs-dataset
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 128Mi
+
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: zfspv-002
+spec:
+  storageClassName: zfs-dataset
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 128Mi
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tester-1
+  labels:
+    app: tester-1
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: tester-1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: tester-1
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - tester-1
+              topologyKey: kubernetes.io/hostname
+      terminationGracePeriodSeconds: 0
+      containers:
+        - name: tester
+          image: library/debian:bullseye
+          command:
+            - "/bin/sleep"
+            - "3600"
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /needed4NFS/irrelevantHere1
+              name: nfs-vol-1
+      restartPolicy: Always
+      volumes:
+        - name: nfs-vol-1
+          persistentVolumeClaim:
+            claimName: zfspv-001

--- a/deploy/yamls/ubuntu/zfs-driver.yaml
+++ b/deploy/yamls/ubuntu/zfs-driver.yaml
@@ -526,6 +526,14 @@ spec:
                 values:
                 - openebs-zfs-controller
             topologyKey: "kubernetes.io/hostname"
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: hosttype
+                    operator: In
+                    values:
+                      - zfsprovider
       priorityClassName: system-cluster-critical
       serviceAccount: openebs-zfs-controller-sa
       containers:
@@ -702,7 +710,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 
 ---
-
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -712,12 +719,22 @@ spec:
   selector:
     matchLabels:
       app: openebs-zfs-node
+      role: openebs-zfs
   template:
     metadata:
       labels:
         app: openebs-zfs-node
         role: openebs-zfs
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: hosttype
+                    operator: In
+                    values:
+                      - zfsprovider
       priorityClassName: system-node-critical
       serviceAccount: openebs-zfs-node-sa
       hostNetwork: true
@@ -791,11 +808,42 @@ spec:
               mountPath: /lib/libuutil.so.1
             - name: libnvpair
               mountPath: /lib/libnvpair.so.1
+            - name: exportfs
+              mountPath: /usr/sbin/exportfs
+            - name: mount-nfs
+              mountPath: /usr/sbin/mount.nfs
+            - name: rpc-nfsd
+              mountPath: /usr/sbin/rpc.nfsd
+            - name: rpc-mountd
+              mountPath: /usr/sbin/rpc.mountd
+            - name: libtirp
+              mountPath: /usr/lib/x86_64-linux-gnu/libtirpc.so.3
             - name: pods-mount-dir
               mountPath: /var/lib/kubelet/
+              mountPropagation: "Bidirectional"
               # needed so that any mounts setup inside this container are
               # propagated back to the host machine.
+            - name: libgssapi
+              mountPath: /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2
+            - name: libkrb
+              mountPath: /usr/lib/x86_64-linux-gnu/libkrb5.so.3
+            - name: libkrbcrypto
+              mountPath: /usr/lib/x86_64-linux-gnu/libk5crypto.so.3
+            - name: libkrbsupport
+              mountPath: /usr/lib/x86_64-linux-gnu/libkrb5support.so.0
+            - name: libkeyutils
+              mountPath: /usr/lib/x86_64-linux-gnu/libkeyutils.so.1
+            - name: libwrap
+              mountPath: /usr/lib/x86_64-linux-gnu/libwrap.so.0
+            - name: exports
+              mountPath: /etc/exports
+            - name: nfs-state
+              mountPath: /var/lib/nfs
+            - name: tank
+              mountPath: /tank
               mountPropagation: "Bidirectional"
+              # needed so that any mounts setup inside this container are
+              # propagated back to the host machine.
       volumes:
         - name: device-dir
           hostPath:
@@ -829,6 +877,50 @@ spec:
           hostPath:
             path: /lib/libnvpair.so.1.0.1
             type: File
+        - name: exportfs
+          hostPath:
+            path: /usr/sbin/exportfs
+            type: File
+        - name: mount-nfs
+          hostPath:
+            path: /usr/sbin/mount.nfs
+            type: File
+        - name: rpc-nfsd
+          hostPath:
+            path: /usr/sbin/rpc.nfsd
+            type: File
+        - name: rpc-mountd
+          hostPath:
+            path: /usr/sbin/rpc.mountd
+            type: File
+        - name: libtirp
+          hostPath:
+            path: /usr/lib/x86_64-linux-gnu/libtirpc.so.3
+            type: File
+        - name: libgssapi
+          hostPath:
+            path: /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2
+            type: File
+        - name: libkrb
+          hostPath:
+            path: /usr/lib/x86_64-linux-gnu/libkrb5.so.3
+            type: File
+        - name: libkrbcrypto
+          hostPath:
+            path: /usr/lib/x86_64-linux-gnu/libk5crypto.so.3
+            type: File
+        - name: libkrbsupport
+          hostPath:
+            path: /usr/lib/x86_64-linux-gnu/libkrb5support.so.0
+            type: File
+        - name: libkeyutils
+          hostPath:
+            path: /usr/lib/x86_64-linux-gnu/libkeyutils.so.1
+            type: File
+        - name: libwrap
+          hostPath:
+            path: /usr/lib/x86_64-linux-gnu/libwrap.so.0
+            type: File
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry/
@@ -841,4 +933,225 @@ spec:
           hostPath:
             path: /var/lib/kubelet/
             type: Directory
+        - name: exports
+          hostPath:
+            path: /etc/exports
+            type: File
+        - name: nfs-state
+          hostPath:
+            path: /var/lib/nfs
+            type: Directory
+        - name: tank
+          hostPath:
+            path: /tank
+            type: Directory
+
 ---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: openebs-zfs-nfs
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: openebs-zfs-node
+      role: openebs-nfs
+  template:
+    metadata:
+      labels:
+        app: openebs-zfs-node
+        role: openebs-nfs
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: hosttype
+                    operator: In
+                    values:
+                      - nfsconsumer
+      priorityClassName: system-node-critical
+      serviceAccount: openebs-zfs-node-sa
+      hostNetwork: true
+      containers:
+        - name: csi-node-driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /registration/zfs-localpv /registration/zfs-localpv-reg.sock"]
+          env:
+            - name: ADDRESS
+              value: /plugin/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/zfs-localpv/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NODE_DRIVER
+              value: openebs-zfs
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /plugin
+            - name: registration-dir
+              mountPath: /registration
+        - name: openebs-zfs-plugin
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["CAP_MKNOD", "CAP_SYS_ADMIN", "SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: quay.io/openebs/zfs-driver:ci
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--nodeid=$(OPENEBS_NODE_ID)"
+            - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
+            - "--plugin=$(OPENEBS_NODE_DRIVER)"
+          env:
+            - name: OPENEBS_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OPENEBS_CSI_ENDPOINT
+              value: unix:///plugin/csi.sock
+            - name: OPENEBS_NODE_DRIVER
+              value: agent
+            - name: OPENEBS_NAMESPACE
+              value: openebs
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /plugin
+            - name: device-dir
+              mountPath: /dev
+            - name: encr-keys
+              mountPath: /home/keys
+            - name: zfs-bin
+              mountPath: /sbin/zfs
+            - name: libzpool
+              mountPath: /lib/libzpool.so.2
+            - name: libzfscore
+              mountPath: /lib/libzfs_core.so.1
+            - name: libzfs
+              mountPath: /lib/libzfs.so.2
+            - name: libuutil
+              mountPath: /lib/libuutil.so.1
+            - name: libnvpair
+              mountPath: /lib/libnvpair.so.1
+            - name: exportfs
+              mountPath: /usr/sbin/exportfs
+            - name: mount-nfs
+              mountPath: /usr/sbin/mount.nfs
+            - name: libtirp
+              mountPath: /usr/lib/x86_64-linux-gnu/libtirpc.so.3
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet/
+              mountPropagation: "Bidirectional"
+              # needed so that any mounts setup inside this container are
+              # propagated back to the host machine.
+            - name: libgssapi
+              mountPath: /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2
+            - name: libkrb
+              mountPath: /usr/lib/x86_64-linux-gnu/libkrb5.so.3
+            - name: libkrbcrypto
+              mountPath: /usr/lib/x86_64-linux-gnu/libk5crypto.so.3
+            - name: libkrbsupport
+              mountPath: /usr/lib/x86_64-linux-gnu/libkrb5support.so.0
+            - name: libkeyutils
+              mountPath: /usr/lib/x86_64-linux-gnu/libkeyutils.so.1
+            - name: exports
+              mountPath: /etc/exports
+            - name: nfs-state
+              mountPath: /var/lib/nfs
+      volumes:
+        - name: device-dir
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: encr-keys
+          hostPath:
+            path: /home/keys
+            type: DirectoryOrCreate
+        - name: zfs-bin
+          hostPath:
+            path: /sbin/zfs
+            type: File
+        - name: libzpool
+          hostPath:
+            path: /lib/libzpool.so.2.0.0
+            type: File
+        - name: libzfscore
+          hostPath:
+            path: /lib/libzfs_core.so.1.0.0
+            type: File
+        - name: libzfs
+          hostPath:
+            path: /lib/libzfs.so.2.0.0
+            type: File
+        - name: libuutil
+          hostPath:
+            path: /lib/libuutil.so.1.0.1
+            type: File
+        - name: libnvpair
+          hostPath:
+            path: /lib/libnvpair.so.1.0.1
+            type: File
+        - name: exportfs
+          hostPath:
+            path: /usr/sbin/exportfs
+            type: File
+        - name: mount-nfs
+          hostPath:
+            path: /usr/sbin/mount.nfs
+            type: File
+        - name: libtirp
+          hostPath:
+            path: /usr/lib/x86_64-linux-gnu/libtirpc.so.3
+            type: File
+        - name: libgssapi
+          hostPath:
+            path: /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2
+            type: File
+        - name: libkrb
+          hostPath:
+            path: /usr/lib/x86_64-linux-gnu/libkrb5.so.3
+            type: File
+        - name: libkrbcrypto
+          hostPath:
+            path: /usr/lib/x86_64-linux-gnu/libk5crypto.so.3
+            type: File
+        - name: libkrbsupport
+          hostPath:
+            path: /usr/lib/x86_64-linux-gnu/libkrb5support.so.0
+            type: File
+        - name: libkeyutils
+          hostPath:
+            path: /usr/lib/x86_64-linux-gnu/libkeyutils.so.1
+            type: File
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: DirectoryOrCreate
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/zfs-localpv/
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet/
+            type: Directory
+        - name: exports
+          hostPath:
+            path: /etc/exports
+            type: File
+        - name: nfs-state
+          hostPath:
+            path: /var/lib/nfs
+            type: Directory

--- a/deploy/yamls/zfsvolume-crd.yaml
+++ b/deploy/yamls/zfsvolume-crd.yaml
@@ -178,6 +178,14 @@ spec:
                 - "yes"
                 - "no"
                 type: string
+              sharenfs:
+                description: 'Specify if, and when, how to share via NFS. Options
+                  are documented in zfs(1M) or zfs(8) and exports(5). Considering
+                  the structure of options to export and the state of
+                  documentation outlined in `github.com/openzfs/zfs/issues/3860`,
+                  validation is non-trivial and very much dependent on other
+                  options.'
+                type: string
               snapname:
                 description: SnapName specifies the name of the snapshot where the
                   volume has been cloned from. Snapname can not be edited after the

--- a/pkg/apis/openebs.io/zfs/v1/zfsvolume.go
+++ b/pkg/apis/openebs.io/zfs/v1/zfsvolume.go
@@ -194,6 +194,11 @@ type VolumeInfo struct {
 	// Default Value: ext4.
 	FsType string `json:"fsType,omitempty"`
 
+	// ShareNfs specifies if, and when, how, to share the dataset via NFS.
+	// It depends on the Linux NFS Kernel Server to be running on the machine
+	// providing the volume and the volume to be mounted.
+	ShareNfs string `json:"sharenfs,omitempty"`
+
 	// Shared specifies whether the volume can be shared among multiple pods.
 	// If it is not set to "yes", then the ZFS-LocalPV Driver will not allow
 	// the volumes to be mounted by more than one pods.

--- a/pkg/builder/volbuilder/build.go
+++ b/pkg/builder/volbuilder/build.go
@@ -148,6 +148,12 @@ func (b *Builder) WithRecordSize(rs string) *Builder {
 	return b
 }
 
+// WithShareNfs sets the sharenfs property string of ZFSVolume
+func (b *Builder) WithShareNfs(sharenfs string) *Builder {
+	b.volume.Object.Spec.ShareNfs = sharenfs
+	return b
+}
+
 // WithVolBlockSize sets the volblocksize of ZFSVolume
 func (b *Builder) WithVolBlockSize(bs string) *Builder {
 	b.volume.Object.Spec.VolBlockSize = bs


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

With issue #69 , sharing via NFS has been requested. Setting the sharenfs property is easy. However, to actually use the property on a system with the nfs-kernel-server, the dataset needs to be mounted and probably shared calling `zfs share -a`.

When invoked locally on a shell, it works. From the provisioner, it doesn't.

**What this PR does?**:

See above

**Does this PR require any upgrade changes?**:

I have not tested intensively, I believe it doesn"t.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

- create new dataset with sharenfs set
- change dataset's sharenfs properties
- destroy dataset

**Any additional information for your reviewer?** :
The PR is not yet ready to be merged. I kindly request help on how to properly mount the dataset on the providing machine, so that it may be exported via NFS.

In the second step, I would probably need assistance on how mount the dataset via nfs without fighting the affinity scheduler.

In both cases, I think pointing out the interface would be sufficient :-)

In any case, thank you very much for developing the zfs local provisioner,

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:


**PLEASE REMOVE BELOW INFORMATION BEFORE SUBMITTING** (which I would love to do when it is ready, which it is not - by far)

The PR title message must follow convention:
   `<type>(<scope>): <subject>`.

Where: <br />
- `type` is defining if release will be triggering after merging submitted changes, details in [CONTRIBUTING.md](../CONTRIBUTING.md).
    Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `scope` is a single word that best describes where the changes fit.
  Most common scopes are like:
    - data engine (`localpv`, `jiva`, `cstor`)
    - feature (`provisioning`, `backup`, `restore`, `exporter`)
    - code component (`api`, `webhook`, `cast`, `upgrade`)
    - test (`tests`, `bdd`)
    - chores (`version`, `build`, `log`, `travis`)

- `subject` is a single line brief description of the changes made in the pull request.
