### PR TITLE
fix(zfspv): mounting the volume if it is ready

### DIFF
--- a/changelogs/unreleased/184-pawanpraka1
+++ b/changelogs/unreleased/184-pawanpraka1
@@ -1,0 +1,1 @@
+mounting the volume if it is ready

--- a/pkg/zfs/mount.go
+++ b/pkg/zfs/mount.go
@@ -139,8 +139,8 @@ func verifyMountRequest(vol *apis.ZFSVolume, mountpath string) error {
 		vol.Spec.OwnerNodeID != NodeID {
 		return status.Error(codes.Internal, "verifyMount: volume is owned by different node")
 	}
-	if vol.Finalizers == nil {
-		return status.Error(codes.Internal, "verifyMount: volume is not ready, driver has not yet set the finalizer")
+	if vol.Status.State != ZFSStatusReady {
+		return status.Error(codes.Internal, "verifyMount: volume is not ready to be mounted")
 	}
 
 	devicePath, err := GetVolumeDevPath(vol)

--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -370,12 +370,6 @@ func CreateClone(vol *apis.ZFSVolume) error {
 	if vol.Spec.FsType == "btrfs" {
 		return btrfsGenerateUUID(volume)
 	}
-	if vol.Spec.FsType == "btrfs" {
-		return btrfsGenerateUUID(volume)
-	}
-	if vol.Spec.FsType == "btrfs" {
-		return btrfsGenerateUUID(volume)
-	}
 	return nil
 }
 


### PR DESCRIPTION

Signed-off-by: Pawan <pawan@mayadata.io>

**Why is this PR required? What issue does it fix?**:

Instead of checking for the finalizer, checking for the
volume state to be ready is more intuitive before mounting it.

Also removed duplicate if statement for btrfs which was added while resolveing
the merge conflict in https://github.com/openebs/zfs-localpv/pull/175.


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

