### PR TITLE
feat(mount): moving to legacy mount

### DIFF
--- a/changelogs/unreleased/151-pawanpraka1
+++ b/changelogs/unreleased/151-pawanpraka1
@@ -1,0 +1,1 @@
+moving to legacy mount


### PR DESCRIPTION

Signed-off-by: Pawan <pawan@mayadata.io>

## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**:

We can not mount the datasets to more than one path via zfs mount command, shifting to the legacy way of handling ZFS volumes where we can mount/umount the datasets via legacy mount and umount commands.

This will also add a building block for SINGLE-NODE-MULTI-WRITER Capability.

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on 