### PR TITLE
fix(provisioning): make volumes with fsType=zfs datasets of type filesystem

### DIFF
--- a/changelogs/unreleased/144-cruwe
+++ b/changelogs/unreleased/144-cruwe
@@ -1,0 +1,1 @@
+Fixes an issue where volumes meant to be filesystem datasets got created as zvols and generally makes storageclass parameter spelling insensitive to case

--- a/pkg/common/helpers/helpers.go
+++ b/pkg/common/helpers/helpers.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"strings"
+)
+
+// Coerce the map's keys to lower case, which only works when unicode char is in
+// ASCII subset. May overwrite key-value pairs on different permutations of key
+// case as in Key and key. DON'T force values to the lower case unconditionally,
+// because values for keys such as mountpoint or keylocation are case-sensitive.
+// Note that although keys such as 'comPREssion' are accepted and processed,
+// even if they are technically invalid, updates to rectify such typing will be
+// prohibited as a forbidden update.
+func GetCaseInsensitiveMap(dict *map[string]string) map[string]string {
+	insensitiveDict := map[string]string{}
+
+	for k, v := range *dict {
+		insensitiveDict[strings.ToLower(k)] = v
+	}
+	return insensitiveDict
+}
+
+// special case of GetCaseInsensitiveMap looking up one key-value pair only
+func GetInsensitiveParameter(dict *map[string]string, key string) string {
+	insensitiveDict := GetCaseInsensitiveMap(dict)
+	return insensitiveDict[strings.ToLower(key)]
+}


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

fixes #143 -> inconsistent naming of fsType with fallback to ext4 and all datasets created as volumes

**What this PR does?**:
Reformulating the getter allows volumes to be created with zfs-type, which will result in a "filesystem" dataset.

**Does this PR require any upgrade changes?**:

I do not think so.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

Without this fix, a dataset as described in #143 is created as a volume. With the fix, it is created as a dataset of type filesystem. Conersly, with type xfs, it is still created as a dataset of type volume. I imagine my testing could have been more thorough, this is what I managed to do to with the time at hand.

**Checklist:**
- [x] Fixes #143 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

