### PR TITLE
fix(zfspv): fixing mounting issue with xfs on centos

### DIFF
--- a/buildscripts/zfs-driver/Dockerfile
+++ b/buildscripts/zfs-driver/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:20.04
+FROM ubuntu:19.10
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN apt-get update; exit 0
 RUN apt-get -y install rsyslog libssl-dev xfsprogs ca-certificates

--- a/changelogs/unreleased/179-pawanpraka1
+++ b/changelogs/unreleased/179-pawanpraka1
@@ -1,0 +1,1 @@
+fixing xfs mounting issue on centos with ubuntu 20.04 image


### PR DESCRIPTION
fixes : https://github.com/openebs/zfs-localpv/issues/173

Signed-off-by: Pawan <pawan@mayadata.io>


**Why is this PR required? What issue does it fix?**:

We changed the ubuntu docker image to 20.04 in https://github.com/openebs/zfs-localpv/pull/170,
which has issues with formatting the zvol as xfs file system. The filesystem
formatted with xfs is not able to mount with error : "missing codepage or helper program, or other error".

**What this PR does?**:

Reverting back to ubuntu 19.10 to fix this issue.

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
