### PR TITLE
fix(pvc): fixing stale ZFSVolume CR issue when deleting pending PVC

### DIFF
--- a/changelogs/unreleased/145-pawanpraka1
+++ b/changelogs/unreleased/145-pawanpraka1
@@ -1,0 +1,1 @@
+fixing stale ZFSVolume resource issue when deleting the pvc in pending state

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -209,16 +209,6 @@ func (cs *controller) CreateVolume(
 		return nil, err
 	}
 
-	selected, state, err := zfs.GetZFSVolumeState(req.Name)
-
-	if err == nil {
-		// ZFSVolume CR has been created, check if it is in Ready state
-		if state == zfs.ZFSStatusReady {
-			goto CreateVolumeResponse
-		}
-		return nil, status.Errorf(codes.Internal, "volume %s creation is Pending", volName)
-	}
-
 	if contentSource != nil && contentSource.GetSnapshot() != nil {
 		snapshotID := contentSource.GetSnapshot().GetSnapshotId()
 
@@ -230,18 +220,6 @@ func (cs *controller) CreateVolume(
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-
-	_, state, err = zfs.GetZFSVolumeState(req.Name)
-
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "createvolume: failed to fetch the volume %v", err.Error())
-	}
-
-	if state == zfs.ZFSStatusPending {
-		return nil, status.Errorf(codes.Internal, "volume %s is being created", volName)
-	}
-
-CreateVolumeResponse:
 
 	sendEventOrIgnore(volName, strconv.FormatInt(int64(size), 10), "zfs-localpv", analytics.VolumeProvision)
 

--- a/pkg/zfs/mount.go
+++ b/pkg/zfs/mount.go
@@ -194,12 +194,12 @@ func MountDataset(vol *apis.ZFSVolume, mount *apis.MountInfo) error {
 	volume := vol.Spec.PoolName + "/" + vol.Name
 	err := verifyMountRequest(vol, mount.MountPath)
 	if err != nil {
-		return status.Error(codes.Internal, "dataset can not be mounted")
+		return status.Error(codes.Internal, "invalid mount request")
 	}
 
 	err = MountZFSDataset(vol, mount.MountPath)
 	if err != nil {
-		return status.Error(codes.Internal, "not able to mount the dataset")
+		return status.Errorf(codes.Internal, "zfs: mount failed err : %v", err.Error())
 	}
 
 	logrus.Infof("dataset %v mounted %v", volume, mount.MountPath)

--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -20,6 +20,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"fmt"
 	"github.com/Sirupsen/logrus"
 	apis "github.com/openebs/zfs-localpv/pkg/apis/openebs.io/zfs/v1"
 )
@@ -379,8 +380,9 @@ func SetDatasetMountProp(volume string, mountpath string) error {
 	if err != nil {
 		logrus.Errorf("zfs: could not set mountpoint on dataset %v cmd %v error: %s",
 			volume, ZFSVolArg, string(out))
+		return fmt.Errorf("could not set the mountpoint, %s", string(out))
 	}
-	return err
+	return nil
 }
 
 // MountZFSDataset mounts the dataset to the given mountpoint
@@ -412,7 +414,7 @@ func MountZFSDataset(vol *apis.ZFSVolume, mountpath string) error {
 		if err != nil {
 			logrus.Errorf("zfs: could not mount the dataset %v cmd %v error: %s",
 				volume, MountVolArg, string(out))
-			return err
+			return fmt.Errorf("not able to mount, %s", string(out))
 		}
 	}
 
@@ -452,7 +454,7 @@ func GetVolumeProperty(vol *apis.ZFSVolume, prop string) (string, error) {
 	if err != nil {
 		logrus.Errorf("zfs: could not get %s on dataset %v cmd %v error: %s",
 			prop, volume, ZFSVolArg, string(out))
-		return "", err
+		return "", fmt.Errorf("get %s failed, %s", prop, string(out))
 	}
 	val := out[:len(out)-1]
 	return string(val), nil


### PR DESCRIPTION
fixes: https://github.com/openebs/zfs-localpv/issues/130

Signed-off-by: Pawan <pawan@mayadata.io>

**Why is this PR required? What issue does it fix?**:

PVC will not bound if there are wrong parameters/poolname in the storageclass,
the ZFSVolume CR will be still created and will remain in Pending State,
deletion of the PVC will delete PVC and since PVC is not bound, ZFS-LocalPV
driver will not get the delete call and will leave the ZFSVolume CR hanging there.

**What this PR does?**:


Reverting the behavior introduced in https://github.com/openebs/zfs-localpv/pull/121,
Now PVC will be bound but still ZFSVolume will be in Pending state until the volume is created.
Now, with the wrong parameter, the POD will be in ContainerCreating and describe of it will show that mount is failing
```
  Warning  FailedMount       1s (x2 over 1s)  kubelet, pawan-node-1  MountVolume.SetUp failed for volume "pvc-ce4c30ca-0eda-48ef-9cec-ca2f53356065" : kubernetes.io/csi: mounter.SetupAt failed: rpc error: code = Internal desc = rpc error: code = Internal desc = zfs: mount failed err : could not set the mountpoint, cannot open 'zfspv-pool1/pvc-ce4c30ca-0eda-48ef-9cec-ca2f53356065': dataset does not exist
```

**Does this PR require any upgrade changes?**:

No


**Checklist:**
- [x] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

