### PR TITLE
fix(yaml): removing volumeLifecycleModes from the operator yaml

### DIFF
--- a/changelogs/unreleased/186-pawanpraka1
+++ b/changelogs/unreleased/186-pawanpraka1
@@ -1,0 +1,1 @@
+removing volumeLifecycleModes from the operator yaml

--- a/deploy/operators/centos7/zfs-operator.yaml
+++ b/deploy/operators/centos7/zfs-operator.yaml
@@ -840,8 +840,6 @@ spec:
   # do not require volumeattachment
   attachRequired: false
   podInfoOnMount: false
-  volumeLifecycleModes:
-  - Persistent
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/deploy/operators/centos8/zfs-operator.yaml
+++ b/deploy/operators/centos8/zfs-operator.yaml
@@ -840,8 +840,6 @@ spec:
   # do not require volumeattachment
   attachRequired: false
   podInfoOnMount: false
-  volumeLifecycleModes:
-  - Persistent
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/deploy/yamls/centos7/zfs-driver.yaml
+++ b/deploy/yamls/centos7/zfs-driver.yaml
@@ -10,8 +10,6 @@ spec:
   # do not require volumeattachment
   attachRequired: false
   podInfoOnMount: false
-  volumeLifecycleModes:
-  - Persistent
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/deploy/yamls/centos8/zfs-driver.yaml
+++ b/deploy/yamls/centos8/zfs-driver.yaml
@@ -10,8 +10,6 @@ spec:
   # do not require volumeattachment
   attachRequired: false
   podInfoOnMount: false
-  volumeLifecycleModes:
-  - Persistent
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/deploy/yamls/ubuntu/zfs-driver.yaml
+++ b/deploy/yamls/ubuntu/zfs-driver.yaml
@@ -10,8 +10,6 @@ spec:
   # do not require volumeattachment
   attachRequired: false
   podInfoOnMount: false
-  volumeLifecycleModes:
-  - Persistent
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -840,8 +840,6 @@ spec:
   # do not require volumeattachment
   attachRequired: false
   podInfoOnMount: false
-  volumeLifecycleModes:
-  - Persistent
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1


### PR DESCRIPTION
fixes: https://github.com/openebs/zfs-localpv/issues/163

Signed-off-by: Pawan <pawan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
 
This field was added in Kubernetes 1.16 and it informs Kubernetes about
the volume modes that are supported by the driver. The default is
"Persistent" if it is not used. 

**What this PR does?**:


This operator yaml will not work on k8s 1.14 and 1.15, since the driver supports
those k8s version so no need to mention volumeLifecycleModes in the operator as
the default is "Persistent". We broke this in https://github.com/openebs/zfs-localpv/pull/85.

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

