### PR TITLE
feat(shared): adding shared mount support ZFSPV volumes

### DIFF
--- a/changelogs/unreleased/164-pawanpraka1
+++ b/changelogs/unreleased/164-pawanpraka1
@@ -1,0 +1,1 @@
+adding shared mount support ZFSPV volumes

--- a/deploy/operators/centos7/zfs-operator.yaml
+++ b/deploy/operators/centos7/zfs-operator.yaml
@@ -77,180 +77,360 @@ spec:
   preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: ZFSVolume represents a ZFS based volume
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: VolumeInfo defines ZFS volume parameters for all modes in which
-            ZFS volumes can be created like - ZFS volume with filesystem, ZFS Volume
-            exposed as zfs or ZFS volume exposed as raw block device. Some of the
-            parameters can be only set during creation time (as specified in the details
-            of the parameter), and a few are editable. In case of Cloned volumes,
-            the parameters are assigned the same values as the source volume.
-          properties:
-            capacity:
-              description: Capacity of the volume
-              minLength: 1
-              type: string
-            compression:
-              description: 'Compression specifies the block-level compression algorithm
-                to be applied to the ZFS Volume. The value "on" indicates ZFS to use
-                the default compression algorithm. The default compression algorithm
-                used by ZFS will be either lzjb or, if the lz4_compress feature is
-                enabled, lz4. Compression property can be edited after the volume
-                has been created. The change will only be applied to the newly-written
-                data. For instance, if the Volume was created with "off" and the next
-                day the compression was modified to "on", the data written prior to
-                setting "on" will not be compressed. Default Value: off.'
-              pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
-              type: string
-            dedup:
-              description: 'Deduplication is the process for removing redundant data
-                at the block level, reducing the total amount of data stored. If a
-                file system has the dedup property enabled, duplicate data blocks
-                are removed synchronously. The result is that only unique data is
-                stored and common components are shared among files. Deduplication
-                can consume significant processing power (CPU) and memory as well
-                as generate additional disk IO. Before creating a pool with deduplication
-                enabled, ensure that you have planned your hardware requirements appropriately
-                and implemented appropriate recovery practices, such as regular backups.
-                As an alternative to deduplication consider using compression=lz4,
-                as a less resource-intensive alternative. should be enabled on the
-                zvol. Dedup property can be edited after the volume has been created.
-                Default Value: off.'
-              enum:
-              - "on"
-              - "off"
-              type: string
-            encryption:
-              description: 'Enabling the encryption feature allows for the creation
-                of encrypted filesystems and volumes. ZFS will encrypt file and zvol
-                data, file attributes, ACLs, permission bits, directory listings,
-                FUID mappings, and userused / groupused data. ZFS will not encrypt
-                metadata related to the pool structure, including dataset and snapshot
-                names, dataset hierarchy, properties, file size, file holes, and deduplication
-                tables (though the deduplicated data itself is encrypted). Default
-                Value: off.'
-              pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
-              type: string
-            fsType:
-              description: 'FsType specifies filesystem type for the zfs volume/dataset.
-                If FsType is provided as "zfs", then the driver will create a ZFS
-                dataset, formatting is not required as underlying filesystem is ZFS
-                anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver will
-                create a ZVOL and format the volume accordingly. FsType can not be
-                modified once volume has been provisioned. Default Value: ext4.'
-              type: string
-            keyformat:
-              description: KeyFormat specifies format of the encryption key The supported
-                KeyFormats are passphrase, raw, hex.
-              enum:
-              - passphrase
-              - raw
-              - hex
-              type: string
-            keylocation:
-              description: KeyLocation is the location of key for the encryption
-              type: string
-            ownerNodeID:
-              description: OwnerNodeID is the Node ID where the ZPOOL is running which
-                is where the volume has been provisioned. OwnerNodeID can not be edited
-                after the volume has been provisioned.
-              minLength: 1
-              type: string
-            poolName:
-              description: poolName specifies the name of the pool where the volume
-                has been created. PoolName can not be edited after the volume has
-                been provisioned.
-              minLength: 1
-              type: string
-            recordsize:
-              description: 'Specifies a suggested block size for files in the file
-                system. The size specified must be a power of two greater than or
-                equal to 512 and less than or equal to 128 Kbytes. RecordSize property
-                can be edited after the volume has been created. Changing the file
-                system''s recordsize affects only files created afterward; existing
-                files are unaffected. Default Value: 128k.'
-              minLength: 1
-              type: string
-            snapname:
-              description: SnapName specifies the name of the snapshot where the volume
-                has been cloned from. Snapname can not be edited after the volume
-                has been provisioned.
-              type: string
-            thinProvision:
-              description: 'ThinProvision describes whether space reservation for
-                the source volume is required or not. The value "yes" indicates that
-                volume should be thin provisioned and "no" means thick provisioning
-                of the volume. If thinProvision is set to "yes" then volume can be
-                provisioned even if the ZPOOL does not have the enough capacity. If
-                thinProvision is set to "no" then volume can be provisioned only if
-                the ZPOOL has enough capacity and capacity required by volume can
-                be reserved. ThinProvision can not be modified once volume has been
-                provisioned. Default Value: no.'
-              enum:
-              - "yes"
-              - "no"
-              type: string
-            volblocksize:
-              description: 'VolBlockSize specifies the block size for the zvol. The
-                volsize can only be set to a multiple of volblocksize, and cannot
-                be zero. VolBlockSize can not be edited after the volume has been
-                provisioned. Default Value: 8k.'
-              minLength: 1
-              type: string
-            volumeType:
-              description: volumeType determines whether the volume is of type "DATASET"
-                or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
-                of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
-                is mentioned as fstype in the storageclass, then a volume of type
-                zvol will be created, which will be further formatted as the fstype
-                provided in the storageclass. VolumeType can not be modified once
-                volume has been provisioned.
-              enum:
-              - ZVOL
-              - DATASET
-              type: string
-          required:
-          - capacity
-          - ownerNodeID
-          - poolName
-          - volumeType
-          type: object
-        status:
-          properties:
-            state:
-              description: State specifies the current state of the volume provisioning
-                request. The state "Pending" means that the volume creation request
-                has not processed yet. The state "Ready" means that the volume has
-                been created and it is ready for the use.
-              enum:
-              - Pending
-              - Ready
-              type: string
-          type: object
-      required:
-      - spec
-      type: object
   version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ZFSVolume represents a ZFS based volume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
+                  to be applied to the ZFS Volume. The value "on" indicates ZFS to
+                  use the default compression algorithm. The default compression algorithm
+                  used by ZFS will be either lzjb or, if the lz4_compress feature
+                  is enabled, lz4. Compression property can be edited after the volume
+                  has been created. The change will only be applied to the newly-written
+                  data. For instance, if the Volume was created with "off" and the
+                  next day the compression was modified to "on", the data written
+                  prior to setting "on" will not be compressed. Default Value: off.'
+                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
+                  data at the block level, reducing the total amount of data stored.
+                  If a file system has the dedup property enabled, duplicate data
+                  blocks are removed synchronously. The result is that only unique
+                  data is stored and common components are shared among files. Deduplication
+                  can consume significant processing power (CPU) and memory as well
+                  as generate additional disk IO. Before creating a pool with deduplication
+                  enabled, ensure that you have planned your hardware requirements
+                  appropriately and implemented appropriate recovery practices, such
+                  as regular backups. As an alternative to deduplication consider
+                  using compression=lz4, as a less resource-intensive alternative.
+                  should be enabled on the zvol. Dedup property can be edited after
+                  the volume has been created. Default Value: off.'
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
+                  of encrypted filesystems and volumes. ZFS will encrypt file and
+                  zvol data, file attributes, ACLs, permission bits, directory listings,
+                  FUID mappings, and userused / groupused data. ZFS will not encrypt
+                  metadata related to the pool structure, including dataset and snapshot
+                  names, dataset hierarchy, properties, file size, file holes, and
+                  deduplication tables (though the deduplicated data itself is encrypted).
+                  Default Value: off.'
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  If FsType is provided as "zfs", then the driver will create a ZFS
+                  dataset, formatting is not required as underlying filesystem is
+                  ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
+                  will create a ZVOL and format the volume accordingly. FsType can
+                  not be modified once volume has been provisioned. Default Value:
+                  ext4.'
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
+                  system. The size specified must be a power of two greater than or
+                  equal to 512 and less than or equal to 128 Kbytes. RecordSize property
+                  can be edited after the volume has been created. Changing the file
+                  system''s recordsize affects only files created afterward; existing
+                  files are unaffected. Default Value: 128k.'
+                minLength: 1
+                type: string
+              shared:
+                description: Shared specifies whether the volume can be shared among
+                  multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
+                  will not allow the volumes to be mounted by more than one pods.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
+                  the source volume is required or not. The value "yes" indicates
+                  that volume should be thin provisioned and "no" means thick provisioning
+                  of the volume. If thinProvision is set to "yes" then volume can
+                  be provisioned even if the ZPOOL does not have the enough capacity.
+                  If thinProvision is set to "no" then volume can be provisioned only
+                  if the ZPOOL has enough capacity and capacity required by volume
+                  can be reserved. ThinProvision can not be modified once volume has
+                  been provisioned. Default Value: no.'
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
+                  The volsize can only be set to a multiple of volblocksize, and cannot
+                  be zero. VolBlockSize can not be edited after the volume has been
+                  provisioned. Default Value: 8k.'
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+          status:
+            properties:
+              state:
+                description: State specifies the current state of the volume provisioning
+                  request. The state "Pending" means that the volume creation request
+                  has not processed yet. The state "Ready" means that the volume has
+                  been created and it is ready for the use.
+                enum:
+                - Pending
+                - Ready
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ZFSVolume represents a ZFS based volume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
+                  to be applied to the ZFS Volume. The value "on" indicates ZFS to
+                  use the default compression algorithm. The default compression algorithm
+                  used by ZFS will be either lzjb or, if the lz4_compress feature
+                  is enabled, lz4. Compression property can be edited after the volume
+                  has been created. The change will only be applied to the newly-written
+                  data. For instance, if the Volume was created with "off" and the
+                  next day the compression was modified to "on", the data written
+                  prior to setting "on" will not be compressed. Default Value: off.'
+                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
+                  data at the block level, reducing the total amount of data stored.
+                  If a file system has the dedup property enabled, duplicate data
+                  blocks are removed synchronously. The result is that only unique
+                  data is stored and common components are shared among files. Deduplication
+                  can consume significant processing power (CPU) and memory as well
+                  as generate additional disk IO. Before creating a pool with deduplication
+                  enabled, ensure that you have planned your hardware requirements
+                  appropriately and implemented appropriate recovery practices, such
+                  as regular backups. As an alternative to deduplication consider
+                  using compression=lz4, as a less resource-intensive alternative.
+                  should be enabled on the zvol. Dedup property can be edited after
+                  the volume has been created. Default Value: off.'
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
+                  of encrypted filesystems and volumes. ZFS will encrypt file and
+                  zvol data, file attributes, ACLs, permission bits, directory listings,
+                  FUID mappings, and userused / groupused data. ZFS will not encrypt
+                  metadata related to the pool structure, including dataset and snapshot
+                  names, dataset hierarchy, properties, file size, file holes, and
+                  deduplication tables (though the deduplicated data itself is encrypted).
+                  Default Value: off.'
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  If FsType is provided as "zfs", then the driver will create a ZFS
+                  dataset, formatting is not required as underlying filesystem is
+                  ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
+                  will create a ZVOL and format the volume accordingly. FsType can
+                  not be modified once volume has been provisioned. Default Value:
+                  ext4.'
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
+                  system. The size specified must be a power of two greater than or
+                  equal to 512 and less than or equal to 128 Kbytes. RecordSize property
+                  can be edited after the volume has been created. Changing the file
+                  system''s recordsize affects only files created afterward; existing
+                  files are unaffected. Default Value: 128k.'
+                minLength: 1
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
+                  the source volume is required or not. The value "yes" indicates
+                  that volume should be thin provisioned and "no" means thick provisioning
+                  of the volume. If thinProvision is set to "yes" then volume can
+                  be provisioned even if the ZPOOL does not have the enough capacity.
+                  If thinProvision is set to "no" then volume can be provisioned only
+                  if the ZPOOL has enough capacity and capacity required by volume
+                  can be reserved. ThinProvision can not be modified once volume has
+                  been provisioned. Default Value: no.'
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
+                  The volsize can only be set to a multiple of volblocksize, and cannot
+                  be zero. VolBlockSize can not be edited after the volume has been
+                  provisioned. Default Value: 8k.'
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+          status:
+            properties:
+              state:
+                description: State specifies the current state of the volume provisioning
+                  request. The state "Pending" means that the volume creation request
+                  has not processed yet. The state "Ready" means that the volume has
+                  been created and it is ready for the use.
+                enum:
+                - Pending
+                - Ready
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: false
 status:
