### PR TITLE
fix(build): update go version to 1.14.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
   - docker
 language: go
 go:
-  - 1.14.4
+  - 1.14.7
 
 addons:
   apt:

--- a/changelogs/unreleased/201-pawanpraka1
+++ b/changelogs/unreleased/201-pawanpraka1
@@ -1,0 +1,1 @@
+update go version to 1.14.7


### PR DESCRIPTION

Signed-off-by: Pawan <pawan@mayadata.io>

**Why is this PR required? What issue does it fix?**:

CVE-2020-16845 has been reported for go versions earlier to 1.14.7,
this PR upgrades the go version for travis builds.

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

