### PR TITLE
feat(backup,restore): adding validation for backup and restore

### DIFF
--- a/changelogs/unreleased/221-pawanpraka1
+++ b/changelogs/unreleased/221-pawanpraka1
@@ -1,0 +1,1 @@
+adding validation for backup and restore

--- a/deploy/yamls/zfsbackup-crd.yaml
+++ b/deploy/yamls/zfsbackup-crd.yaml
@@ -65,6 +65,7 @@ spec:
             backupDest:
               description: BackupDest is the remote address for backup transfer
               minLength: 1
+              pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
               type: string
             ownerNodeID:
               description: OwnerNodeID is a name of the nodes where the source volume
@@ -90,6 +91,13 @@ spec:
           type: object
         status:
           description: ZFSBackupStatus is to hold status of backup
+          enum:
+          - Init
+          - Done
+          - Failed
+          - Pending
+          - InProgress
+          - Invalid
           type: string
       required:
       - spec

--- a/deploy/yamls/zfsrestore-crd.yaml
+++ b/deploy/yamls/zfsrestore-crd.yaml
@@ -55,6 +55,7 @@ spec:
               description: it can be ip:port in case of restore from remote or volumeName
                 in case of local restore
               minLength: 1
+              pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
               type: string
             volumeName:
               description: volume name to where restore has to be performed
@@ -67,6 +68,13 @@ spec:
           type: object
         status:
           description: ZFSRestoreStatus is to hold result of action.
+          enum:
+          - Init
+          - Done
+          - Failed
+          - Pending
+          - InProgress
+          - Invalid
           type: string
       required:
       - spec

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -895,6 +895,7 @@ spec:
             backupDest:
               description: BackupDest is the remote address for backup transfer
               minLength: 1
+              pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
               type: string
             ownerNodeID:
               description: OwnerNodeID is a name of the nodes where the source volume
@@ -920,6 +921,13 @@ spec:
           type: object
         status:
           description: ZFSBackupStatus is to hold status of backup
+          enum:
+          - Init
+          - Done
+          - Failed
+          - Pending
+          - InProgress
+          - Invalid
           type: string
       required:
       - spec
@@ -993,6 +1001,7 @@ spec:
               description: it can be ip:port in case of restore from remote or volumeName
                 in case of local restore
               minLength: 1
+              pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
               type: string
             volumeName:
               description: volume name to where restore has to be performed
@@ -1005,6 +1014,13 @@ spec:
           type: object
         status:
           description: ZFSRestoreStatus is to hold result of action.
+          enum:
+          - Init
+          - Done
+          - Failed
+          - Pending
+          - InProgress
+          - Invalid
           type: string
       required:
       - spec

--- a/pkg/apis/openebs.io/zfs/v1/zfsbackup.go
+++ b/pkg/apis/openebs.io/zfs/v1/zfsbackup.go
@@ -34,8 +34,10 @@ import (
 type ZFSBackup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              ZFSBackupSpec   `json:"spec"`
-	Status            ZFSBackupStatus `json:"status"`
+	Spec              ZFSBackupSpec `json:"spec"`
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Enum=Init;Done;Failed;Pending;InProgress;Invalid
+	Status ZFSBackupStatus `json:"status"`
 }
 
 // ZFSBackupSpec is the spec for a ZFSBackup resource
@@ -61,6 +63,7 @@ type ZFSBackupSpec struct {
 	// BackupDest is the remote address for backup transfer
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Pattern="^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$"
 	BackupDest string `json:"backupDest"`
 }
 
@@ -69,9 +72,6 @@ type ZFSBackupStatus string
 
 // Status written onto ZFSBackup objects.
 const (
-	// BKPZFSStatusEmpty ensures the create operation is to be done, if import fails.
-	BKPZFSStatusEmpty ZFSBackupStatus = ""
-
 	// BKPZFSStatusDone , backup is completed.
 	BKPZFSStatusDone ZFSBackupStatus = "Done"
 

--- a/pkg/apis/openebs.io/zfs/v1/zfsrestore.go
+++ b/pkg/apis/openebs.io/zfs/v1/zfsrestore.go
@@ -29,7 +29,9 @@ type ZFSRestore struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"` // set name to restore name + volume name + something like csp tag
 	Spec              ZFSRestoreSpec              `json:"spec"`
-	Status            ZFSRestoreStatus            `json:"status"`
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Enum=Init;Done;Failed;Pending;InProgress;Invalid
+	Status ZFSRestoreStatus `json:"status"`
 }
 
 // ZFSRestoreSpec is the spec for a ZFSRestore resource
@@ -46,6 +48,7 @@ type ZFSRestoreSpec struct {
 	// it can be ip:port in case of restore from remote or volumeName in case of local restore
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Pattern="^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$"
 	RestoreSrc string `json:"restoreSrc"`
 }
 
@@ -54,9 +57,6 @@ type ZFSRestoreStatus string
 
 // Status written onto CStrorRestore object.
 const (
-	// RSTZFSStatusEmpty ensures the create operation is to be done, if import fails.
-	RSTZFSStatusEmpty ZFSRestoreStatus = ""
-
 	// RSTZFSStatusDone , restore operation is completed.
 	RSTZFSStatusDone ZFSRestoreStatus = "Done"
 


### PR DESCRIPTION

Signed-off-by: Pawan <pawan@mayadata.io>

**Why is this PR required? What issue does it fix?**:

Added a schema validation for backup and restore CR. Also validating
the server address in the backup/restore controller.

**What this PR does?**:

Validating the server address as :

^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$

which is :

<any number>.<any number>.<any number>.<any number>:<any number>

Here we are validating just the format of the IP, not validating that IP should be
correct which  will be little more complex. In any case if IP is not correct,
the zfs send will fail, so no need to do complex validation to validate the
correct IP and port.

**Does this PR require any upgrade changes?**:

NA


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
