### PR TITLE
feat(schd): adding capacity weighted scheduler

### DIFF
--- a/changelogs/unreleased/266-pawanpraka1
+++ b/changelogs/unreleased/266-pawanpraka1
@@ -1,0 +1,1 @@
+adding capacity weighted scheduler


### PR DESCRIPTION
The ZFS Driver will use capacity scheduler to pick a node
which has less capacity occupied by the volumes. Making this
as default scheduler as it is better than the volume count based
scheduling. We can use below storageclass to specify the scheduler
```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
 name: openebs-zfspv
allowVolumeExpansion: true
parameters:
 scheduler: "CapacityWeighted"
 poolname: "zfspv-pool"
provisioner: zfs.csi.openebs.io
```

Please Note that after the upgrade, there will be a change in the behavior.
If we are not using `scheduler` parameter in the storage class then after
the upgrade ZFS Driver will pick the node based on volume capacity weight
instead of the count.

fixes: https://github.com/openebs/zfs-localpv/issues/215

**Explanation**

ZFS Driver does not control the zfs pool, by checking volumes capacity on the node for a particular pool can get us close to balancing the volumes across the nodes. So let us say that we have three pools on 3 different nodes node1, node2 and node3, with initial volumes provisioned like this =>
```
node       -     node1    -     node2       -     node3 
volume     -     vol1     -     vol2        -    vol3
size       -     100G     -     5G          -    50G
```
Now, if we want to provision a volume a new volume, the driver will pick the node2 for provisioning the volume. It will keep on picking the node2 until the volume nodes are equally distributed capacity wise.


Signed-off-by: Pawan <pawan@mayadata.io>
