### PR TITLE
fix(upgrade): Reverting back to old way of checking the volume status

### DIFF
--- a/changelogs/unreleased/196-pawanpraka1
+++ b/changelogs/unreleased/196-pawanpraka1
@@ -1,0 +1,1 @@
+Reverting back to old way of checking the volume status

--- a/pkg/zfs/mount.go
+++ b/pkg/zfs/mount.go
@@ -139,7 +139,7 @@ func verifyMountRequest(vol *apis.ZFSVolume, mountpath string) error {
 		vol.Spec.OwnerNodeID != NodeID {
 		return status.Error(codes.Internal, "verifyMount: volume is owned by different node")
 	}
-	if vol.Status.State != ZFSStatusReady {
+	if vol.Finalizers == nil {
 		return status.Error(codes.Internal, "verifyMount: volume is not ready to be mounted")
 	}
 


### PR DESCRIPTION
cherry-pick :- https://github.com/openebs/zfs-localpv/pull/196

few customers are using old version of the driver where
Status field is not present. So mount will fail after the
upgrade to the 0.9 or later version.

Reverting back to the checking if finalizer is set to check if
volume is ready to be mounted.

Signed-off-by: Pawan <pawan@mayadata.io>

