### PR TITLE
refact(charts): add pod security policy for zfslocalpv charts

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: zfs-localpv
 description: CSI Driver for dynamic provisioning of ZFS Persistent Local Volumes.
-version: 1.3.0
+version: 1.3.1
 appVersion: 1.3.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -118,6 +118,7 @@ The following table lists the configurable parameters of the OpenEBS ZFS Localpv
 | `zfsController.nodeSelector`| Nodeselector for zfs localpv controller statefulset pods| `""`|
 | `zfsController.tolerations` | zfs localpv controller statefulset's pod toleration values | `""`|
 | `zfsController.securityContext` | Seurity context for zfs localpv controller statefulset container | `""`|
+| `rbac.pspEnabled` | Enable PodSecurityPolicy | `false` |
 | `serviceAccount.zfsNode.create` | Create a service account for zfsnode or not| `true`|
 | `serviceAccount.zfsNode.name` | Name for the zfsnode service account| `openebs-zfs-node-sa`|
 | `serviceAccount.zfsController.create` | Create a service account for zfs localpv controller or not| `true`|

--- a/deploy/helm/charts/templates/psp.yaml
+++ b/deploy/helm/charts/templates/psp.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "zfslocalpv.fullname" . }}-psp
+  {{- with .Values.zfsNode.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "zfslocalpv.zfsNode.labels" . | nindent 4 }}
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities: ['*']
+  volumes: ['*']
+  hostNetwork: true
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+{{- end }}

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -7,6 +7,11 @@ release:
 imagePullSecrets:
 # - name: "image-pull-secret"
 
+
+rbac:
+  # rbac.pspEnabled: `true` if PodSecurityPolicy resources should be created
+  pspEnabled: false
+
 # zfsNode contains the configurables for
 # the zfs node daemonset
 zfsNode:


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

**Why is this PR required? What issue does it fix?**:
Add Pod Security policy for zfs localpv charts, disable by default