@@ -290,174 +470,348 @@ spec:
     singular: zfssnapshot
   preserveUnknownFields: false
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: ZFSSnapshot represents a ZFS Snapshot of the zfsvolume
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: VolumeInfo defines ZFS volume parameters for all modes in which
-            ZFS volumes can be created like - ZFS volume with filesystem, ZFS Volume
-            exposed as zfs or ZFS volume exposed as raw block device. Some of the
-            parameters can be only set during creation time (as specified in the details
-            of the parameter), and a few are editable. In case of Cloned volumes,
-            the parameters are assigned the same values as the source volume.
-          properties:
-            capacity:
-              description: Capacity of the volume
-              minLength: 1
-              type: string
-            compression:
-              description: 'Compression specifies the block-level compression algorithm
-                to be applied to the ZFS Volume. The value "on" indicates ZFS to use
-                the default compression algorithm. The default compression algorithm
-                used by ZFS will be either lzjb or, if the lz4_compress feature is
-                enabled, lz4. Compression property can be edited after the volume
-                has been created. The change will only be applied to the newly-written
-                data. For instance, if the Volume was created with "off" and the next
-                day the compression was modified to "on", the data written prior to
-                setting "on" will not be compressed. Default Value: off.'
-              pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
-              type: string
-            dedup:
-              description: 'Deduplication is the process for removing redundant data
-                at the block level, reducing the total amount of data stored. If a
-                file system has the dedup property enabled, duplicate data blocks
-                are removed synchronously. The result is that only unique data is
-                stored and common components are shared among files. Deduplication
-                can consume significant processing power (CPU) and memory as well
-                as generate additional disk IO. Before creating a pool with deduplication
-                enabled, ensure that you have planned your hardware requirements appropriately
-                and implemented appropriate recovery practices, such as regular backups.
-                As an alternative to deduplication consider using compression=lz4,
-                as a less resource-intensive alternative. should be enabled on the
-                zvol. Dedup property can be edited after the volume has been created.
-                Default Value: off.'
-              enum:
-              - "on"
-              - "off"
-              type: string
-            encryption:
-              description: 'Enabling the encryption feature allows for the creation
-                of encrypted filesystems and volumes. ZFS will encrypt file and zvol
-                data, file attributes, ACLs, permission bits, directory listings,
-                FUID mappings, and userused / groupused data. ZFS will not encrypt
-                metadata related to the pool structure, including dataset and snapshot
-                names, dataset hierarchy, properties, file size, file holes, and deduplication
-                tables (though the deduplicated data itself is encrypted). Default
-                Value: off.'
-              pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
-              type: string
-            fsType:
-              description: 'FsType specifies filesystem type for the zfs volume/dataset.
-                If FsType is provided as "zfs", then the driver will create a ZFS
-                dataset, formatting is not required as underlying filesystem is ZFS
-                anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver will
-                create a ZVOL and format the volume accordingly. FsType can not be
-                modified once volume has been provisioned. Default Value: ext4.'
-              type: string
-            keyformat:
-              description: KeyFormat specifies format of the encryption key The supported
-                KeyFormats are passphrase, raw, hex.
-              enum:
-              - passphrase
-              - raw
-              - hex
-              type: string
-            keylocation:
-              description: KeyLocation is the location of key for the encryption
-              type: string
-            ownerNodeID:
-              description: OwnerNodeID is the Node ID where the ZPOOL is running which
-                is where the volume has been provisioned. OwnerNodeID can not be edited
-                after the volume has been provisioned.
-              minLength: 1
-              type: string
-            poolName:
-              description: poolName specifies the name of the pool where the volume
-                has been created. PoolName can not be edited after the volume has
-                been provisioned.
-              minLength: 1
-              type: string
-            recordsize:
-              description: 'Specifies a suggested block size for files in the file
-                system. The size specified must be a power of two greater than or
-                equal to 512 and less than or equal to 128 Kbytes. RecordSize property
-                can be edited after the volume has been created. Changing the file
-                system''s recordsize affects only files created afterward; existing
-                files are unaffected. Default Value: 128k.'
-              minLength: 1
-              type: string
-            snapname:
-              description: SnapName specifies the name of the snapshot where the volume
-                has been cloned from. Snapname can not be edited after the volume
-                has been provisioned.
-              type: string
-            thinProvision:
-              description: 'ThinProvision describes whether space reservation for
-                the source volume is required or not. The value "yes" indicates that
-                volume should be thin provisioned and "no" means thick provisioning
-                of the volume. If thinProvision is set to "yes" then volume can be
-                provisioned even if the ZPOOL does not have the enough capacity. If
-                thinProvision is set to "no" then volume can be provisioned only if
-                the ZPOOL has enough capacity and capacity required by volume can
-                be reserved. ThinProvision can not be modified once volume has been
-                provisioned. Default Value: no.'
-              enum:
-              - "yes"
-              - "no"
-              type: string
-            volblocksize:
-              description: 'VolBlockSize specifies the block size for the zvol. The
-                volsize can only be set to a multiple of volblocksize, and cannot
-                be zero. VolBlockSize can not be edited after the volume has been
-                provisioned. Default Value: 8k.'
-              minLength: 1
-              type: string
-            volumeType:
-              description: volumeType determines whether the volume is of type "DATASET"
-                or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
-                of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
-                is mentioned as fstype in the storageclass, then a volume of type
-                zvol will be created, which will be further formatted as the fstype
-                provided in the storageclass. VolumeType can not be modified once
-                volume has been provisioned.
-              enum:
-              - ZVOL
-              - DATASET
-              type: string
-          required:
-          - capacity
-          - ownerNodeID
-          - poolName
-          - volumeType
-          type: object
-        status:
-          properties:
-            state:
-              type: string
-          type: object
-      required:
-      - spec
-      - status
-      type: object
   version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ZFSSnapshot represents a ZFS Snapshot of the zfsvolume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
+                  to be applied to the ZFS Volume. The value "on" indicates ZFS to
+                  use the default compression algorithm. The default compression algorithm
+                  used by ZFS will be either lzjb or, if the lz4_compress feature
+                  is enabled, lz4. Compression property can be edited after the volume
+                  has been created. The change will only be applied to the newly-written
+                  data. For instance, if the Volume was created with "off" and the
+                  next day the compression was modified to "on", the data written
+                  prior to setting "on" will not be compressed. Default Value: off.'
+                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
+                  data at the block level, reducing the total amount of data stored.
+                  If a file system has the dedup property enabled, duplicate data
+                  blocks are removed synchronously. The result is that only unique
+                  data is stored and common components are shared among files. Deduplication
+                  can consume significant processing power (CPU) and memory as well
+                  as generate additional disk IO. Before creating a pool with deduplication
+                  enabled, ensure that you have planned your hardware requirements
+                  appropriately and implemented appropriate recovery practices, such
+                  as regular backups. As an alternative to deduplication consider
+                  using compression=lz4, as a less resource-intensive alternative.
+                  should be enabled on the zvol. Dedup property can be edited after
+                  the volume has been created. Default Value: off.'
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
+                  of encrypted filesystems and volumes. ZFS will encrypt file and
+                  zvol data, file attributes, ACLs, permission bits, directory listings,
+                  FUID mappings, and userused / groupused data. ZFS will not encrypt
+                  metadata related to the pool structure, including dataset and snapshot
+                  names, dataset hierarchy, properties, file size, file holes, and
+                  deduplication tables (though the deduplicated data itself is encrypted).
+                  Default Value: off.'
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  If FsType is provided as "zfs", then the driver will create a ZFS
+                  dataset, formatting is not required as underlying filesystem is
+                  ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
+                  will create a ZVOL and format the volume accordingly. FsType can
+                  not be modified once volume has been provisioned. Default Value:
+                  ext4.'
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
+                  system. The size specified must be a power of two greater than or
+                  equal to 512 and less than or equal to 128 Kbytes. RecordSize property
+                  can be edited after the volume has been created. Changing the file
+                  system''s recordsize affects only files created afterward; existing
+                  files are unaffected. Default Value: 128k.'
+                minLength: 1
+                type: string
+              shared:
+                description: Shared specifies whether the volume can be shared among
+                  multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
+                  will not allow the volumes to be mounted by more than one pods.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
+                  the source volume is required or not. The value "yes" indicates
+                  that volume should be thin provisioned and "no" means thick provisioning
+                  of the volume. If thinProvision is set to "yes" then volume can
+                  be provisioned even if the ZPOOL does not have the enough capacity.
+                  If thinProvision is set to "no" then volume can be provisioned only
+                  if the ZPOOL has enough capacity and capacity required by volume
+                  can be reserved. ThinProvision can not be modified once volume has
+                  been provisioned. Default Value: no.'
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
+                  The volsize can only be set to a multiple of volblocksize, and cannot
+                  be zero. VolBlockSize can not be edited after the volume has been
+                  provisioned. Default Value: 8k.'
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+          status:
+            properties:
+              state:
+                type: string
+            type: object
+        required:
+        - spec
+        - status
+        type: object
     served: true
     storage: true
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ZFSSnapshot represents a ZFS Snapshot of the zfsvolume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
+                  to be applied to the ZFS Volume. The value "on" indicates ZFS to
+                  use the default compression algorithm. The default compression algorithm
+                  used by ZFS will be either lzjb or, if the lz4_compress feature
+                  is enabled, lz4. Compression property can be edited after the volume
+                  has been created. The change will only be applied to the newly-written
+                  data. For instance, if the Volume was created with "off" and the
+                  next day the compression was modified to "on", the data written
+                  prior to setting "on" will not be compressed. Default Value: off.'
+                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
+                  data at the block level, reducing the total amount of data stored.
+                  If a file system has the dedup property enabled, duplicate data
+                  blocks are removed synchronously. The result is that only unique
+                  data is stored and common components are shared among files. Deduplication
+                  can consume significant processing power (CPU) and memory as well
+                  as generate additional disk IO. Before creating a pool with deduplication
+                  enabled, ensure that you have planned your hardware requirements
+                  appropriately and implemented appropriate recovery practices, such
+                  as regular backups. As an alternative to deduplication consider
+                  using compression=lz4, as a less resource-intensive alternative.
+                  should be enabled on the zvol. Dedup property can be edited after
+                  the volume has been created. Default Value: off.'
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
+                  of encrypted filesystems and volumes. ZFS will encrypt file and
+                  zvol data, file attributes, ACLs, permission bits, directory listings,
+                  FUID mappings, and userused / groupused data. ZFS will not encrypt
+                  metadata related to the pool structure, including dataset and snapshot
+                  names, dataset hierarchy, properties, file size, file holes, and
+                  deduplication tables (though the deduplicated data itself is encrypted).
+                  Default Value: off.'
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  If FsType is provided as "zfs", then the driver will create a ZFS
+                  dataset, formatting is not required as underlying filesystem is
+                  ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
+                  will create a ZVOL and format the volume accordingly. FsType can
+                  not be modified once volume has been provisioned. Default Value:
+                  ext4.'
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
+                  system. The size specified must be a power of two greater than or
+                  equal to 512 and less than or equal to 128 Kbytes. RecordSize property
+                  can be edited after the volume has been created. Changing the file
+                  system''s recordsize affects only files created afterward; existing
+                  files are unaffected. Default Value: 128k.'
+                minLength: 1
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
+                  the source volume is required or not. The value "yes" indicates
+                  that volume should be thin provisioned and "no" means thick provisioning
+                  of the volume. If thinProvision is set to "yes" then volume can
+                  be provisioned even if the ZPOOL does not have the enough capacity.
+                  If thinProvision is set to "no" then volume can be provisioned only
+                  if the ZPOOL has enough capacity and capacity required by volume
+                  can be reserved. ThinProvision can not be modified once volume has
+                  been provisioned. Default Value: no.'
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
+                  The volsize can only be set to a multiple of volblocksize, and cannot
+                  be zero. VolBlockSize can not be edited after the volume has been
+                  provisioned. Default Value: 8k.'
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+          status:
+            properties:
+              state:
+                type: string
+            type: object
+        required:
+        - spec
+        - status
+        type: object
     served: true
     storage: false
 status:

