### PR TITLE
feat(upgrade): support parallel/faster upgrades for node daemonset

### DIFF
--- a/changelogs/unreleased/230-pawanpraka1
+++ b/changelogs/unreleased/230-pawanpraka1
@@ -1,0 +1,1 @@
+support parallel/faster upgrades for node daemonset

--- a/deploy/yamls/zfs-driver.yaml
+++ b/deploy/yamls/zfs-driver.yaml
@@ -501,6 +501,9 @@ apiVersion: apps/v1
 metadata:
   name: openebs-zfs-controller
   namespace: kube-system
+  labels:
+    openebs.io/component-name: openebs-zfs-controller
+    openebs.io/version: ci
 spec:
   selector:
     matchLabels:
@@ -513,6 +516,8 @@ spec:
       labels:
         app: openebs-zfs-controller
         role: openebs-zfs
+        openebs.io/component-name: openebs-zfs-controller
+        openebs.io/version: ci
     spec:
       affinity:
         podAntiAffinity:
@@ -724,15 +729,24 @@ apiVersion: apps/v1
 metadata:
   name: openebs-zfs-node
   namespace: kube-system
+  labels:
+    openebs.io/component-name: openebs-zfs-node
+    openebs.io/version: ci
 spec:
   selector:
     matchLabels:
       app: openebs-zfs-node
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 100%
+    type: RollingUpdate
   template:
     metadata:
       labels:
         app: openebs-zfs-node
         role: openebs-zfs
+        openebs.io/component-name: openebs-zfs-node
+        openebs.io/version: ci
     spec:
       priorityClassName: system-node-critical
       serviceAccount: openebs-zfs-node-sa
@@ -768,8 +782,6 @@ spec:
         - name: openebs-zfs-plugin
           securityContext:
             privileged: true
-            capabilities:
-              add: ["CAP_MKNOD", "CAP_SYS_ADMIN", "SYS_ADMIN"]
             allowPrivilegeEscalation: true
           image: quay.io/openebs/zfs-driver:ci
           imagePullPolicy: IfNotPresent

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -1540,6 +1540,9 @@ apiVersion: apps/v1
 metadata:
   name: openebs-zfs-controller
   namespace: kube-system
+  labels:
+    openebs.io/component-name: openebs-zfs-controller
+    openebs.io/version: ci
 spec:
   selector:
     matchLabels:
@@ -1552,6 +1555,8 @@ spec:
       labels:
         app: openebs-zfs-controller
         role: openebs-zfs
+        openebs.io/component-name: openebs-zfs-controller
+        openebs.io/version: ci
     spec:
       affinity:
         podAntiAffinity:
@@ -1763,15 +1768,24 @@ apiVersion: apps/v1
 metadata:
   name: openebs-zfs-node
   namespace: kube-system
+  labels:
+    openebs.io/component-name: openebs-zfs-node
+    openebs.io/version: ci
 spec:
   selector:
     matchLabels:
       app: openebs-zfs-node
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 100%
+    type: RollingUpdate
   template:
     metadata:
       labels:
         app: openebs-zfs-node
         role: openebs-zfs
+        openebs.io/component-name: openebs-zfs-node
+        openebs.io/version: ci
     spec:
       priorityClassName: system-node-critical
       serviceAccount: openebs-zfs-node-sa
@@ -1807,8 +1821,6 @@ spec:
         - name: openebs-zfs-plugin
           securityContext:
             privileged: true
-            capabilities:
-              add: ["CAP_MKNOD", "CAP_SYS_ADMIN", "SYS_ADMIN"]
             allowPrivilegeEscalation: true
           image: quay.io/openebs/zfs-driver:ci
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Signed-off-by: Pawan <pawan@mayadata.io>


**Why is this PR required? What issue does it fix?**:

For ZFSPV, all the node daemonset pods can go into the terminating state at
the same time since it does not need any minimum availability of those pods.

**What this PR does?**:

Changing maxUnavailable to 100% so that K8s can upgrade all the daemonset
pods parallelly. Also added labels to all the pods.

