### PR TITLE
feat(btrfs): adding support to have btrfs filesystem for ZFS-LocalPV

### DIFF
--- a/buildscripts/zfs-driver/Dockerfile
+++ b/buildscripts/zfs-driver/Dockerfile
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN apt-get update; exit 0
 RUN apt-get -y install rsyslog libssl-dev xfsprogs ca-certificates
+RUN apt-get -y install btrfs-progs
 
 ARG ARCH
 ARG DBUILD_DATE

--- a/changelogs/unreleased/170-pawanpraka1
+++ b/changelogs/unreleased/170-pawanpraka1
@@ -1,0 +1,1 @@
+adding support to have btrfs filesystem for ZFS-LocalPV


### PR DESCRIPTION
fixes: https://github.com/openebs/zfs-localpv/issues/169

Now, applications can use the btrfs file system by mentioning "btrfs"
as fstype in the storageclass :-

```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-zfspv
parameters:
  fstype: "btrfs"
  poolname: "zfspv-pool"
provisioner: zfs.csi.openebs.io
```

Signed-off-by: Pawan <pawan@mayadata.io>

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