--- a/deploy/operators/centos8/zfs-operator.yaml
+++ b/deploy/operators/centos8/zfs-operator.yaml
@@ -77,180 +77,360 @@ spec:
   preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: ZFSVolume represents a ZFS based volume
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: VolumeInfo defines ZFS volume parameters for all modes in which
-            ZFS volumes can be created like - ZFS volume with filesystem, ZFS Volume
-            exposed as zfs or ZFS volume exposed as raw block device. Some of the
-            parameters can be only set during creation time (as specified in the details
-            of the parameter), and a few are editable. In case of Cloned volumes,
-            the parameters are assigned the same values as the source volume.
-          properties:
-            capacity:
-              description: Capacity of the volume
-              minLength: 1
-              type: string
-            compression:
-              description: 'Compression specifies the block-level compression algorithm
-                to be applied to the ZFS Volume. The value "on" indicates ZFS to use
-                the default compression algorithm. The default compression algorithm
-                used by ZFS will be either lzjb or, if the lz4_compress feature is
-                enabled, lz4. Compression property can be edited after the volume
-                has been created. The change will only be applied to the newly-written
-                data. For instance, if the Volume was created with "off" and the next
-                day the compression was modified to "on", the data written prior to
-                setting "on" will not be compressed. Default Value: off.'
-              pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
-              type: string
-            dedup:
-              description: 'Deduplication is the process for removing redundant data
-                at the block level, reducing the total amount of data stored. If a
-                file system has the dedup property enabled, duplicate data blocks
-                are removed synchronously. The result is that only unique data is
-                stored and common components are shared among files. Deduplication
-                can consume significant processing power (CPU) and memory as well
-                as generate additional disk IO. Before creating a pool with deduplication
-                enabled, ensure that you have planned your hardware requirements appropriately
-                and implemented appropriate recovery practices, such as regular backups.
-                As an alternative to deduplication consider using compression=lz4,
-                as a less resource-intensive alternative. should be enabled on the
-                zvol. Dedup property can be edited after the volume has been created.
-                Default Value: off.'
-              enum:
-              - "on"
-              - "off"
-              type: string
-            encryption:
-              description: 'Enabling the encryption feature allows for the creation
-                of encrypted filesystems and volumes. ZFS will encrypt file and zvol
-                data, file attributes, ACLs, permission bits, directory listings,
-                FUID mappings, and userused / groupused data. ZFS will not encrypt
-                metadata related to the pool structure, including dataset and snapshot
-                names, dataset hierarchy, properties, file size, file holes, and deduplication
-                tables (though the deduplicated data itself is encrypted). Default
-                Value: off.'
-              pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
-              type: string
-            fsType:
-              description: 'FsType specifies filesystem type for the zfs volume/dataset.
-                If FsType is provided as "zfs", then the driver will create a ZFS
-                dataset, formatting is not required as underlying filesystem is ZFS
-                anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver will
-                create a ZVOL and format the volume accordingly. FsType can not be
-                modified once volume has been provisioned. Default Value: ext4.'
-              type: string
-            keyformat:
-              description: KeyFormat specifies format of the encryption key The supported
-                KeyFormats are passphrase, raw, hex.
-              enum:
-              - passphrase
-              - raw
-              - hex
-              type: string
-            keylocation:
-              description: KeyLocation is the location of key for the encryption
-              type: string
-            ownerNodeID:
-              description: OwnerNodeID is the Node ID where the ZPOOL is running which
-                is where the volume has been provisioned. OwnerNodeID can not be edited
-                after the volume has been provisioned.
-              minLength: 1
-              type: string
-            poolName:
-              description: poolName specifies the name of the pool where the volume
-                has been created. PoolName can not be edited after the volume has
-                been provisioned.
-              minLength: 1
-              type: string
-            recordsize:
-              description: 'Specifies a suggested block size for files in the file
-                system. The size specified must be a power of two greater than or
-                equal to 512 and less than or equal to 128 Kbytes. RecordSize property
-                can be edited after the volume has been created. Changing the file
-                system''s recordsize affects only files created afterward; existing
-                files are unaffected. Default Value: 128k.'
-              minLength: 1
-              type: string
-            snapname:
-              description: SnapName specifies the name of the snapshot where the volume
-                has been cloned from. Snapname can not be edited after the volume
-                has been provisioned.
-              type: string
-            thinProvision:
-              description: 'ThinProvision describes whether space reservation for
-                the source volume is required or not. The value "yes" indicates that
-                volume should be thin provisioned and "no" means thick provisioning
-                of the volume. If thinProvision is set to "yes" then volume can be
-                provisioned even if the ZPOOL does not have the enough capacity. If
-                thinProvision is set to "no" then volume can be provisioned only if
-                the ZPOOL has enough capacity and capacity required by volume can
-                be reserved. ThinProvision can not be modified once volume has been
-                provisioned. Default Value: no.'
-              enum:
-              - "yes"
-              - "no"
-              type: string
-            volblocksize:
-              description: 'VolBlockSize specifies the block size for the zvol. The
-                volsize can only be set to a multiple of volblocksize, and cannot
-                be zero. VolBlockSize can not be edited after the volume has been
-                provisioned. Default Value: 8k.'
-              minLength: 1
-              type: string
-            volumeType:
-              description: volumeType determines whether the volume is of type "DATASET"
-                or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
-                of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
-                is mentioned as fstype in the storageclass, then a volume of type
-                zvol will be created, which will be further formatted as the fstype
-                provided in the storageclass. VolumeType can not be modified once
-                volume has been provisioned.
-              enum:
-              - ZVOL
-              - DATASET
-              type: string
-          required:
-          - capacity
-          - ownerNodeID
-          - poolName
-          - volumeType
-          type: object
-        status:
-          properties:
-            state:
-              description: State specifies the current state of the volume provisioning
-                request. The state "Pending" means that the volume creation request
-                has not processed yet. The state "Ready" means that the volume has
-                been created and it is ready for the use.
-              enum:
-              - Pending
-              - Ready
-              type: string
-          type: object
-      required:
-      - spec
-      type: object
   version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ZFSVolume represents a ZFS based volume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
+                  to be applied to the ZFS Volume. The value "on" indicates ZFS to
+                  use the default compression algorithm. The default compression algorithm
+                  used by ZFS will be either lzjb or, if the lz4_compress feature
+                  is enabled, lz4. Compression property can be edited after the volume
+                  has been created. The change will only be applied to the newly-written
+                  data. For instance, if the Volume was created with "off" and the
+                  next day the compression was modified to "on", the data written
+                  prior to setting "on" will not be compressed. Default Value: off.'
+                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
+                  data at the block level, reducing the total amount of data stored.
+                  If a file system has the dedup property enabled, duplicate data
+                  blocks are removed synchronously. The result is that only unique
+                  data is stored and common components are shared among files. Deduplication
+                  can consume significant processing power (CPU) and memory as well
+                  as generate additional disk IO. Before creating a pool with deduplication
+                  enabled, ensure that you have planned your hardware requirements
+                  appropriately and implemented appropriate recovery practices, such
+                  as regular backups. As an alternative to deduplication consider
+                  using compression=lz4, as a less resource-intensive alternative.
+                  should be enabled on the zvol. Dedup property can be edited after
+                  the volume has been created. Default Value: off.'
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
+                  of encrypted filesystems and volumes. ZFS will encrypt file and
+                  zvol data, file attributes, ACLs, permission bits, directory listings,
+                  FUID mappings, and userused / groupused data. ZFS will not encrypt
+                  metadata related to the pool structure, including dataset and snapshot
+                  names, dataset hierarchy, properties, file size, file holes, and
+                  deduplication tables (though the deduplicated data itself is encrypted).
+                  Default Value: off.'
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  If FsType is provided as "zfs", then the driver will create a ZFS
+                  dataset, formatting is not required as underlying filesystem is
+                  ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
+                  will create a ZVOL and format the volume accordingly. FsType can
+                  not be modified once volume has been provisioned. Default Value:
+                  ext4.'
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
+                  system. The size specified must be a power of two greater than or
+                  equal to 512 and less than or equal to 128 Kbytes. RecordSize property
+                  can be edited after the volume has been created. Changing the file
+                  system''s recordsize affects only files created afterward; existing
+                  files are unaffected. Default Value: 128k.'
+                minLength: 1
+                type: string
+              shared:
+                description: Shared specifies whether the volume can be shared among
+                  multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
+                  will not allow the volumes to be mounted by more than one pods.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
+                  the source volume is required or not. The value "yes" indicates
+                  that volume should be thin provisioned and "no" means thick provisioning
+                  of the volume. If thinProvision is set to "yes" then volume can
+                  be provisioned even if the ZPOOL does not have the enough capacity.
+                  If thinProvision is set to "no" then volume can be provisioned only
+                  if the ZPOOL has enough capacity and capacity required by volume
+                  can be reserved. ThinProvision can not be modified once volume has
+                  been provisioned. Default Value: no.'
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
+                  The volsize can only be set to a multiple of volblocksize, and cannot
+                  be zero. VolBlockSize can not be edited after the volume has been
+                  provisioned. Default Value: 8k.'
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+          status:
+            properties:
+              state:
+                description: State specifies the current state of the volume provisioning
+                  request. The state "Pending" means that the volume creation request
+                  has not processed yet. The state "Ready" means that the volume has
+                  been created and it is ready for the use.
+                enum:
+                - Pending
+                - Ready
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ZFSVolume represents a ZFS based volume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
+                  to be applied to the ZFS Volume. The value "on" indicates ZFS to
+                  use the default compression algorithm. The default compression algorithm
+                  used by ZFS will be either lzjb or, if the lz4_compress feature
+                  is enabled, lz4. Compression property can be edited after the volume
+                  has been created. The change will only be applied to the newly-written
+                  data. For instance, if the Volume was created with "off" and the
+                  next day the compression was modified to "on", the data written
+                  prior to setting "on" will not be compressed. Default Value: off.'
+                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
+                  data at the block level, reducing the total amount of data stored.
+                  If a file system has the dedup property enabled, duplicate data
+                  blocks are removed synchronously. The result is that only unique
+                  data is stored and common components are shared among files. Deduplication
+                  can consume significant processing power (CPU) and memory as well
+                  as generate additional disk IO. Before creating a pool with deduplication
+                  enabled, ensure that you have planned your hardware requirements
+                  appropriately and implemented appropriate recovery practices, such
+                  as regular backups. As an alternative to deduplication consider
+                  using compression=lz4, as a less resource-intensive alternative.
+                  should be enabled on the zvol. Dedup property can be edited after
+                  the volume has been created. Default Value: off.'
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
+                  of encrypted filesystems and volumes. ZFS will encrypt file and
+                  zvol data, file attributes, ACLs, permission bits, directory listings,
+                  FUID mappings, and userused / groupused data. ZFS will not encrypt
+                  metadata related to the pool structure, including dataset and snapshot
+                  names, dataset hierarchy, properties, file size, file holes, and
+                  deduplication tables (though the deduplicated data itself is encrypted).
+                  Default Value: off.'
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  If FsType is provided as "zfs", then the driver will create a ZFS
+                  dataset, formatting is not required as underlying filesystem is
+                  ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
+                  will create a ZVOL and format the volume accordingly. FsType can
+                  not be modified once volume has been provisioned. Default Value:
+                  ext4.'
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
+                  system. The size specified must be a power of two greater than or
+                  equal to 512 and less than or equal to 128 Kbytes. RecordSize property
+                  can be edited after the volume has been created. Changing the file
+                  system''s recordsize affects only files created afterward; existing
+                  files are unaffected. Default Value: 128k.'
+                minLength: 1
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
+                  the source volume is required or not. The value "yes" indicates
+                  that volume should be thin provisioned and "no" means thick provisioning
+                  of the volume. If thinProvision is set to "yes" then volume can
+                  be provisioned even if the ZPOOL does not have the enough capacity.
+                  If thinProvision is set to "no" then volume can be provisioned only
+                  if the ZPOOL has enough capacity and capacity required by volume
+                  can be reserved. ThinProvision can not be modified once volume has
+                  been provisioned. Default Value: no.'
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
+                  The volsize can only be set to a multiple of volblocksize, and cannot
+                  be zero. VolBlockSize can not be edited after the volume has been
+                  provisioned. Default Value: 8k.'
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+          status:
+            properties:
+              state:
+                description: State specifies the current state of the volume provisioning
+                  request. The state "Pending" means that the volume creation request
+                  has not processed yet. The state "Ready" means that the volume has
+                  been created and it is ready for the use.
+                enum:
+                - Pending
+                - Ready
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: false
 status:
