### PR TITLE
fix(btrfs): fixing duplicate UUID issue with btrfs

### DIFF
--- a/changelogs/172-pawanpraka1
+++ b/changelogs/172-pawanpraka1
@@ -1,0 +1,1 @@
+fixing duplicate UUID issue with btrfs

--- a/pkg/zfs/btrfs_util.go
+++ b/pkg/zfs/btrfs_util.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2020 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package zfs
+
+import (
+	"k8s.io/klog"
+	"os/exec"
+)
+
+/*
+* We have to generate a new UUID for the cloned volumes with btrfs filesystem
+* otherwise system will mount the same volume if UUID is same. Here, since cloned
+* volume refers to the same block because of the way ZFS clone works, it will
+* also have the same UUID.
+ */
+func btrfsGenerateUuid(volume string) error {
+	device := ZFS_DEVPATH + volume
+
+	// for mounting the cloned volume for btrfs, a new UUID has to be generated
+	cmd := exec.Command("btrfstune", "-f", "-u", device)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		klog.Errorf("btrfs: uuid generate failed %s error: %s", volume, string(out))
+		return err
+	}
+	klog.Infof("btrfs: generated UUID for the cloned volume %s \n %v", volume, string(out))
+	return nil
+}

--- a/pkg/zfs/mount.go
+++ b/pkg/zfs/mount.go
@@ -139,6 +139,9 @@ func verifyMountRequest(vol *apis.ZFSVolume, mountpath string) error {
 		vol.Spec.OwnerNodeID != NodeID {
 		return status.Error(codes.Internal, "verifyMount: volume is owned by different node")
 	}
+	if vol.Finalizers == nil {
+		return status.Error(codes.Internal, "verifyMount: volume is not ready, driver has not yet set the finalizer")
+	}
 
 	devicePath, err := GetVolumeDevPath(vol)
 	if err != nil {

--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -367,6 +367,9 @@ func CreateClone(vol *apis.ZFSVolume) error {
 	if vol.Spec.FsType == "xfs" {
 		return xfsGenerateUuid(volume)
 	}
+	if vol.Spec.FsType == "btrfs" {
+		return btrfsGenerateUuid(volume)
+	}
 	return nil
 }
 


### PR DESCRIPTION
fixes : https://github.com/openebs/zfs-localpv/issues/169

Continuation of the PR https://github.com/openebs/zfs-localpv/pull/170

Signed-off-by: Pawan <pawan@mayadata.io>



**Why is this PR required? What issue does it fix?**:

btrfs, like xfs, needs to generate a new UUID for the
cloned volumes. All the devices with the same UUID will be treated
same for btrfs.

**What this PR does?**:

generating the new UUID for the cloned volumes using btrfstune command.

**Does this PR require any upgrade changes?**:

no

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
