### PR TITLE
feat(zfspv): mounting the root filesystem to remove the dependency on the Operating system

### DIFF
--- a/changelogs/unreleased/204-pawanpraka1
+++ b/changelogs/unreleased/204-pawanpraka1
@@ -1,0 +1,1 @@
+mounting the root filesystem to remove the dependency on the Operating system

--- a/deploy/yamls/ubuntu/zfs-driver.yaml
+++ b/deploy/yamls/ubuntu/zfs-driver.yaml
@@ -705,7 +705,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: openebs-zfspv-bin
-  namespace: kube-system
+  namespace: kube-system # should be the same namespace where it is getting mounted
 data:
   zfs: |
     #!/bin/sh

--- a/deploy/yamls/ubuntu/zfs-driver.yaml
+++ b/deploy/yamls/ubuntu/zfs-driver.yaml
@@ -701,6 +701,24 @@ roleRef:
 
 ---
 
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: openebs-zfspv-bin
+  namespace: kube-system
+data:
+  zfs: |
+    #!/bin/sh
+    if [ -x /host/sbin/zfs ]; then
+      chroot /host /sbin/zfs "$@"
+    elif [ -x /host/usr/sbin/zfs ]; then
+      chroot /host /usr/sbin/zfs "$@"
+    else
+      chroot /host zfs "$@"
+    fi
+
+---
+
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -777,18 +795,13 @@ spec:
               mountPath: /dev
             - name: encr-keys
               mountPath: /home/keys
-            - name: zfs-bin
+            - name: chroot-zfs
               mountPath: /sbin/zfs
-            - name: libzpool
-              mountPath: /lib/libzpool.so.2
-            - name: libzfscore
-              mountPath: /lib/libzfs_core.so.1
-            - name: libzfs
-              mountPath: /lib/libzfs.so.2
-            - name: libuutil
-              mountPath: /lib/libuutil.so.1
-            - name: libnvpair
-              mountPath: /lib/libnvpair.so.1
+              subPath: zfs
+            - name: host-root
+              mountPath: /host
+              mountPropagation: "HostToContainer"
+              readOnly: true
             - name: pods-mount-dir
               mountPath: /var/lib/kubelet/
               # needed so that any mounts setup inside this container are
@@ -803,30 +816,14 @@ spec:
           hostPath:
             path: /home/keys
             type: DirectoryOrCreate
-        - name: zfs-bin
+        - name: chroot-zfs
+          configMap:
+            defaultMode: 0555
+            name: openebs-zfspv-bin
+        - name: host-root
           hostPath:
-            path: /sbin/zfs
-            type: File
-        - name: libzpool
-          hostPath:
-            path: /lib/libzpool.so.2.0.0
-            type: File
-        - name: libzfscore
-          hostPath:
-            path: /lib/libzfs_core.so.1.0.0
-            type: File
-        - name: libzfs
-          hostPath:
-            path: /lib/libzfs.so.2.0.0
-            type: File
-        - name: libuutil
-          hostPath:
-            path: /lib/libuutil.so.1.0.1
-            type: File
-        - name: libnvpair
-          hostPath:
-            path: /lib/libnvpair.so.1.0.1
-            type: File
+            path: /
+            type: Directory
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry/

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -1535,7 +1535,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: openebs-zfspv-bin
-  namespace: kube-system
+  namespace: kube-system # should be the same namespace where it is getting mounted
 data:
   zfs: |
     #!/bin/sh

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -1531,6 +1531,24 @@ roleRef:
 
 ---
 
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: openebs-zfspv-bin
+  namespace: kube-system
+data:
+  zfs: |
+    #!/bin/sh
+    if [ -x /host/sbin/zfs ]; then
+      chroot /host /sbin/zfs "$@"
+    elif [ -x /host/usr/sbin/zfs ]; then
+      chroot /host /usr/sbin/zfs "$@"
+    else
+      chroot /host zfs "$@"
+    fi
+
+---
+
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -1607,18 +1625,13 @@ spec:
               mountPath: /dev
             - name: encr-keys
               mountPath: /home/keys
-            - name: zfs-bin
+            - name: chroot-zfs
               mountPath: /sbin/zfs
-            - name: libzpool
-              mountPath: /lib/libzpool.so.2
-            - name: libzfscore
-              mountPath: /lib/libzfs_core.so.1
-            - name: libzfs
-              mountPath: /lib/libzfs.so.2
-            - name: libuutil
-              mountPath: /lib/libuutil.so.1
-            - name: libnvpair
-              mountPath: /lib/libnvpair.so.1
+              subPath: zfs
+            - name: host-root
+              mountPath: /host
+              mountPropagation: "HostToContainer"
+              readOnly: true
             - name: pods-mount-dir
               mountPath: /var/lib/kubelet/
               # needed so that any mounts setup inside this container are
@@ -1633,30 +1646,14 @@ spec:
           hostPath:
             path: /home/keys
             type: DirectoryOrCreate
-        - name: zfs-bin
+        - name: chroot-zfs
+          configMap:
+            defaultMode: 0555
+            name: openebs-zfspv-bin
+        - name: host-root
           hostPath:
-            path: /sbin/zfs
-            type: File
-        - name: libzpool
-          hostPath:
-            path: /lib/libzpool.so.2.0.0
-            type: File
-        - name: libzfscore
-          hostPath:
-            path: /lib/libzfs_core.so.1.0.0
-            type: File
-        - name: libzfs
-          hostPath:
-            path: /lib/libzfs.so.2.0.0
-            type: File
-        - name: libuutil
-          hostPath:
-            path: /lib/libuutil.so.1.0.1
-            type: File
-        - name: libnvpair
-          hostPath:
-            path: /lib/libnvpair.so.1.0.1
-            type: File
+            path: /
+            type: Directory
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry/


### PR DESCRIPTION
fixes : https://github.com/openebs/zfs-localpv/issues/202 and probably https://github.com/openebs/zfs-localpv/issues/72 also.

Signed-off-by: Pawan <pawan@mayadata.io>

**Why is this PR required? What issue does it fix?**:

We are mounting the individual library to run the zfs
binary inside the ZFS-LocalPV daemonset. The problem with this
is each OS has different sets of libraries. We need to have different
Operator yamls for different OS versions.

**What this PR does?**:

Here we are mounting the root directory inside the ZFS-LocalPV daemonset Pod
which does chroot to this path and run the command. As all the libraries will
be available which are present on the host inside the Pod, so we don't need to mount each
library here and also it will work for all the Operating systems.


**Any additional information for your reviewer?** :

To be on the safe side, we are mounting the host's root directory
as Readonly filesystem. Will cleanup the centos yamls once we have migrated to this in e2e.

Thanks @jlcox1970 for helping me verify this change on CentOS 8.

**Checklist:**
- [x] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
