### PR TITLE
feat(image): moving to ubuntu bionic(18.04 LTS) docker image

### DIFF
--- a/buildscripts/zfs-driver/Dockerfile
+++ b/buildscripts/zfs-driver/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:19.10
+FROM ubuntu:18.04
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN apt-get update; exit 0
 RUN apt-get -y install rsyslog libssl-dev xfsprogs ca-certificates


### PR DESCRIPTION
build is failing on ubuntu 19.10 as the ca-certificate package has been obsolete. Switching to 18.04 as now since we are doing root mount, we can use any ubuntu image.

Signed-off-by: Pawan <pawan@mayadata.io>
