### PR TITLE
feat(clone): add support for creating the Clone from volume as datasource

### DIFF
--- a/changelogs/unreleased/234-pawanpraka1
+++ b/changelogs/unreleased/234-pawanpraka1
@@ -1,0 +1,1 @@
+add support for creating the Clone from volume as datasource

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -191,7 +191,7 @@ func CreateVolClone(req *csi.CreateVolumeRequest, srcVol string) (string, error)
 
 	selected := vol.Spec.OwnerNodeID
 
-	labels := map[string]string{zfs.ZFSVolKey: vol.Name}
+	labels := map[string]string{zfs.ZFSSrcVolKey: vol.Name}
 
 	// create the clone from the source volume
 

--- a/pkg/zfs/volume.go
+++ b/pkg/zfs/volume.go
@@ -39,6 +39,8 @@ const (
 	ZFSFinalizer string = "zfs.openebs.io/finalizer"
 	// ZFSVolKey for the ZfsSnapshot CR to store Persistence Volume name
 	ZFSVolKey string = "openebs.io/persistent-volume"
+	// ZFSSrcVolKey key for the source Volume name
+	ZFSSrcVolKey string = "openebs.io/source-volume"
 	// PoolNameKey is key for ZFS pool name
 	PoolNameKey string = "openebs.io/poolname"
 	// ZFSNodeKey will be used to insert Label in ZfsVolume CR

--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -401,7 +401,7 @@ func CreateVolume(vol *apis.ZFSVolume) error {
 func CreateClone(vol *apis.ZFSVolume) error {
 	volume := vol.Spec.PoolName + "/" + vol.Name
 
-	if srcVol, ok := vol.Labels[ZFSVolKey]; ok {
+	if srcVol, ok := vol.Labels[ZFSSrcVolKey]; ok {
 		// datasource is volume, create the snapshot first
 		snap := &apis.ZFSSnapshot{}
 		snap.Name = vol.Name // use volname as snapname
@@ -601,7 +601,7 @@ func DestroyVolume(vol *apis.ZFSVolume) error {
 		return err
 	}
 
-	if srcVol, ok := vol.Labels[ZFSVolKey]; ok {
+	if srcVol, ok := vol.Labels[ZFSSrcVolKey]; ok {
 		// datasource is volume, delete the dependent snapshot
 		snap := &apis.ZFSSnapshot{}
 		snap.Name = vol.Name // snapname is same as volname

--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -401,6 +401,26 @@ func CreateVolume(vol *apis.ZFSVolume) error {
 func CreateClone(vol *apis.ZFSVolume) error {
 	volume := vol.Spec.PoolName + "/" + vol.Name
 
+	if srcVol, ok := vol.Labels[ZFSVolKey]; ok {
+		// datasource is volume, create the snapshot first
+		snap := &apis.ZFSSnapshot{}
+		snap.Name = vol.Name // use volname as snapname
+		snap.Spec = vol.Spec
+		// add src vol name
+		snap.Labels = map[string]string{ZFSVolKey: srcVol}
+
+		klog.Infof("creating snapshot %s@%s for the clone %s", srcVol, snap.Name, volume)
+
+		err := CreateSnapshot(snap)
+
+		if err != nil {
+			klog.Errorf(
+				"zfs: could not create snapshot for the clone vol %s snap %s err %v", volume, snap.Name, err,
+			)
+			return err
+		}
+	}
+
 	if err := getVolume(volume); err != nil {
 		var args []string
 		args = buildCloneCreateArgs(vol)
@@ -580,6 +600,27 @@ func DestroyVolume(vol *apis.ZFSVolume) error {
 		)
 		return err
 	}
+
+	if srcVol, ok := vol.Labels[ZFSVolKey]; ok {
+		// datasource is volume, delete the dependent snapshot
+		snap := &apis.ZFSSnapshot{}
+		snap.Name = vol.Name // snapname is same as volname
+		snap.Spec = vol.Spec
+		// add src vol name
+		snap.Labels = map[string]string{ZFSVolKey: srcVol}
+
+		klog.Infof("destroying snapshot %s@%s for the clone %s", srcVol, snap.Name, volume)
+
+		err := DestroySnapshot(snap)
+
+		if err != nil {
+			// no need to reconcile as volume has already been deleted
+			klog.Errorf(
+				"zfs: could not destroy snapshot for the clone vol %s snap %s err %v", volume, snap.Name, err,
+			)
+		}
+	}
+
 	klog.Infof("destroyed volume %s", volume)
 
 	return nil


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

 add support for creating the Clone from volume as datasource

**What this PR does?**:

We can now create the Clone from pvc directly

```
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: pvc-clone
spec:
  storageClassName: openebs-clone
  dataSource:
    name: pvc-vol
    kind: PersistentVolumeClaim
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 4Gi 
```
The ZFS_LocalPV driver will create one internal snapshot of the name
same as the new volume name and will create a clone out of it. Also,
while destroying the volume the driver will take care of deleting
the created snapshot for the clone.



**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