@@ -290,174 +470,348 @@ spec:
     singular: zfssnapshot
   preserveUnknownFields: false
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: ZFSSnapshot represents a ZFS Snapshot of the zfsvolume
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: VolumeInfo defines ZFS volume parameters for all modes in which
-            ZFS volumes can be created like - ZFS volume with filesystem, ZFS Volume
-            exposed as zfs or ZFS volume exposed as raw block device. Some of the
-            parameters can be only set during creation time (as specified in the details
-            of the parameter), and a few are editable. In case of Cloned volumes,
-            the parameters are assigned the same values as the source volume.
-          properties:
-            capacity:
-              description: Capacity of the volume
-              minLength: 1
-              type: string
-            compression:
-              description: 'Compression specifies the block-level compression algorithm
-                to be applied to the ZFS Volume. The value "on" indicates ZFS to use
-                the default compression algorithm. The default compression algorithm
-                used by ZFS will be either lzjb or, if the lz4_compress feature is
-                enabled, lz4. Compression property can be edited after the volume
-                has been created. The change will only be applied to the newly-written
-                data. For instance, if the Volume was created with "off" and the next
-                day the compression was modified to "on", the data written prior to
-                setting "on" will not be compressed. Default Value: off.'
-              pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
-              type: string
-            dedup:
-              description: 'Deduplication is the process for removing redundant data
-                at the block level, reducing the total amount of data stored. If a
-                file system has the dedup property enabled, duplicate data blocks
-                are removed synchronously. The result is that only unique data is
-                stored and common components are shared among files. Deduplication
-                can consume significant processing power (CPU) and memory as well
-                as generate additional disk IO. Before creating a pool with deduplication
-                enabled, ensure that you have planned your hardware requirements appropriately
-                and implemented appropriate recovery practices, such as regular backups.
-                As an alternative to deduplication consider using compression=lz4,
-                as a less resource-intensive alternative. should be enabled on the
-                zvol. Dedup property can be edited after the volume has been created.
-                Default Value: off.'
-              enum:
-              - "on"
-              - "off"
-              type: string
-            encryption:
-              description: 'Enabling the encryption feature allows for the creation
-                of encrypted filesystems and volumes. ZFS will encrypt file and zvol
-                data, file attributes, ACLs, permission bits, directory listings,
-                FUID mappings, and userused / groupused data. ZFS will not encrypt
-                metadata related to the pool structure, including dataset and snapshot
-                names, dataset hierarchy, properties, file size, file holes, and deduplication
-                tables (though the deduplicated data itself is encrypted). Default
-                Value: off.'
-              pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
-              type: string
-            fsType:
-              description: 'FsType specifies filesystem type for the zfs volume/dataset.
-                If FsType is provided as "zfs", then the driver will create a ZFS
-                dataset, formatting is not required as underlying filesystem is ZFS
-                anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver will
-                create a ZVOL and format the volume accordingly. FsType can not be
-                modified once volume has been provisioned. Default Value: ext4.'
-              type: string
-            keyformat:
-              description: KeyFormat specifies format of the encryption key The supported
-                KeyFormats are passphrase, raw, hex.
-              enum:
-              - passphrase
-              - raw
-              - hex
-              type: string
-            keylocation:
-              description: KeyLocation is the location of key for the encryption
-              type: string
-            ownerNodeID:
-              description: OwnerNodeID is the Node ID where the ZPOOL is running which
-                is where the volume has been provisioned. OwnerNodeID can not be edited
-                after the volume has been provisioned.
-              minLength: 1
-              type: string
-            poolName:
-              description: poolName specifies the name of the pool where the volume
-                has been created. PoolName can not be edited after the volume has
-                been provisioned.
-              minLength: 1
-              type: string
-            recordsize:
-              description: 'Specifies a suggested block size for files in the file
-                system. The size specified must be a power of two greater than or
-                equal to 512 and less than or equal to 128 Kbytes. RecordSize property
-                can be edited after the volume has been created. Changing the file
-                system''s recordsize affects only files created afterward; existing
-                files are unaffected. Default Value: 128k.'
-              minLength: 1
-              type: string
-            snapname:
-              description: SnapName specifies the name of the snapshot where the volume
-                has been cloned from. Snapname can not be edited after the volume
-                has been provisioned.
-              type: string
-            thinProvision:
-              description: 'ThinProvision describes whether space reservation for
-                the source volume is required or not. The value "yes" indicates that
-                volume should be thin provisioned and "no" means thick provisioning
-                of the volume. If thinProvision is set to "yes" then volume can be
-                provisioned even if the ZPOOL does not have the enough capacity. If
-                thinProvision is set to "no" then volume can be provisioned only if
-                the ZPOOL has enough capacity and capacity required by volume can
-                be reserved. ThinProvision can not be modified once volume has been
-                provisioned. Default Value: no.'
-              enum:
-              - "yes"
-              - "no"
-              type: string
-            volblocksize:
-              description: 'VolBlockSize specifies the block size for the zvol. The
-                volsize can only be set to a multiple of volblocksize, and cannot
-                be zero. VolBlockSize can not be edited after the volume has been
-                provisioned. Default Value: 8k.'
-              minLength: 1
-              type: string
-            volumeType:
-              description: volumeType determines whether the volume is of type "DATASET"
-                or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
-                of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
-                is mentioned as fstype in the storageclass, then a volume of type
-                zvol will be created, which will be further formatted as the fstype
-                provided in the storageclass. VolumeType can not be modified once
-                volume has been provisioned.
-              enum:
-              - ZVOL
-              - DATASET
-              type: string
-          required:
-          - capacity
-          - ownerNodeID
-          - poolName
-          - volumeType
-          type: object
-        status:
-          properties:
-            state:
-              type: string
-          type: object
-      required:
-      - spec
-      - status
-      type: object
   version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ZFSSnapshot represents a ZFS Snapshot of the zfsvolume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
+                  to be applied to the ZFS Volume. The value "on" indicates ZFS to
+                  use the default compression algorithm. The default compression algorithm
+                  used by ZFS will be either lzjb or, if the lz4_compress feature
+                  is enabled, lz4. Compression property can be edited after the volume
+                  has been created. The change will only be applied to the newly-written
+                  data. For instance, if the Volume was created with "off" and the
+                  next day the compression was modified to "on", the data written
+                  prior to setting "on" will not be compressed. Default Value: off.'
+                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
+                  data at the block level, reducing the total amount of data stored.
+                  If a file system has the dedup property enabled, duplicate data
+                  blocks are removed synchronously. The result is that only unique
+                  data is stored and common components are shared among files. Deduplication
+                  can consume significant processing power (CPU) and memory as well
+                  as generate additional disk IO. Before creating a pool with deduplication
+                  enabled, ensure that you have planned your hardware requirements
+                  appropriately and implemented appropriate recovery practices, such
+                  as regular backups. As an alternative to deduplication consider
+                  using compression=lz4, as a less resource-intensive alternative.
+                  should be enabled on the zvol. Dedup property can be edited after
+                  the volume has been created. Default Value: off.'
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
+                  of encrypted filesystems and volumes. ZFS will encrypt file and
+                  zvol data, file attributes, ACLs, permission bits, directory listings,
+                  FUID mappings, and userused / groupused data. ZFS will not encrypt
+                  metadata related to the pool structure, including dataset and snapshot
+                  names, dataset hierarchy, properties, file size, file holes, and
+                  deduplication tables (though the deduplicated data itself is encrypted).
+                  Default Value: off.'
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  If FsType is provided as "zfs", then the driver will create a ZFS
+                  dataset, formatting is not required as underlying filesystem is
+                  ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
+                  will create a ZVOL and format the volume accordingly. FsType can
+                  not be modified once volume has been provisioned. Default Value:
+                  ext4.'
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
+                  system. The size specified must be a power of two greater than or
+                  equal to 512 and less than or equal to 128 Kbytes. RecordSize property
+                  can be edited after the volume has been created. Changing the file
+                  system''s recordsize affects only files created afterward; existing
+                  files are unaffected. Default Value: 128k.'
+                minLength: 1
+                type: string
+              shared:
+                description: Shared specifies whether the volume can be shared among
+                  multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
+                  will not allow the volumes to be mounted by more than one pods.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
+                  the source volume is required or not. The value "yes" indicates
+                  that volume should be thin provisioned and "no" means thick provisioning
+                  of the volume. If thinProvision is set to "yes" then volume can
+                  be provisioned even if the ZPOOL does not have the enough capacity.
+                  If thinProvision is set to "no" then volume can be provisioned only
+                  if the ZPOOL has enough capacity and capacity required by volume
+                  can be reserved. ThinProvision can not be modified once volume has
+                  been provisioned. Default Value: no.'
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
+                  The volsize can only be set to a multiple of volblocksize, and cannot
+                  be zero. VolBlockSize can not be edited after the volume has been
+                  provisioned. Default Value: 8k.'
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+          status:
+            properties:
+              state:
+                type: string
+            type: object
+        required:
+        - spec
+        - status
+        type: object
     served: true
     storage: true
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ZFSSnapshot represents a ZFS Snapshot of the zfsvolume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
+                  to be applied to the ZFS Volume. The value "on" indicates ZFS to
+                  use the default compression algorithm. The default compression algorithm
+                  used by ZFS will be either lzjb or, if the lz4_compress feature
+                  is enabled, lz4. Compression property can be edited after the volume
+                  has been created. The change will only be applied to the newly-written
+                  data. For instance, if the Volume was created with "off" and the
+                  next day the compression was modified to "on", the data written
+                  prior to setting "on" will not be compressed. Default Value: off.'
+                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
+                  data at the block level, reducing the total amount of data stored.
+                  If a file system has the dedup property enabled, duplicate data
+                  blocks are removed synchronously. The result is that only unique
+                  data is stored and common components are shared among files. Deduplication
+                  can consume significant processing power (CPU) and memory as well
+                  as generate additional disk IO. Before creating a pool with deduplication
+                  enabled, ensure that you have planned your hardware requirements
+                  appropriately and implemented appropriate recovery practices, such
+                  as regular backups. As an alternative to deduplication consider
+                  using compression=lz4, as a less resource-intensive alternative.
+                  should be enabled on the zvol. Dedup property can be edited after
+                  the volume has been created. Default Value: off.'
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
+                  of encrypted filesystems and volumes. ZFS will encrypt file and
+                  zvol data, file attributes, ACLs, permission bits, directory listings,
+                  FUID mappings, and userused / groupused data. ZFS will not encrypt
+                  metadata related to the pool structure, including dataset and snapshot
+                  names, dataset hierarchy, properties, file size, file holes, and
+                  deduplication tables (though the deduplicated data itself is encrypted).
+                  Default Value: off.'
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  If FsType is provided as "zfs", then the driver will create a ZFS
+                  dataset, formatting is not required as underlying filesystem is
+                  ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
+                  will create a ZVOL and format the volume accordingly. FsType can
+                  not be modified once volume has been provisioned. Default Value:
+                  ext4.'
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
+                  system. The size specified must be a power of two greater than or
+                  equal to 512 and less than or equal to 128 Kbytes. RecordSize property
+                  can be edited after the volume has been created. Changing the file
+                  system''s recordsize affects only files created afterward; existing
+                  files are unaffected. Default Value: 128k.'
+                minLength: 1
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
+                  the source volume is required or not. The value "yes" indicates
+                  that volume should be thin provisioned and "no" means thick provisioning
+                  of the volume. If thinProvision is set to "yes" then volume can
+                  be provisioned even if the ZPOOL does not have the enough capacity.
+                  If thinProvision is set to "no" then volume can be provisioned only
+                  if the ZPOOL has enough capacity and capacity required by volume
+                  can be reserved. ThinProvision can not be modified once volume has
+                  been provisioned. Default Value: no.'
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
+                  The volsize can only be set to a multiple of volblocksize, and cannot
+                  be zero. VolBlockSize can not be edited after the volume has been
+                  provisioned. Default Value: 8k.'
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+          status:
+            properties:
+              state:
+                type: string
+            type: object
+        required:
+        - spec
+        - status
+        type: object
     served: true
     storage: false
 status:

