### PR TITLE
fix(zfspv): fixing mounting issue with xfs on centos

### DIFF
--- a/buildscripts/zfs-driver/Dockerfile
+++ b/buildscripts/zfs-driver/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:20.04
+FROM ubuntu:19.10
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN apt-get update; exit 0
 RUN apt-get -y install rsyslog libssl-dev xfsprogs ca-certificates

--- a/changelogs/unreleased/179-pawanpraka1
+++ b/changelogs/unreleased/179-pawanpraka1
@@ -1,0 +1,1 @@
+fixing xfs mounting issue on centos with ubuntu 20.04 image


### PR DESCRIPTION
Cherry-pick PR in v0.9.x branch.

We changed the ubuntu docker image to 20.04 in https://github.com/openebs/zfs-localpv/pull/170,
which has issues with formatting the zvol as xfs file system. The filesystem
formatted with xfs is not able to mount with error : "missing codepage or helper program, or other error".

Reverting back to ubuntu 19.10 to fix this issue.

Signed-off-by: Pawan <pawan@mayadata.io>
