### PR TITLE
fix(upgrade): Reverting back to old way of checking the volume status

### DIFF
--- a/changelogs/unreleased/196-pawanpraka1
+++ b/changelogs/unreleased/196-pawanpraka1
@@ -1,0 +1,1 @@
+Reverting back to old way of checking the volume status

--- a/pkg/zfs/mount.go
+++ b/pkg/zfs/mount.go
@@ -139,7 +139,7 @@ func verifyMountRequest(vol *apis.ZFSVolume, mountpath string) error {
 		vol.Spec.OwnerNodeID != NodeID {
 		return status.Error(codes.Internal, "verifyMount: volume is owned by different node")
 	}
-	if vol.Status.State != ZFSStatusReady {
+	if vol.Finalizers == nil {
 		return status.Error(codes.Internal, "verifyMount: volume is not ready to be mounted")
 	}
 


### PR DESCRIPTION
Signed-off-by: Pawan <pawan@mayadata.io>


**Why is this PR required? What issue does it fix?**:

few customers are using old version of the driver where
Status field is not present. So mount will fail after the
upgrade to the 0.9.1 or later version.

Reverting back to the checking if finalizer is set to check if
volume is ready to be mounted.

We need to support upgrade for alpha release until we offically announce it that we no longer support upgrade for alpha release.  

Added this in https://github.com/openebs/zfs-localpv/pull/184

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