--- a/deploy/yamls/zfssnapshot-crd.yaml
+++ b/deploy/yamls/zfssnapshot-crd.yaml
@@ -29,174 +29,348 @@ spec:
     singular: zfssnapshot
   preserveUnknownFields: false
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: ZFSSnapshot represents a ZFS Snapshot of the zfsvolume
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: VolumeInfo defines ZFS volume parameters for all modes in which
-            ZFS volumes can be created like - ZFS volume with filesystem, ZFS Volume
-            exposed as zfs or ZFS volume exposed as raw block device. Some of the
-            parameters can be only set during creation time (as specified in the details
-            of the parameter), and a few are editable. In case of Cloned volumes,
-            the parameters are assigned the same values as the source volume.
-          properties:
-            capacity:
-              description: Capacity of the volume
-              minLength: 1
-              type: string
-            compression:
-              description: 'Compression specifies the block-level compression algorithm
-                to be applied to the ZFS Volume. The value "on" indicates ZFS to use
-                the default compression algorithm. The default compression algorithm
-                used by ZFS will be either lzjb or, if the lz4_compress feature is
-                enabled, lz4. Compression property can be edited after the volume
-                has been created. The change will only be applied to the newly-written
-                data. For instance, if the Volume was created with "off" and the next
-                day the compression was modified to "on", the data written prior to
-                setting "on" will not be compressed. Default Value: off.'
-              pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
-              type: string
-            dedup:
-              description: 'Deduplication is the process for removing redundant data
-                at the block level, reducing the total amount of data stored. If a
-                file system has the dedup property enabled, duplicate data blocks
-                are removed synchronously. The result is that only unique data is
-                stored and common components are shared among files. Deduplication
-                can consume significant processing power (CPU) and memory as well
-                as generate additional disk IO. Before creating a pool with deduplication
-                enabled, ensure that you have planned your hardware requirements appropriately
-                and implemented appropriate recovery practices, such as regular backups.
-                As an alternative to deduplication consider using compression=lz4,
-                as a less resource-intensive alternative. should be enabled on the
-                zvol. Dedup property can be edited after the volume has been created.
-                Default Value: off.'
-              enum:
-              - "on"
-              - "off"
-              type: string
-            encryption:
-              description: 'Enabling the encryption feature allows for the creation
-                of encrypted filesystems and volumes. ZFS will encrypt file and zvol
-                data, file attributes, ACLs, permission bits, directory listings,
-                FUID mappings, and userused / groupused data. ZFS will not encrypt
-                metadata related to the pool structure, including dataset and snapshot
-                names, dataset hierarchy, properties, file size, file holes, and deduplication
-                tables (though the deduplicated data itself is encrypted). Default
-                Value: off.'
-              pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
-              type: string
-            fsType:
-              description: 'FsType specifies filesystem type for the zfs volume/dataset.
-                If FsType is provided as "zfs", then the driver will create a ZFS
-                dataset, formatting is not required as underlying filesystem is ZFS
-                anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver will
-                create a ZVOL and format the volume accordingly. FsType can not be
-                modified once volume has been provisioned. Default Value: ext4.'
-              type: string
-            keyformat:
-              description: KeyFormat specifies format of the encryption key The supported
-                KeyFormats are passphrase, raw, hex.
-              enum:
-              - passphrase
-              - raw
-              - hex
-              type: string
-            keylocation:
-              description: KeyLocation is the location of key for the encryption
-              type: string
-            ownerNodeID:
-              description: OwnerNodeID is the Node ID where the ZPOOL is running which
-                is where the volume has been provisioned. OwnerNodeID can not be edited
-                after the volume has been provisioned.
-              minLength: 1
-              type: string
-            poolName:
-              description: poolName specifies the name of the pool where the volume
-                has been created. PoolName can not be edited after the volume has
-                been provisioned.
-              minLength: 1
-              type: string
-            recordsize:
-              description: 'Specifies a suggested block size for files in the file
-                system. The size specified must be a power of two greater than or
-                equal to 512 and less than or equal to 128 Kbytes. RecordSize property
-                can be edited after the volume has been created. Changing the file
-                system''s recordsize affects only files created afterward; existing
-                files are unaffected. Default Value: 128k.'
-              minLength: 1
-              type: string
-            snapname:
-              description: SnapName specifies the name of the snapshot where the volume
-                has been cloned from. Snapname can not be edited after the volume
-                has been provisioned.
-              type: string
-            thinProvision:
-              description: 'ThinProvision describes whether space reservation for
-                the source volume is required or not. The value "yes" indicates that
-                volume should be thin provisioned and "no" means thick provisioning
-                of the volume. If thinProvision is set to "yes" then volume can be
-                provisioned even if the ZPOOL does not have the enough capacity. If
-                thinProvision is set to "no" then volume can be provisioned only if
-                the ZPOOL has enough capacity and capacity required by volume can
-                be reserved. ThinProvision can not be modified once volume has been
-                provisioned. Default Value: no.'
-              enum:
-              - "yes"
-              - "no"
-              type: string
-            volblocksize:
-              description: 'VolBlockSize specifies the block size for the zvol. The
-                volsize can only be set to a multiple of volblocksize, and cannot
-                be zero. VolBlockSize can not be edited after the volume has been
-                provisioned. Default Value: 8k.'
-              minLength: 1
-              type: string
-            volumeType:
-              description: volumeType determines whether the volume is of type "DATASET"
-                or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
-                of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
-                is mentioned as fstype in the storageclass, then a volume of type
-                zvol will be created, which will be further formatted as the fstype
-                provided in the storageclass. VolumeType can not be modified once
-                volume has been provisioned.
-              enum:
-              - ZVOL
-              - DATASET
-              type: string
-          required:
-          - capacity
-          - ownerNodeID
-          - poolName
-          - volumeType
-          type: object
-        status:
-          properties:
-            state:
-              type: string
-          type: object
-      required:
-      - spec
-      - status
-      type: object
   version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ZFSSnapshot represents a ZFS Snapshot of the zfsvolume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
+                  to be applied to the ZFS Volume. The value "on" indicates ZFS to
+                  use the default compression algorithm. The default compression algorithm
+                  used by ZFS will be either lzjb or, if the lz4_compress feature
+                  is enabled, lz4. Compression property can be edited after the volume
+                  has been created. The change will only be applied to the newly-written
+                  data. For instance, if the Volume was created with "off" and the
+                  next day the compression was modified to "on", the data written
+                  prior to setting "on" will not be compressed. Default Value: off.'
+                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
+                  data at the block level, reducing the total amount of data stored.
+                  If a file system has the dedup property enabled, duplicate data
+                  blocks are removed synchronously. The result is that only unique
+                  data is stored and common components are shared among files. Deduplication
+                  can consume significant processing power (CPU) and memory as well
+                  as generate additional disk IO. Before creating a pool with deduplication
+                  enabled, ensure that you have planned your hardware requirements
+                  appropriately and implemented appropriate recovery practices, such
+                  as regular backups. As an alternative to deduplication consider
+                  using compression=lz4, as a less resource-intensive alternative.
+                  should be enabled on the zvol. Dedup property can be edited after
+                  the volume has been created. Default Value: off.'
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
+                  of encrypted filesystems and volumes. ZFS will encrypt file and
+                  zvol data, file attributes, ACLs, permission bits, directory listings,
+                  FUID mappings, and userused / groupused data. ZFS will not encrypt
+                  metadata related to the pool structure, including dataset and snapshot
+                  names, dataset hierarchy, properties, file size, file holes, and
+                  deduplication tables (though the deduplicated data itself is encrypted).
+                  Default Value: off.'
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  If FsType is provided as "zfs", then the driver will create a ZFS
+                  dataset, formatting is not required as underlying filesystem is
+                  ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
+                  will create a ZVOL and format the volume accordingly. FsType can
+                  not be modified once volume has been provisioned. Default Value:
+                  ext4.'
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
+                  system. The size specified must be a power of two greater than or
+                  equal to 512 and less than or equal to 128 Kbytes. RecordSize property
+                  can be edited after the volume has been created. Changing the file
+                  system''s recordsize affects only files created afterward; existing
+                  files are unaffected. Default Value: 128k.'
+                minLength: 1
+                type: string
+              shared:
+                description: Shared specifies whether the volume can be shared among
+                  multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
+                  will not allow the volumes to be mounted by more than one pods.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
+                  the source volume is required or not. The value "yes" indicates
+                  that volume should be thin provisioned and "no" means thick provisioning
+                  of the volume. If thinProvision is set to "yes" then volume can
+                  be provisioned even if the ZPOOL does not have the enough capacity.
+                  If thinProvision is set to "no" then volume can be provisioned only
+                  if the ZPOOL has enough capacity and capacity required by volume
+                  can be reserved. ThinProvision can not be modified once volume has
+                  been provisioned. Default Value: no.'
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
+                  The volsize can only be set to a multiple of volblocksize, and cannot
+                  be zero. VolBlockSize can not be edited after the volume has been
+                  provisioned. Default Value: 8k.'
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+          status:
+            properties:
+              state:
+                type: string
+            type: object
+        required:
+        - spec
+        - status
+        type: object
     served: true
     storage: true
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ZFSSnapshot represents a ZFS Snapshot of the zfsvolume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
+                  to be applied to the ZFS Volume. The value "on" indicates ZFS to
+                  use the default compression algorithm. The default compression algorithm
+                  used by ZFS will be either lzjb or, if the lz4_compress feature
+                  is enabled, lz4. Compression property can be edited after the volume
+                  has been created. The change will only be applied to the newly-written
+                  data. For instance, if the Volume was created with "off" and the
+                  next day the compression was modified to "on", the data written
+                  prior to setting "on" will not be compressed. Default Value: off.'
+                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
+                  data at the block level, reducing the total amount of data stored.
+                  If a file system has the dedup property enabled, duplicate data
+                  blocks are removed synchronously. The result is that only unique
+                  data is stored and common components are shared among files. Deduplication
+                  can consume significant processing power (CPU) and memory as well
+                  as generate additional disk IO. Before creating a pool with deduplication
+                  enabled, ensure that you have planned your hardware requirements
+                  appropriately and implemented appropriate recovery practices, such
+                  as regular backups. As an alternative to deduplication consider
+                  using compression=lz4, as a less resource-intensive alternative.
+                  should be enabled on the zvol. Dedup property can be edited after
+                  the volume has been created. Default Value: off.'
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
+                  of encrypted filesystems and volumes. ZFS will encrypt file and
+                  zvol data, file attributes, ACLs, permission bits, directory listings,
+                  FUID mappings, and userused / groupused data. ZFS will not encrypt
+                  metadata related to the pool structure, including dataset and snapshot
+                  names, dataset hierarchy, properties, file size, file holes, and
+                  deduplication tables (though the deduplicated data itself is encrypted).
+                  Default Value: off.'
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  If FsType is provided as "zfs", then the driver will create a ZFS
+                  dataset, formatting is not required as underlying filesystem is
+                  ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
+                  will create a ZVOL and format the volume accordingly. FsType can
+                  not be modified once volume has been provisioned. Default Value:
+                  ext4.'
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
+                  system. The size specified must be a power of two greater than or
+                  equal to 512 and less than or equal to 128 Kbytes. RecordSize property
+                  can be edited after the volume has been created. Changing the file
+                  system''s recordsize affects only files created afterward; existing
+                  files are unaffected. Default Value: 128k.'
+                minLength: 1
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
+                  the source volume is required or not. The value "yes" indicates
+                  that volume should be thin provisioned and "no" means thick provisioning
+                  of the volume. If thinProvision is set to "yes" then volume can
+                  be provisioned even if the ZPOOL does not have the enough capacity.
+                  If thinProvision is set to "no" then volume can be provisioned only
+                  if the ZPOOL has enough capacity and capacity required by volume
+                  can be reserved. ThinProvision can not be modified once volume has
+                  been provisioned. Default Value: no.'
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
+                  The volsize can only be set to a multiple of volblocksize, and cannot
+                  be zero. VolBlockSize can not be edited after the volume has been
+                  provisioned. Default Value: 8k.'
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+          status:
+            properties:
+              state:
+                type: string
+            type: object
+        required:
+        - spec
+        - status
+        type: object
     served: true
     storage: false
 status:

--- a/deploy/yamls/zfsvolume-crd.yaml
+++ b/deploy/yamls/zfsvolume-crd.yaml
@@ -56,180 +56,360 @@ spec:
   preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: ZFSVolume represents a ZFS based volume
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: VolumeInfo defines ZFS volume parameters for all modes in which
-            ZFS volumes can be created like - ZFS volume with filesystem, ZFS Volume
-            exposed as zfs or ZFS volume exposed as raw block device. Some of the
-            parameters can be only set during creation time (as specified in the details
-            of the parameter), and a few are editable. In case of Cloned volumes,
-            the parameters are assigned the same values as the source volume.
-          properties:
-            capacity:
-              description: Capacity of the volume
-              minLength: 1
-              type: string
-            compression:
-              description: 'Compression specifies the block-level compression algorithm
-                to be applied to the ZFS Volume. The value "on" indicates ZFS to use
-                the default compression algorithm. The default compression algorithm
-                used by ZFS will be either lzjb or, if the lz4_compress feature is
-                enabled, lz4. Compression property can be edited after the volume
-                has been created. The change will only be applied to the newly-written
-                data. For instance, if the Volume was created with "off" and the next
-                day the compression was modified to "on", the data written prior to
-                setting "on" will not be compressed. Default Value: off.'
-              pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
-              type: string
-            dedup:
-              description: 'Deduplication is the process for removing redundant data
-                at the block level, reducing the total amount of data stored. If a
-                file system has the dedup property enabled, duplicate data blocks
-                are removed synchronously. The result is that only unique data is
-                stored and common components are shared among files. Deduplication
-                can consume significant processing power (CPU) and memory as well
-                as generate additional disk IO. Before creating a pool with deduplication
-                enabled, ensure that you have planned your hardware requirements appropriately
-                and implemented appropriate recovery practices, such as regular backups.
-                As an alternative to deduplication consider using compression=lz4,
-                as a less resource-intensive alternative. should be enabled on the
-                zvol. Dedup property can be edited after the volume has been created.
-                Default Value: off.'
-              enum:
-              - "on"
-              - "off"
-              type: string
-            encryption:
-              description: 'Enabling the encryption feature allows for the creation
-                of encrypted filesystems and volumes. ZFS will encrypt file and zvol
-                data, file attributes, ACLs, permission bits, directory listings,
-                FUID mappings, and userused / groupused data. ZFS will not encrypt
-                metadata related to the pool structure, including dataset and snapshot
-                names, dataset hierarchy, properties, file size, file holes, and deduplication
-                tables (though the deduplicated data itself is encrypted). Default
-                Value: off.'
-              pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
-              type: string
-            fsType:
-              description: 'FsType specifies filesystem type for the zfs volume/dataset.
-                If FsType is provided as "zfs", then the driver will create a ZFS
-                dataset, formatting is not required as underlying filesystem is ZFS
-                anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver will
-                create a ZVOL and format the volume accordingly. FsType can not be
-                modified once volume has been provisioned. Default Value: ext4.'
-              type: string
-            keyformat:
-              description: KeyFormat specifies format of the encryption key The supported
-                KeyFormats are passphrase, raw, hex.
-              enum:
-              - passphrase
-              - raw
-              - hex
-              type: string
-            keylocation:
-              description: KeyLocation is the location of key for the encryption
-              type: string
-            ownerNodeID:
-              description: OwnerNodeID is the Node ID where the ZPOOL is running which
-                is where the volume has been provisioned. OwnerNodeID can not be edited
-                after the volume has been provisioned.
-              minLength: 1
-              type: string
-            poolName:
-              description: poolName specifies the name of the pool where the volume
-                has been created. PoolName can not be edited after the volume has
-                been provisioned.
-              minLength: 1
-              type: string
-            recordsize:
-              description: 'Specifies a suggested block size for files in the file
-                system. The size specified must be a power of two greater than or
-                equal to 512 and less than or equal to 128 Kbytes. RecordSize property
-                can be edited after the volume has been created. Changing the file
-                system''s recordsize affects only files created afterward; existing
-                files are unaffected. Default Value: 128k.'
-              minLength: 1
-              type: string
-            snapname:
-              description: SnapName specifies the name of the snapshot where the volume
-                has been cloned from. Snapname can not be edited after the volume
-                has been provisioned.
-              type: string
-            thinProvision:
-              description: 'ThinProvision describes whether space reservation for
-                the source volume is required or not. The value "yes" indicates that
-                volume should be thin provisioned and "no" means thick provisioning
-                of the volume. If thinProvision is set to "yes" then volume can be
-                provisioned even if the ZPOOL does not have the enough capacity. If
-                thinProvision is set to "no" then volume can be provisioned only if
-                the ZPOOL has enough capacity and capacity required by volume can
-                be reserved. ThinProvision can not be modified once volume has been
-                provisioned. Default Value: no.'
-              enum:
-              - "yes"
-              - "no"
-              type: string
-            volblocksize:
-              description: 'VolBlockSize specifies the block size for the zvol. The
-                volsize can only be set to a multiple of volblocksize, and cannot
-                be zero. VolBlockSize can not be edited after the volume has been
-                provisioned. Default Value: 8k.'
-              minLength: 1
-              type: string
-            volumeType:
-              description: volumeType determines whether the volume is of type "DATASET"
-                or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
-                of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
-                is mentioned as fstype in the storageclass, then a volume of type
-                zvol will be created, which will be further formatted as the fstype
-                provided in the storageclass. VolumeType can not be modified once
-                volume has been provisioned.
-              enum:
-              - ZVOL
-              - DATASET
-              type: string
-          required:
-          - capacity
-          - ownerNodeID
-          - poolName
-          - volumeType
-          type: object
-        status:
-          properties:
-            state:
-              description: State specifies the current state of the volume provisioning
-                request. The state "Pending" means that the volume creation request
-                has not processed yet. The state "Ready" means that the volume has
-                been created and it is ready for the use.
-              enum:
-              - Pending
-              - Ready
-              type: string
-          type: object
-      required:
-      - spec
-      type: object
   version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ZFSVolume represents a ZFS based volume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
+                  to be applied to the ZFS Volume. The value "on" indicates ZFS to
+                  use the default compression algorithm. The default compression algorithm
+                  used by ZFS will be either lzjb or, if the lz4_compress feature
+                  is enabled, lz4. Compression property can be edited after the volume
+                  has been created. The change will only be applied to the newly-written
+                  data. For instance, if the Volume was created with "off" and the
+                  next day the compression was modified to "on", the data written
+                  prior to setting "on" will not be compressed. Default Value: off.'
+                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
+                  data at the block level, reducing the total amount of data stored.
+                  If a file system has the dedup property enabled, duplicate data
+                  blocks are removed synchronously. The result is that only unique
+                  data is stored and common components are shared among files. Deduplication
+                  can consume significant processing power (CPU) and memory as well
+                  as generate additional disk IO. Before creating a pool with deduplication
+                  enabled, ensure that you have planned your hardware requirements
+                  appropriately and implemented appropriate recovery practices, such
+                  as regular backups. As an alternative to deduplication consider
+                  using compression=lz4, as a less resource-intensive alternative.
+                  should be enabled on the zvol. Dedup property can be edited after
+                  the volume has been created. Default Value: off.'
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
+                  of encrypted filesystems and volumes. ZFS will encrypt file and
+                  zvol data, file attributes, ACLs, permission bits, directory listings,
+                  FUID mappings, and userused / groupused data. ZFS will not encrypt
+                  metadata related to the pool structure, including dataset and snapshot
+                  names, dataset hierarchy, properties, file size, file holes, and
+                  deduplication tables (though the deduplicated data itself is encrypted).
+                  Default Value: off.'
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  If FsType is provided as "zfs", then the driver will create a ZFS
+                  dataset, formatting is not required as underlying filesystem is
+                  ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
+                  will create a ZVOL and format the volume accordingly. FsType can
+                  not be modified once volume has been provisioned. Default Value:
+                  ext4.'
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
+                  system. The size specified must be a power of two greater than or
+                  equal to 512 and less than or equal to 128 Kbytes. RecordSize property
+                  can be edited after the volume has been created. Changing the file
+                  system''s recordsize affects only files created afterward; existing
+                  files are unaffected. Default Value: 128k.'
+                minLength: 1
+                type: string
+              shared:
+                description: Shared specifies whether the volume can be shared among
+                  multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
+                  will not allow the volumes to be mounted by more than one pods.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
+                  the source volume is required or not. The value "yes" indicates
+                  that volume should be thin provisioned and "no" means thick provisioning
+                  of the volume. If thinProvision is set to "yes" then volume can
+                  be provisioned even if the ZPOOL does not have the enough capacity.
+                  If thinProvision is set to "no" then volume can be provisioned only
+                  if the ZPOOL has enough capacity and capacity required by volume
+                  can be reserved. ThinProvision can not be modified once volume has
+                  been provisioned. Default Value: no.'
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
+                  The volsize can only be set to a multiple of volblocksize, and cannot
+                  be zero. VolBlockSize can not be edited after the volume has been
+                  provisioned. Default Value: 8k.'
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+          status:
+            properties:
+              state:
+                description: State specifies the current state of the volume provisioning
+                  request. The state "Pending" means that the volume creation request
+                  has not processed yet. The state "Ready" means that the volume has
+                  been created and it is ready for the use.
+                enum:
+                - Pending
+                - Ready
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ZFSVolume represents a ZFS based volume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
+                  to be applied to the ZFS Volume. The value "on" indicates ZFS to
+                  use the default compression algorithm. The default compression algorithm
+                  used by ZFS will be either lzjb or, if the lz4_compress feature
+                  is enabled, lz4. Compression property can be edited after the volume
+                  has been created. The change will only be applied to the newly-written
+                  data. For instance, if the Volume was created with "off" and the
+                  next day the compression was modified to "on", the data written
+                  prior to setting "on" will not be compressed. Default Value: off.'
+                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
+                  data at the block level, reducing the total amount of data stored.
+                  If a file system has the dedup property enabled, duplicate data
+                  blocks are removed synchronously. The result is that only unique
+                  data is stored and common components are shared among files. Deduplication
+                  can consume significant processing power (CPU) and memory as well
+                  as generate additional disk IO. Before creating a pool with deduplication
+                  enabled, ensure that you have planned your hardware requirements
+                  appropriately and implemented appropriate recovery practices, such
+                  as regular backups. As an alternative to deduplication consider
+                  using compression=lz4, as a less resource-intensive alternative.
+                  should be enabled on the zvol. Dedup property can be edited after
+                  the volume has been created. Default Value: off.'
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
+                  of encrypted filesystems and volumes. ZFS will encrypt file and
+                  zvol data, file attributes, ACLs, permission bits, directory listings,
+                  FUID mappings, and userused / groupused data. ZFS will not encrypt
+                  metadata related to the pool structure, including dataset and snapshot
+                  names, dataset hierarchy, properties, file size, file holes, and
+                  deduplication tables (though the deduplicated data itself is encrypted).
+                  Default Value: off.'
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  If FsType is provided as "zfs", then the driver will create a ZFS
+                  dataset, formatting is not required as underlying filesystem is
+                  ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
+                  will create a ZVOL and format the volume accordingly. FsType can
+                  not be modified once volume has been provisioned. Default Value:
+                  ext4.'
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
+                  system. The size specified must be a power of two greater than or
+                  equal to 512 and less than or equal to 128 Kbytes. RecordSize property
+                  can be edited after the volume has been created. Changing the file
+                  system''s recordsize affects only files created afterward; existing
+                  files are unaffected. Default Value: 128k.'
+                minLength: 1
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
+                  the source volume is required or not. The value "yes" indicates
+                  that volume should be thin provisioned and "no" means thick provisioning
+                  of the volume. If thinProvision is set to "yes" then volume can
+                  be provisioned even if the ZPOOL does not have the enough capacity.
+                  If thinProvision is set to "no" then volume can be provisioned only
+                  if the ZPOOL has enough capacity and capacity required by volume
+                  can be reserved. ThinProvision can not be modified once volume has
+                  been provisioned. Default Value: no.'
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
+                  The volsize can only be set to a multiple of volblocksize, and cannot
+                  be zero. VolBlockSize can not be edited after the volume has been
+                  provisioned. Default Value: 8k.'
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+          status:
+            properties:
+              state:
+                description: State specifies the current state of the volume provisioning
+                  request. The state "Pending" means that the volume creation request
+                  has not processed yet. The state "Ready" means that the volume has
+                  been created and it is ready for the use.
+                enum:
+                - Pending
+                - Ready
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: false
 status:

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -77,180 +77,360 @@ spec:
   preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: ZFSVolume represents a ZFS based volume
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: VolumeInfo defines ZFS volume parameters for all modes in which
-            ZFS volumes can be created like - ZFS volume with filesystem, ZFS Volume
-            exposed as zfs or ZFS volume exposed as raw block device. Some of the
-            parameters can be only set during creation time (as specified in the details
-            of the parameter), and a few are editable. In case of Cloned volumes,
-            the parameters are assigned the same values as the source volume.
-          properties:
-            capacity:
-              description: Capacity of the volume
-              minLength: 1
-              type: string
-            compression:
-              description: 'Compression specifies the block-level compression algorithm
-                to be applied to the ZFS Volume. The value "on" indicates ZFS to use
-                the default compression algorithm. The default compression algorithm
-                used by ZFS will be either lzjb or, if the lz4_compress feature is
-                enabled, lz4. Compression property can be edited after the volume
-                has been created. The change will only be applied to the newly-written
-                data. For instance, if the Volume was created with "off" and the next
-                day the compression was modified to "on", the data written prior to
-                setting "on" will not be compressed. Default Value: off.'
-              pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
-              type: string
-            dedup:
-              description: 'Deduplication is the process for removing redundant data
-                at the block level, reducing the total amount of data stored. If a
-                file system has the dedup property enabled, duplicate data blocks
-                are removed synchronously. The result is that only unique data is
-                stored and common components are shared among files. Deduplication
-                can consume significant processing power (CPU) and memory as well
-                as generate additional disk IO. Before creating a pool with deduplication
-                enabled, ensure that you have planned your hardware requirements appropriately
-                and implemented appropriate recovery practices, such as regular backups.
-                As an alternative to deduplication consider using compression=lz4,
-                as a less resource-intensive alternative. should be enabled on the
-                zvol. Dedup property can be edited after the volume has been created.
-                Default Value: off.'
-              enum:
-              - "on"
-              - "off"
-              type: string
-            encryption:
-              description: 'Enabling the encryption feature allows for the creation
-                of encrypted filesystems and volumes. ZFS will encrypt file and zvol
-                data, file attributes, ACLs, permission bits, directory listings,
-                FUID mappings, and userused / groupused data. ZFS will not encrypt
-                metadata related to the pool structure, including dataset and snapshot
-                names, dataset hierarchy, properties, file size, file holes, and deduplication
-                tables (though the deduplicated data itself is encrypted). Default
-                Value: off.'
-              pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
-              type: string
-            fsType:
-              description: 'FsType specifies filesystem type for the zfs volume/dataset.
-                If FsType is provided as "zfs", then the driver will create a ZFS
-                dataset, formatting is not required as underlying filesystem is ZFS
-                anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver will
-                create a ZVOL and format the volume accordingly. FsType can not be
-                modified once volume has been provisioned. Default Value: ext4.'
-              type: string
-            keyformat:
-              description: KeyFormat specifies format of the encryption key The supported
-                KeyFormats are passphrase, raw, hex.
-              enum:
-              - passphrase
-              - raw
-              - hex
-              type: string
-            keylocation:
-              description: KeyLocation is the location of key for the encryption
-              type: string
-            ownerNodeID:
-              description: OwnerNodeID is the Node ID where the ZPOOL is running which
-                is where the volume has been provisioned. OwnerNodeID can not be edited
-                after the volume has been provisioned.
-              minLength: 1
-              type: string
-            poolName:
-              description: poolName specifies the name of the pool where the volume
-                has been created. PoolName can not be edited after the volume has
-                been provisioned.
-              minLength: 1
-              type: string
-            recordsize:
-              description: 'Specifies a suggested block size for files in the file
-                system. The size specified must be a power of two greater than or
-                equal to 512 and less than or equal to 128 Kbytes. RecordSize property
-                can be edited after the volume has been created. Changing the file
-                system''s recordsize affects only files created afterward; existing
-                files are unaffected. Default Value: 128k.'
-              minLength: 1
-              type: string
-            snapname:
-              description: SnapName specifies the name of the snapshot where the volume
-                has been cloned from. Snapname can not be edited after the volume
-                has been provisioned.
-              type: string
-            thinProvision:
-              description: 'ThinProvision describes whether space reservation for
-                the source volume is required or not. The value "yes" indicates that
-                volume should be thin provisioned and "no" means thick provisioning
-                of the volume. If thinProvision is set to "yes" then volume can be
-                provisioned even if the ZPOOL does not have the enough capacity. If
-                thinProvision is set to "no" then volume can be provisioned only if
-                the ZPOOL has enough capacity and capacity required by volume can
-                be reserved. ThinProvision can not be modified once volume has been
-                provisioned. Default Value: no.'
-              enum:
-              - "yes"
-              - "no"
-              type: string
-            volblocksize:
-              description: 'VolBlockSize specifies the block size for the zvol. The
-                volsize can only be set to a multiple of volblocksize, and cannot
-                be zero. VolBlockSize can not be edited after the volume has been
-                provisioned. Default Value: 8k.'
-              minLength: 1
-              type: string
-            volumeType:
-              description: volumeType determines whether the volume is of type "DATASET"
-                or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
-                of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
-                is mentioned as fstype in the storageclass, then a volume of type
-                zvol will be created, which will be further formatted as the fstype
-                provided in the storageclass. VolumeType can not be modified once
-                volume has been provisioned.
-              enum:
-              - ZVOL
-              - DATASET
-              type: string
-          required:
-          - capacity
-          - ownerNodeID
-          - poolName
-          - volumeType
-          type: object
-        status:
-          properties:
-            state:
-              description: State specifies the current state of the volume provisioning
-                request. The state "Pending" means that the volume creation request
-                has not processed yet. The state "Ready" means that the volume has
-                been created and it is ready for the use.
-              enum:
-              - Pending
-              - Ready
-              type: string
-          type: object
-      required:
-      - spec
-      type: object
   version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ZFSVolume represents a ZFS based volume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
+                  to be applied to the ZFS Volume. The value "on" indicates ZFS to
+                  use the default compression algorithm. The default compression algorithm
+                  used by ZFS will be either lzjb or, if the lz4_compress feature
+                  is enabled, lz4. Compression property can be edited after the volume
+                  has been created. The change will only be applied to the newly-written
+                  data. For instance, if the Volume was created with "off" and the
+                  next day the compression was modified to "on", the data written
+                  prior to setting "on" will not be compressed. Default Value: off.'
+                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
+                  data at the block level, reducing the total amount of data stored.
+                  If a file system has the dedup property enabled, duplicate data
+                  blocks are removed synchronously. The result is that only unique
+                  data is stored and common components are shared among files. Deduplication
+                  can consume significant processing power (CPU) and memory as well
+                  as generate additional disk IO. Before creating a pool with deduplication
+                  enabled, ensure that you have planned your hardware requirements
+                  appropriately and implemented appropriate recovery practices, such
+                  as regular backups. As an alternative to deduplication consider
+                  using compression=lz4, as a less resource-intensive alternative.
+                  should be enabled on the zvol. Dedup property can be edited after
+                  the volume has been created. Default Value: off.'
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
+                  of encrypted filesystems and volumes. ZFS will encrypt file and
+                  zvol data, file attributes, ACLs, permission bits, directory listings,
+                  FUID mappings, and userused / groupused data. ZFS will not encrypt
+                  metadata related to the pool structure, including dataset and snapshot
+                  names, dataset hierarchy, properties, file size, file holes, and
+                  deduplication tables (though the deduplicated data itself is encrypted).
+                  Default Value: off.'
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  If FsType is provided as "zfs", then the driver will create a ZFS
+                  dataset, formatting is not required as underlying filesystem is
+                  ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
+                  will create a ZVOL and format the volume accordingly. FsType can
+                  not be modified once volume has been provisioned. Default Value:
+                  ext4.'
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
+                  system. The size specified must be a power of two greater than or
+                  equal to 512 and less than or equal to 128 Kbytes. RecordSize property
+                  can be edited after the volume has been created. Changing the file
+                  system''s recordsize affects only files created afterward; existing
+                  files are unaffected. Default Value: 128k.'
+                minLength: 1
+                type: string
+              shared:
+                description: Shared specifies whether the volume can be shared among
+                  multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
+                  will not allow the volumes to be mounted by more than one pods.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
+                  the source volume is required or not. The value "yes" indicates
+                  that volume should be thin provisioned and "no" means thick provisioning
+                  of the volume. If thinProvision is set to "yes" then volume can
+                  be provisioned even if the ZPOOL does not have the enough capacity.
+                  If thinProvision is set to "no" then volume can be provisioned only
+                  if the ZPOOL has enough capacity and capacity required by volume
+                  can be reserved. ThinProvision can not be modified once volume has
+                  been provisioned. Default Value: no.'
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
+                  The volsize can only be set to a multiple of volblocksize, and cannot
+                  be zero. VolBlockSize can not be edited after the volume has been
+                  provisioned. Default Value: 8k.'
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+          status:
+            properties:
+              state:
+                description: State specifies the current state of the volume provisioning
+                  request. The state "Pending" means that the volume creation request
+                  has not processed yet. The state "Ready" means that the volume has
+                  been created and it is ready for the use.
+                enum:
+                - Pending
+                - Ready
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ZFSVolume represents a ZFS based volume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
+                  to be applied to the ZFS Volume. The value "on" indicates ZFS to
+                  use the default compression algorithm. The default compression algorithm
+                  used by ZFS will be either lzjb or, if the lz4_compress feature
+                  is enabled, lz4. Compression property can be edited after the volume
+                  has been created. The change will only be applied to the newly-written
+                  data. For instance, if the Volume was created with "off" and the
+                  next day the compression was modified to "on", the data written
+                  prior to setting "on" will not be compressed. Default Value: off.'
+                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
+                  data at the block level, reducing the total amount of data stored.
+                  If a file system has the dedup property enabled, duplicate data
+                  blocks are removed synchronously. The result is that only unique
+                  data is stored and common components are shared among files. Deduplication
+                  can consume significant processing power (CPU) and memory as well
+                  as generate additional disk IO. Before creating a pool with deduplication
+                  enabled, ensure that you have planned your hardware requirements
+                  appropriately and implemented appropriate recovery practices, such
+                  as regular backups. As an alternative to deduplication consider
+                  using compression=lz4, as a less resource-intensive alternative.
+                  should be enabled on the zvol. Dedup property can be edited after
+                  the volume has been created. Default Value: off.'
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
+                  of encrypted filesystems and volumes. ZFS will encrypt file and
+                  zvol data, file attributes, ACLs, permission bits, directory listings,
+                  FUID mappings, and userused / groupused data. ZFS will not encrypt
+                  metadata related to the pool structure, including dataset and snapshot
+                  names, dataset hierarchy, properties, file size, file holes, and
+                  deduplication tables (though the deduplicated data itself is encrypted).
+                  Default Value: off.'
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  If FsType is provided as "zfs", then the driver will create a ZFS
+                  dataset, formatting is not required as underlying filesystem is
+                  ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
+                  will create a ZVOL and format the volume accordingly. FsType can
+                  not be modified once volume has been provisioned. Default Value:
+                  ext4.'
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
+                  system. The size specified must be a power of two greater than or
+                  equal to 512 and less than or equal to 128 Kbytes. RecordSize property
+                  can be edited after the volume has been created. Changing the file
+                  system''s recordsize affects only files created afterward; existing
+                  files are unaffected. Default Value: 128k.'
+                minLength: 1
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
+                  the source volume is required or not. The value "yes" indicates
+                  that volume should be thin provisioned and "no" means thick provisioning
+                  of the volume. If thinProvision is set to "yes" then volume can
+                  be provisioned even if the ZPOOL does not have the enough capacity.
+                  If thinProvision is set to "no" then volume can be provisioned only
+                  if the ZPOOL has enough capacity and capacity required by volume
+                  can be reserved. ThinProvision can not be modified once volume has
+                  been provisioned. Default Value: no.'
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
+                  The volsize can only be set to a multiple of volblocksize, and cannot
+                  be zero. VolBlockSize can not be edited after the volume has been
+                  provisioned. Default Value: 8k.'
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+          status:
+            properties:
+              state:
+                description: State specifies the current state of the volume provisioning
+                  request. The state "Pending" means that the volume creation request
+                  has not processed yet. The state "Ready" means that the volume has
+                  been created and it is ready for the use.
+                enum:
+                - Pending
+                - Ready
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: false
 status:
@@ -290,174 +470,348 @@ spec:
     singular: zfssnapshot
   preserveUnknownFields: false
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: ZFSSnapshot represents a ZFS Snapshot of the zfsvolume
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: VolumeInfo defines ZFS volume parameters for all modes in which
-            ZFS volumes can be created like - ZFS volume with filesystem, ZFS Volume
-            exposed as zfs or ZFS volume exposed as raw block device. Some of the
-            parameters can be only set during creation time (as specified in the details
-            of the parameter), and a few are editable. In case of Cloned volumes,
-            the parameters are assigned the same values as the source volume.
-          properties:
-            capacity:
-              description: Capacity of the volume
-              minLength: 1
-              type: string
-            compression:
-              description: 'Compression specifies the block-level compression algorithm
-                to be applied to the ZFS Volume. The value "on" indicates ZFS to use
-                the default compression algorithm. The default compression algorithm
-                used by ZFS will be either lzjb or, if the lz4_compress feature is
-                enabled, lz4. Compression property can be edited after the volume
-                has been created. The change will only be applied to the newly-written
-                data. For instance, if the Volume was created with "off" and the next
-                day the compression was modified to "on", the data written prior to
-                setting "on" will not be compressed. Default Value: off.'
-              pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
-              type: string
-            dedup:
-              description: 'Deduplication is the process for removing redundant data
-                at the block level, reducing the total amount of data stored. If a
-                file system has the dedup property enabled, duplicate data blocks
-                are removed synchronously. The result is that only unique data is
-                stored and common components are shared among files. Deduplication
-                can consume significant processing power (CPU) and memory as well
-                as generate additional disk IO. Before creating a pool with deduplication
-                enabled, ensure that you have planned your hardware requirements appropriately
-                and implemented appropriate recovery practices, such as regular backups.
-                As an alternative to deduplication consider using compression=lz4,
-                as a less resource-intensive alternative. should be enabled on the
-                zvol. Dedup property can be edited after the volume has been created.
-                Default Value: off.'
-              enum:
-              - "on"
-              - "off"
-              type: string
-            encryption:
-              description: 'Enabling the encryption feature allows for the creation
-                of encrypted filesystems and volumes. ZFS will encrypt file and zvol
-                data, file attributes, ACLs, permission bits, directory listings,
-                FUID mappings, and userused / groupused data. ZFS will not encrypt
-                metadata related to the pool structure, including dataset and snapshot
-                names, dataset hierarchy, properties, file size, file holes, and deduplication
-                tables (though the deduplicated data itself is encrypted). Default
-                Value: off.'
-              pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
-              type: string
-            fsType:
-              description: 'FsType specifies filesystem type for the zfs volume/dataset.
-                If FsType is provided as "zfs", then the driver will create a ZFS
-                dataset, formatting is not required as underlying filesystem is ZFS
-                anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver will
-                create a ZVOL and format the volume accordingly. FsType can not be
-                modified once volume has been provisioned. Default Value: ext4.'
-              type: string
-            keyformat:
-              description: KeyFormat specifies format of the encryption key The supported
-                KeyFormats are passphrase, raw, hex.
-              enum:
-              - passphrase
-              - raw
-              - hex
-              type: string
-            keylocation:
-              description: KeyLocation is the location of key for the encryption
-              type: string
-            ownerNodeID:
-              description: OwnerNodeID is the Node ID where the ZPOOL is running which
-                is where the volume has been provisioned. OwnerNodeID can not be edited
-                after the volume has been provisioned.
-              minLength: 1
-              type: string
-            poolName:
-              description: poolName specifies the name of the pool where the volume
-                has been created. PoolName can not be edited after the volume has
-                been provisioned.
-              minLength: 1
-              type: string
-            recordsize:
-              description: 'Specifies a suggested block size for files in the file
-                system. The size specified must be a power of two greater than or
-                equal to 512 and less than or equal to 128 Kbytes. RecordSize property
-                can be edited after the volume has been created. Changing the file
-                system''s recordsize affects only files created afterward; existing
-                files are unaffected. Default Value: 128k.'
-              minLength: 1
-              type: string
-            snapname:
-              description: SnapName specifies the name of the snapshot where the volume
-                has been cloned from. Snapname can not be edited after the volume
-                has been provisioned.
-              type: string
-            thinProvision:
-              description: 'ThinProvision describes whether space reservation for
-                the source volume is required or not. The value "yes" indicates that
-                volume should be thin provisioned and "no" means thick provisioning
-                of the volume. If thinProvision is set to "yes" then volume can be
-                provisioned even if the ZPOOL does not have the enough capacity. If
-                thinProvision is set to "no" then volume can be provisioned only if
-                the ZPOOL has enough capacity and capacity required by volume can
-                be reserved. ThinProvision can not be modified once volume has been
-                provisioned. Default Value: no.'
-              enum:
-              - "yes"
-              - "no"
-              type: string
-            volblocksize:
-              description: 'VolBlockSize specifies the block size for the zvol. The
-                volsize can only be set to a multiple of volblocksize, and cannot
-                be zero. VolBlockSize can not be edited after the volume has been
-                provisioned. Default Value: 8k.'
-              minLength: 1
-              type: string
-            volumeType:
-              description: volumeType determines whether the volume is of type "DATASET"
-                or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
-                of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
-                is mentioned as fstype in the storageclass, then a volume of type
-                zvol will be created, which will be further formatted as the fstype
-                provided in the storageclass. VolumeType can not be modified once
-                volume has been provisioned.
-              enum:
-              - ZVOL
-              - DATASET
-              type: string
-          required:
-          - capacity
-          - ownerNodeID
-          - poolName
-          - volumeType
-          type: object
-        status:
-          properties:
-            state:
-              type: string
-          type: object
-      required:
-      - spec
-      - status
-      type: object
   version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ZFSSnapshot represents a ZFS Snapshot of the zfsvolume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
+                  to be applied to the ZFS Volume. The value "on" indicates ZFS to
+                  use the default compression algorithm. The default compression algorithm
+                  used by ZFS will be either lzjb or, if the lz4_compress feature
+                  is enabled, lz4. Compression property can be edited after the volume
+                  has been created. The change will only be applied to the newly-written
+                  data. For instance, if the Volume was created with "off" and the
+                  next day the compression was modified to "on", the data written
+                  prior to setting "on" will not be compressed. Default Value: off.'
+                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
+                  data at the block level, reducing the total amount of data stored.
+                  If a file system has the dedup property enabled, duplicate data
+                  blocks are removed synchronously. The result is that only unique
+                  data is stored and common components are shared among files. Deduplication
+                  can consume significant processing power (CPU) and memory as well
+                  as generate additional disk IO. Before creating a pool with deduplication
+                  enabled, ensure that you have planned your hardware requirements
+                  appropriately and implemented appropriate recovery practices, such
+                  as regular backups. As an alternative to deduplication consider
+                  using compression=lz4, as a less resource-intensive alternative.
+                  should be enabled on the zvol. Dedup property can be edited after
+                  the volume has been created. Default Value: off.'
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
+                  of encrypted filesystems and volumes. ZFS will encrypt file and
+                  zvol data, file attributes, ACLs, permission bits, directory listings,
+                  FUID mappings, and userused / groupused data. ZFS will not encrypt
+                  metadata related to the pool structure, including dataset and snapshot
+                  names, dataset hierarchy, properties, file size, file holes, and
+                  deduplication tables (though the deduplicated data itself is encrypted).
+                  Default Value: off.'
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  If FsType is provided as "zfs", then the driver will create a ZFS
+                  dataset, formatting is not required as underlying filesystem is
+                  ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
+                  will create a ZVOL and format the volume accordingly. FsType can
+                  not be modified once volume has been provisioned. Default Value:
+                  ext4.'
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
+                  system. The size specified must be a power of two greater than or
+                  equal to 512 and less than or equal to 128 Kbytes. RecordSize property
+                  can be edited after the volume has been created. Changing the file
+                  system''s recordsize affects only files created afterward; existing
+                  files are unaffected. Default Value: 128k.'
+                minLength: 1
+                type: string
+              shared:
+                description: Shared specifies whether the volume can be shared among
+                  multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
+                  will not allow the volumes to be mounted by more than one pods.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
+                  the source volume is required or not. The value "yes" indicates
+                  that volume should be thin provisioned and "no" means thick provisioning
+                  of the volume. If thinProvision is set to "yes" then volume can
+                  be provisioned even if the ZPOOL does not have the enough capacity.
+                  If thinProvision is set to "no" then volume can be provisioned only
+                  if the ZPOOL has enough capacity and capacity required by volume
+                  can be reserved. ThinProvision can not be modified once volume has
+                  been provisioned. Default Value: no.'
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
+                  The volsize can only be set to a multiple of volblocksize, and cannot
+                  be zero. VolBlockSize can not be edited after the volume has been
+                  provisioned. Default Value: 8k.'
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+          status:
+            properties:
+              state:
+                type: string
+            type: object
+        required:
+        - spec
+        - status
+        type: object
     served: true
     storage: true
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ZFSSnapshot represents a ZFS Snapshot of the zfsvolume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
+                  to be applied to the ZFS Volume. The value "on" indicates ZFS to
+                  use the default compression algorithm. The default compression algorithm
+                  used by ZFS will be either lzjb or, if the lz4_compress feature
+                  is enabled, lz4. Compression property can be edited after the volume
+                  has been created. The change will only be applied to the newly-written
+                  data. For instance, if the Volume was created with "off" and the
+                  next day the compression was modified to "on", the data written
+                  prior to setting "on" will not be compressed. Default Value: off.'
+                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
+                  data at the block level, reducing the total amount of data stored.
+                  If a file system has the dedup property enabled, duplicate data
+                  blocks are removed synchronously. The result is that only unique
+                  data is stored and common components are shared among files. Deduplication
+                  can consume significant processing power (CPU) and memory as well
+                  as generate additional disk IO. Before creating a pool with deduplication
+                  enabled, ensure that you have planned your hardware requirements
+                  appropriately and implemented appropriate recovery practices, such
+                  as regular backups. As an alternative to deduplication consider
+                  using compression=lz4, as a less resource-intensive alternative.
+                  should be enabled on the zvol. Dedup property can be edited after
+                  the volume has been created. Default Value: off.'
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
+                  of encrypted filesystems and volumes. ZFS will encrypt file and
+                  zvol data, file attributes, ACLs, permission bits, directory listings,
+                  FUID mappings, and userused / groupused data. ZFS will not encrypt
+                  metadata related to the pool structure, including dataset and snapshot
+                  names, dataset hierarchy, properties, file size, file holes, and
+                  deduplication tables (though the deduplicated data itself is encrypted).
+                  Default Value: off.'
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  If FsType is provided as "zfs", then the driver will create a ZFS
+                  dataset, formatting is not required as underlying filesystem is
+                  ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
+                  will create a ZVOL and format the volume accordingly. FsType can
+                  not be modified once volume has been provisioned. Default Value:
+                  ext4.'
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
+                  system. The size specified must be a power of two greater than or
+                  equal to 512 and less than or equal to 128 Kbytes. RecordSize property
+                  can be edited after the volume has been created. Changing the file
+                  system''s recordsize affects only files created afterward; existing
+                  files are unaffected. Default Value: 128k.'
+                minLength: 1
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
+                  the source volume is required or not. The value "yes" indicates
+                  that volume should be thin provisioned and "no" means thick provisioning
+                  of the volume. If thinProvision is set to "yes" then volume can
+                  be provisioned even if the ZPOOL does not have the enough capacity.
+                  If thinProvision is set to "no" then volume can be provisioned only
+                  if the ZPOOL has enough capacity and capacity required by volume
+                  can be reserved. ThinProvision can not be modified once volume has
+                  been provisioned. Default Value: no.'
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
+                  The volsize can only be set to a multiple of volblocksize, and cannot
+                  be zero. VolBlockSize can not be edited after the volume has been
+                  provisioned. Default Value: 8k.'
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+          status:
+            properties:
+              state:
+                type: string
+            type: object
+        required:
+        - spec
+        - status
+        type: object
     served: true
     storage: false
 status:

--- a/pkg/apis/openebs.io/zfs/v1/zfsvolume.go
+++ b/pkg/apis/openebs.io/zfs/v1/zfsvolume.go
@@ -193,6 +193,13 @@ type VolumeInfo struct {
 	// FsType can not be modified once volume has been provisioned.
 	// Default Value: ext4.
 	FsType string `json:"fsType,omitempty"`
+
+	// Shared specifies whether the volume can be shared among multiple pods.
+	// If it is not set to "yes", then the ZFS-LocalPV Driver will not allow
+	// the volumes to be mounted by more than one pods.
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Enum=yes;no
+	Shared string `json:"shared,omitempty"`
 }
 
 type VolStatus struct {

--- a/pkg/builder/volbuilder/build.go
+++ b/pkg/builder/volbuilder/build.go
@@ -172,6 +172,12 @@ func (b *Builder) WithFsType(fstype string) *Builder {
 	return b
 }
 
+// WithShared sets where filesystem is shared or not
+func (b *Builder) WithShared(shared string) *Builder {
+	b.volume.Object.Spec.Shared = shared
+	return b
+}
+
 // WithSnapshot sets Snapshot name for creating clone volume
 func (b *Builder) WithSnapshot(snap string) *Builder {
 	b.volume.Object.Spec.SnapName = snap

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -98,6 +98,7 @@ func CreateZFSVolume(req *csi.CreateVolumeRequest) (string, error) {
 	tp := parameters["thinprovision"]
 	schld := parameters["scheduler"]
 	fstype := parameters["fstype"]
+	shared := parameters["shared"]
 
 	vtype := zfs.GetVolumeType(fstype)
 
@@ -124,6 +125,7 @@ func CreateZFSVolume(req *csi.CreateVolumeRequest) (string, error) {
 		WithVolumeType(vtype).
 		WithVolumeStatus(zfs.ZFSStatusPending).
 		WithFsType(fstype).
+		WithShared(shared).
 		WithCompression(compression).Build()
 
 	if err != nil {

--- a/pkg/driver/grpc.go
+++ b/pkg/driver/grpc.go
@@ -69,7 +69,7 @@ func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 
 	log := isInfotrmativeLog(info.FullMethod)
 	if log == true {
-		klog.Infof("GRPC call: %s\n requests %s", info.FullMethod, protosanitizer.StripSecrets(req))
+		klog.Infof("GRPC call: %s requests %s", info.FullMethod, protosanitizer.StripSecrets(req))
 	}
 
 	resp, err := handler(ctx, req)

--- a/pkg/zfs/mount.go
+++ b/pkg/zfs/mount.go
@@ -147,24 +147,27 @@ func verifyMountRequest(vol *apis.ZFSVolume, mountpath string) error {
 		return status.Errorf(codes.Internal, "verifyMount: GetVolumePath failed %s", err.Error())
 	}
 
-	/*
-	 * This check is the famous *Wall Of North*
-	 * It will not let the volume to be mounted
-	 * at more than two places. The volume should
-	 * be unmounted before proceeding to the mount
-	 * operation.
-	 */
-	currentMounts, err := GetMounts(devicePath)
-	if err != nil {
-		klog.Errorf("can not get mounts for volume:%s dev %s err: %v",
-			vol.Name, devicePath, err.Error())
-		return status.Errorf(codes.Internal, "verifyMount: Getmounts failed %s", err.Error())
-	} else if len(currentMounts) >= 1 {
-		klog.Errorf(
-			"can not mount, volume:%s already mounted dev %s mounts: %v",
-			vol.Name, devicePath, currentMounts,
-		)
-		return status.Errorf(codes.Internal, "verifyMount: device already mounted at %s", currentMounts)
+	// if it is not a shared volume, then make sure it is not mounted to more than one path
+	if vol.Spec.Shared != "yes" {
+		/*
+		 * This check is the famous *Wall Of North*
+		 * It will not let the volume to be mounted
+		 * at more than two places. The volume should
+		 * be unmounted before proceeding to the mount
+		 * operation.
+		 */
+		currentMounts, err := GetMounts(devicePath)
+		if err != nil {
+			klog.Errorf("can not get mounts for volume:%s dev %s err: %v",
+				vol.Name, devicePath, err.Error())
+			return status.Errorf(codes.Internal, "verifyMount: Getmounts failed %s", err.Error())
+		} else if len(currentMounts) >= 1 {
+			klog.Errorf(
+				"can not mount, volume:%s already mounted dev %s mounts: %v",
+				vol.Name, devicePath, currentMounts,
+			)
+			return status.Errorf(codes.Internal, "verifyMount: device already mounted at %s", currentMounts)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
fixes : https://github.com/openebs/zfs-localpv/issues/152

Signed-off-by: Pawan <pawan@mayadata.io>

**Why is this PR required? What issue does it fix?**:

Applications who wants to share a volume can use below storageclass
to make their volumes shared by multiple pods

```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-zfspv
parameters:
  shared: "yes"
  fstype: "zfs"
  poolname: "zfspv-pool"
provisioner: zfs.csi.openebs.io
```

Now the provisioned volume using this storageclass can be used by multiple pods.
Here pods have to make sure of the data consistency and have to have locking mechanism.
One thing to note here is pods will be scheduled to the node where volume is present
so that all the pods can use the same volume as they can access it locally only. 
This way we can avoid the NFS overhead and can get the optimal performance also.

**What this PR does?**:
Add a new field "shared" which specifies that the volume can be shared mounted.
Also fixed the log formatting in the GRPC log.

**Does this PR require any upgrade changes?**:

no


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
