### PR TITLE
chore(k8s): updated storage and apiextension version to v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ bootstrap: controller-gen
 
 .PHONY: controller-gen
 controller-gen:
-	TMP_DIR=$(shell mktemp -d) && cd $$TMP_DIR && go mod init tmp && go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.8 && rm -rf $$TMP_DIR;
+	TMP_DIR=$(shell mktemp -d) && cd $$TMP_DIR && go mod init tmp && go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.0 && rm -rf $$TMP_DIR;
 
 # SRC_PKG is the path of code files
 SRC_PKG := github.com/openebs/zfs-localpv/pkg

--- a/changelogs/unreleased/299-shubham14bajpai
+++ b/changelogs/unreleased/299-shubham14bajpai
@@ -1,0 +1,1 @@
+With k8s v1.22 the v1beta1 for various resources will no longer be supported. Updating the storage and apiexention version to v1 for better support.

--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: zfs-localpv
 description: CSI Driver for dynamic provisioning of ZFS Persistent Local Volumes.
-version: 1.5.0
+version: 1.5.1
 appVersion: 1.5.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/

--- a/deploy/helm/charts/crds/zfsbackup.yaml
+++ b/deploy/helm/charts/crds/zfsbackup.yaml
@@ -11,27 +11,14 @@
 # to generate the CRD definition
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.8
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: zfsbackups.zfs.openebs.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.prevSnapName
-    description: Previous snapshot for backup
-    name: PrevSnap
-    type: string
-  - JSONPath: .status
-    description: Backup status
-    name: Status
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of the volume
-    name: Age
-    type: date
   group: zfs.openebs.io
   names:
     kind: ZFSBackup
@@ -40,74 +27,87 @@ spec:
     shortNames:
     - zb
     singular: zfsbackup
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: ZFSBackup describes a zfs backup resource created as a custom resource
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ZFSBackupSpec is the spec for a ZFSBackup resource
-          properties:
-            backupDest:
-              description: BackupDest is the remote address for backup transfer
-              minLength: 1
-              pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
-              type: string
-            ownerNodeID:
-              description: OwnerNodeID is a name of the nodes where the source volume
-                is
-              minLength: 1
-              type: string
-            prevSnapName:
-              description: PrevSnapName is the last completed-backup's snapshot name
-              type: string
-            snapName:
-              description: SnapName is the snapshot name for backup
-              minLength: 1
-              type: string
-            volumeName:
-              description: VolumeName is a name of the volume for which this backup
-                is destined
-              minLength: 1
-              type: string
-          required:
-          - backupDest
-          - ownerNodeID
-          - volumeName
-          type: object
-        status:
-          description: ZFSBackupStatus is to hold status of backup
-          enum:
-          - Init
-          - Done
-          - Failed
-          - Pending
-          - InProgress
-          - Invalid
-          type: string
-      required:
-      - spec
-      - status
-      type: object
-  version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Previous snapshot for backup
+      jsonPath: .spec.prevSnapName
+      name: PrevSnap
+      type: string
+    - description: Backup status
+      jsonPath: .status
+      name: Status
+      type: string
+    - description: Age of the volume
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ZFSBackup describes a zfs backup resource created as a custom
+          resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ZFSBackupSpec is the spec for a ZFSBackup resource
+            properties:
+              backupDest:
+                description: BackupDest is the remote address for backup transfer
+                minLength: 1
+                pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is a name of the nodes where the source volume
+                  is
+                minLength: 1
+                type: string
+              prevSnapName:
+                description: PrevSnapName is the last completed-backup's snapshot
+                  name
+                type: string
+              snapName:
+                description: SnapName is the snapshot name for backup
+                minLength: 1
+                type: string
+              volumeName:
+                description: VolumeName is a name of the volume for which this backup
+                  is destined
+                minLength: 1
+                type: string
+            required:
+            - backupDest
+            - ownerNodeID
+            - volumeName
+            type: object
+          status:
+            description: ZFSBackupStatus is to hold status of backup
+            enum:
+            - Init
+            - Done
+            - Failed
+            - Pending
+            - InProgress
+            - Invalid
+            type: string
+        required:
+        - spec
+        - status
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/deploy/helm/charts/crds/zfsrestore.yaml
+++ b/deploy/helm/charts/crds/zfsrestore.yaml
@@ -11,11 +11,11 @@
 # to generate the CRD definition
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.8
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: zfsrestores.zfs.openebs.io
 spec:
@@ -25,209 +25,209 @@ spec:
     listKind: ZFSRestoreList
     plural: zfsrestores
     singular: zfsrestore
-  preserveUnknownFields: false
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: ZFSRestore describes a cstor restore resource created as a custom
-        resource
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ZFSRestoreSpec is the spec for a ZFSRestore resource
-          properties:
-            ownerNodeID:
-              description: owner node name where restore volume is present
-              minLength: 1
-              type: string
-            restoreSrc:
-              description: it can be ip:port in case of restore from remote or volumeName
-                in case of local restore
-              minLength: 1
-              pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
-              type: string
-            volumeName:
-              description: volume name to where restore has to be performed
-              minLength: 1
-              type: string
-          required:
-          - ownerNodeID
-          - restoreSrc
-          - volumeName
-          type: object
-        status:
-          description: ZFSRestoreStatus is to hold result of action.
-          enum:
-          - Init
-          - Done
-          - Failed
-          - Pending
-          - InProgress
-          - Invalid
-          type: string
-        volSpec:
-          description: VolumeInfo defines ZFS volume parameters for all modes in which
-            ZFS volumes can be created like - ZFS volume with filesystem, ZFS Volume
-            exposed as zfs or ZFS volume exposed as raw block device. Some of the
-            parameters can be only set during creation time (as specified in the details
-            of the parameter), and a few are editable. In case of Cloned volumes,
-            the parameters are assigned the same values as the source volume.
-          properties:
-            capacity:
-              description: Capacity of the volume
-              minLength: 1
-              type: string
-            compression:
-              description: 'Compression specifies the block-level compression algorithm
-                to be applied to the ZFS Volume. The value "on" indicates ZFS to use
-                the default compression algorithm. The default compression algorithm
-                used by ZFS will be either lzjb or, if the lz4_compress feature is
-                enabled, lz4. Compression property can be edited after the volume
-                has been created. The change will only be applied to the newly-written
-                data. For instance, if the Volume was created with "off" and the next
-                day the compression was modified to "on", the data written prior to
-                setting "on" will not be compressed. Default Value: off.'
-              pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
-              type: string
-            dedup:
-              description: 'Deduplication is the process for removing redundant data
-                at the block level, reducing the total amount of data stored. If a
-                file system has the dedup property enabled, duplicate data blocks
-                are removed synchronously. The result is that only unique data is
-                stored and common components are shared among files. Deduplication
-                can consume significant processing power (CPU) and memory as well
-                as generate additional disk IO. Before creating a pool with deduplication
-                enabled, ensure that you have planned your hardware requirements appropriately
-                and implemented appropriate recovery practices, such as regular backups.
-                As an alternative to deduplication consider using compression=lz4,
-                as a less resource-intensive alternative. should be enabled on the
-                zvol. Dedup property can be edited after the volume has been created.
-                Default Value: off.'
-              enum:
-              - "on"
-              - "off"
-              type: string
-            encryption:
-              description: 'Enabling the encryption feature allows for the creation
-                of encrypted filesystems and volumes. ZFS will encrypt file and zvol
-                data, file attributes, ACLs, permission bits, directory listings,
-                FUID mappings, and userused / groupused data. ZFS will not encrypt
-                metadata related to the pool structure, including dataset and snapshot
-                names, dataset hierarchy, properties, file size, file holes, and deduplication
-                tables (though the deduplicated data itself is encrypted). Default
-                Value: off.'
-              pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
-              type: string
-            fsType:
-              description: 'FsType specifies filesystem type for the zfs volume/dataset.
-                If FsType is provided as "zfs", then the driver will create a ZFS
-                dataset, formatting is not required as underlying filesystem is ZFS
-                anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver will
-                create a ZVOL and format the volume accordingly. FsType can not be
-                modified once volume has been provisioned. Default Value: ext4.'
-              type: string
-            keyformat:
-              description: KeyFormat specifies format of the encryption key The supported
-                KeyFormats are passphrase, raw, hex.
-              enum:
-              - passphrase
-              - raw
-              - hex
-              type: string
-            keylocation:
-              description: KeyLocation is the location of key for the encryption
-              type: string
-            ownerNodeID:
-              description: OwnerNodeID is the Node ID where the ZPOOL is running which
-                is where the volume has been provisioned. OwnerNodeID can not be edited
-                after the volume has been provisioned.
-              minLength: 1
-              type: string
-            poolName:
-              description: poolName specifies the name of the pool where the volume
-                has been created. PoolName can not be edited after the volume has
-                been provisioned.
-              minLength: 1
-              type: string
-            recordsize:
-              description: 'Specifies a suggested block size for files in the file
-                system. The size specified must be a power of two greater than or
-                equal to 512 and less than or equal to 128 Kbytes. RecordSize property
-                can be edited after the volume has been created. Changing the file
-                system''s recordsize affects only files created afterward; existing
-                files are unaffected. Default Value: 128k.'
-              minLength: 1
-              type: string
-            shared:
-              description: Shared specifies whether the volume can be shared among
-                multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
-                will not allow the volumes to be mounted by more than one pods.
-              enum:
-              - "yes"
-              - "no"
-              type: string
-            snapname:
-              description: SnapName specifies the name of the snapshot where the volume
-                has been cloned from. Snapname can not be edited after the volume
-                has been provisioned.
-              type: string
-            thinProvision:
-              description: 'ThinProvision describes whether space reservation for
-                the source volume is required or not. The value "yes" indicates that
-                volume should be thin provisioned and "no" means thick provisioning
-                of the volume. If thinProvision is set to "yes" then volume can be
-                provisioned even if the ZPOOL does not have the enough capacity. If
-                thinProvision is set to "no" then volume can be provisioned only if
-                the ZPOOL has enough capacity and capacity required by volume can
-                be reserved. ThinProvision can not be modified once volume has been
-                provisioned. Default Value: no.'
-              enum:
-              - "yes"
-              - "no"
-              type: string
-            volblocksize:
-              description: 'VolBlockSize specifies the block size for the zvol. The
-                volsize can only be set to a multiple of volblocksize, and cannot
-                be zero. VolBlockSize can not be edited after the volume has been
-                provisioned. Default Value: 8k.'
-              minLength: 1
-              type: string
-            volumeType:
-              description: volumeType determines whether the volume is of type "DATASET"
-                or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
-                of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
-                is mentioned as fstype in the storageclass, then a volume of type
-                zvol will be created, which will be further formatted as the fstype
-                provided in the storageclass. VolumeType can not be modified once
-                volume has been provisioned.
-              enum:
-              - ZVOL
-              - DATASET
-              type: string
-          required:
-          - capacity
-          - ownerNodeID
-          - poolName
-          - volumeType
-          type: object
-      required:
-      - spec
-      - status
-      type: object
-  version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ZFSRestore describes a cstor restore resource created as a custom
+          resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ZFSRestoreSpec is the spec for a ZFSRestore resource
+            properties:
+              ownerNodeID:
+                description: owner node name where restore volume is present
+                minLength: 1
+                type: string
+              restoreSrc:
+                description: it can be ip:port in case of restore from remote or volumeName
+                  in case of local restore
+                minLength: 1
+                pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
+                type: string
+              volumeName:
+                description: volume name to where restore has to be performed
+                minLength: 1
+                type: string
+            required:
+            - ownerNodeID
+            - restoreSrc
+            - volumeName
+            type: object
+          status:
+            description: ZFSRestoreStatus is to hold result of action.
+            enum:
+            - Init
+            - Done
+            - Failed
+            - Pending
+            - InProgress
+            - Invalid
+            type: string
+          volSpec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
+                  to be applied to the ZFS Volume. The value "on" indicates ZFS to
+                  use the default compression algorithm. The default compression algorithm
+                  used by ZFS will be either lzjb or, if the lz4_compress feature
+                  is enabled, lz4. Compression property can be edited after the volume
+                  has been created. The change will only be applied to the newly-written
+                  data. For instance, if the Volume was created with "off" and the
+                  next day the compression was modified to "on", the data written
+                  prior to setting "on" will not be compressed. Default Value: off.'
+                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
+                  data at the block level, reducing the total amount of data stored.
+                  If a file system has the dedup property enabled, duplicate data
+                  blocks are removed synchronously. The result is that only unique
+                  data is stored and common components are shared among files. Deduplication
+                  can consume significant processing power (CPU) and memory as well
+                  as generate additional disk IO. Before creating a pool with deduplication
+                  enabled, ensure that you have planned your hardware requirements
+                  appropriately and implemented appropriate recovery practices, such
+                  as regular backups. As an alternative to deduplication consider
+                  using compression=lz4, as a less resource-intensive alternative.
+                  should be enabled on the zvol. Dedup property can be edited after
+                  the volume has been created. Default Value: off.'
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
+                  of encrypted filesystems and volumes. ZFS will encrypt file and
+                  zvol data, file attributes, ACLs, permission bits, directory listings,
+                  FUID mappings, and userused / groupused data. ZFS will not encrypt
+                  metadata related to the pool structure, including dataset and snapshot
+                  names, dataset hierarchy, properties, file size, file holes, and
+                  deduplication tables (though the deduplicated data itself is encrypted).
+                  Default Value: off.'
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  If FsType is provided as "zfs", then the driver will create a ZFS
+                  dataset, formatting is not required as underlying filesystem is
+                  ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
+                  will create a ZVOL and format the volume accordingly. FsType can
+                  not be modified once volume has been provisioned. Default Value:
+                  ext4.'
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
+                  system. The size specified must be a power of two greater than or
+                  equal to 512 and less than or equal to 128 Kbytes. RecordSize property
+                  can be edited after the volume has been created. Changing the file
+                  system''s recordsize affects only files created afterward; existing
+                  files are unaffected. Default Value: 128k.'
+                minLength: 1
+                type: string
+              shared:
+                description: Shared specifies whether the volume can be shared among
+                  multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
+                  will not allow the volumes to be mounted by more than one pods.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
+                  the source volume is required or not. The value "yes" indicates
+                  that volume should be thin provisioned and "no" means thick provisioning
+                  of the volume. If thinProvision is set to "yes" then volume can
+                  be provisioned even if the ZPOOL does not have the enough capacity.
+                  If thinProvision is set to "no" then volume can be provisioned only
+                  if the ZPOOL has enough capacity and capacity required by volume
+                  can be reserved. ThinProvision can not be modified once volume has
+                  been provisioned. Default Value: no.'
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
+                  The volsize can only be set to a multiple of volblocksize, and cannot
+                  be zero. VolBlockSize can not be edited after the volume has been
+                  provisioned. Default Value: 8k.'
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+        required:
+        - spec
+        - status
+        type: object
     served: true
     storage: true
 status:

--- a/deploy/helm/charts/crds/zfssnapshot.yaml
+++ b/deploy/helm/charts/crds/zfssnapshot.yaml
@@ -11,11 +11,11 @@
 # to generate the CRD definition
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.8
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: zfssnapshots.zfs.openebs.io
 spec:
@@ -27,9 +27,7 @@ spec:
     shortNames:
     - zfssnap
     singular: zfssnapshot
-  preserveUnknownFields: false
   scope: Namespaced
-  version: v1
   versions:
   - name: v1
     schema:

--- a/deploy/helm/charts/crds/zfsvolume.yaml
+++ b/deploy/helm/charts/crds/zfsvolume.yaml
@@ -11,39 +11,14 @@
 # to generate the CRD definition
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.8
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: zfsvolumes.zfs.openebs.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.poolName
-    description: ZFS Pool where the volume is created
-    name: ZPool
-    type: string
-  - JSONPath: .spec.ownerNodeID
-    description: Node where the volume is created
-    name: Node
-    type: string
-  - JSONPath: .spec.capacity
-    description: Size of the volume
-    name: Size
-    type: string
-  - JSONPath: .status.state
-    description: Status of the volume
-    name: Status
-    type: string
-  - JSONPath: .spec.fsType
-    description: filesystem created on the volume
-    name: Filesystem
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of the volume
-    name: Age
-    type: date
   group: zfs.openebs.io
   names:
     kind: ZFSVolume
@@ -53,12 +28,34 @@ spec:
     - zfsvol
     - zv
     singular: zfsvolume
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: ZFS Pool where the volume is created
+      jsonPath: .spec.poolName
+      name: ZPool
+      type: string
+    - description: Node where the volume is created
+      jsonPath: .spec.ownerNodeID
+      name: Node
+      type: string
+    - description: Size of the volume
+      jsonPath: .spec.capacity
+      name: Size
+      type: string
+    - description: Status of the volume
+      jsonPath: .status.state
+      name: Status
+      type: string
+    - description: filesystem created on the volume
+      jsonPath: .spec.fsType
+      name: Filesystem
+      type: string
+    - description: Age of the volume
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: ZFSVolume represents a ZFS based volume
@@ -241,7 +238,33 @@ spec:
         type: object
     served: true
     storage: true
-  - name: v1alpha1
+    subresources: {}
+  - additionalPrinterColumns:
+    - description: ZFS Pool where the volume is created
+      jsonPath: .spec.poolName
+      name: ZPool
+      type: string
+    - description: Node where the volume is created
+      jsonPath: .spec.ownerNodeID
+      name: Node
+      type: string
+    - description: Size of the volume
+      jsonPath: .spec.capacity
+      name: Size
+      type: string
+    - description: Status of the volume
+      jsonPath: .status.state
+      name: Status
+      type: string
+    - description: filesystem created on the volume
+      jsonPath: .spec.fsType
+      name: Filesystem
+      type: string
+    - description: Age of the volume
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ZFSVolume represents a ZFS based volume
@@ -416,6 +439,7 @@ spec:
         type: object
     served: true
     storage: false
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/deploy/helm/charts/templates/csidriver.yaml
+++ b/deploy/helm/charts/templates/csidriver.yaml
@@ -1,5 +1,5 @@
 # Create the CSI Driver object
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: zfs.csi.openebs.io

--- a/deploy/yamls/zfs-driver.yaml
+++ b/deploy/yamls/zfs-driver.yaml
@@ -2,7 +2,7 @@
 ---
 
 # Create the CSI Driver object
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: zfs.csi.openebs.io

--- a/deploy/yamls/zfsbackup-crd.yaml
+++ b/deploy/yamls/zfsbackup-crd.yaml
@@ -11,27 +11,14 @@
 # to generate the CRD definition
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.8
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: zfsbackups.zfs.openebs.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.prevSnapName
-    description: Previous snapshot for backup
-    name: PrevSnap
-    type: string
-  - JSONPath: .status
-    description: Backup status
-    name: Status
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of the volume
-    name: Age
-    type: date
   group: zfs.openebs.io
   names:
     kind: ZFSBackup
@@ -40,74 +27,87 @@ spec:
     shortNames:
     - zb
     singular: zfsbackup
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: ZFSBackup describes a zfs backup resource created as a custom resource
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ZFSBackupSpec is the spec for a ZFSBackup resource
-          properties:
-            backupDest:
-              description: BackupDest is the remote address for backup transfer
-              minLength: 1
-              pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
-              type: string
-            ownerNodeID:
-              description: OwnerNodeID is a name of the nodes where the source volume
-                is
-              minLength: 1
-              type: string
-            prevSnapName:
-              description: PrevSnapName is the last completed-backup's snapshot name
-              type: string
-            snapName:
-              description: SnapName is the snapshot name for backup
-              minLength: 1
-              type: string
-            volumeName:
-              description: VolumeName is a name of the volume for which this backup
-                is destined
-              minLength: 1
-              type: string
-          required:
-          - backupDest
-          - ownerNodeID
-          - volumeName
-          type: object
-        status:
-          description: ZFSBackupStatus is to hold status of backup
-          enum:
-          - Init
-          - Done
-          - Failed
-          - Pending
-          - InProgress
-          - Invalid
-          type: string
-      required:
-      - spec
-      - status
-      type: object
-  version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Previous snapshot for backup
+      jsonPath: .spec.prevSnapName
+      name: PrevSnap
+      type: string
+    - description: Backup status
+      jsonPath: .status
+      name: Status
+      type: string
+    - description: Age of the volume
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ZFSBackup describes a zfs backup resource created as a custom
+          resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ZFSBackupSpec is the spec for a ZFSBackup resource
+            properties:
+              backupDest:
+                description: BackupDest is the remote address for backup transfer
+                minLength: 1
+                pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is a name of the nodes where the source volume
+                  is
+                minLength: 1
+                type: string
+              prevSnapName:
+                description: PrevSnapName is the last completed-backup's snapshot
+                  name
+                type: string
+              snapName:
+                description: SnapName is the snapshot name for backup
+                minLength: 1
+                type: string
+              volumeName:
+                description: VolumeName is a name of the volume for which this backup
+                  is destined
+                minLength: 1
+                type: string
+            required:
+            - backupDest
+            - ownerNodeID
+            - volumeName
+            type: object
+          status:
+            description: ZFSBackupStatus is to hold status of backup
+            enum:
+            - Init
+            - Done
+            - Failed
+            - Pending
+            - InProgress
+            - Invalid
+            type: string
+        required:
+        - spec
+        - status
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/deploy/yamls/zfsrestore-crd.yaml
+++ b/deploy/yamls/zfsrestore-crd.yaml
@@ -11,11 +11,11 @@
 # to generate the CRD definition
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.8
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: zfsrestores.zfs.openebs.io
 spec:
@@ -25,209 +25,209 @@ spec:
     listKind: ZFSRestoreList
     plural: zfsrestores
     singular: zfsrestore
-  preserveUnknownFields: false
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: ZFSRestore describes a cstor restore resource created as a custom
-        resource
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ZFSRestoreSpec is the spec for a ZFSRestore resource
-          properties:
-            ownerNodeID:
-              description: owner node name where restore volume is present
-              minLength: 1
-              type: string
-            restoreSrc:
-              description: it can be ip:port in case of restore from remote or volumeName
-                in case of local restore
-              minLength: 1
-              pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
-              type: string
-            volumeName:
-              description: volume name to where restore has to be performed
-              minLength: 1
-              type: string
-          required:
-          - ownerNodeID
-          - restoreSrc
-          - volumeName
-          type: object
-        status:
-          description: ZFSRestoreStatus is to hold result of action.
-          enum:
-          - Init
-          - Done
-          - Failed
-          - Pending
-          - InProgress
-          - Invalid
-          type: string
-        volSpec:
-          description: VolumeInfo defines ZFS volume parameters for all modes in which
-            ZFS volumes can be created like - ZFS volume with filesystem, ZFS Volume
-            exposed as zfs or ZFS volume exposed as raw block device. Some of the
-            parameters can be only set during creation time (as specified in the details
-            of the parameter), and a few are editable. In case of Cloned volumes,
-            the parameters are assigned the same values as the source volume.
-          properties:
-            capacity:
-              description: Capacity of the volume
-              minLength: 1
-              type: string
-            compression:
-              description: 'Compression specifies the block-level compression algorithm
-                to be applied to the ZFS Volume. The value "on" indicates ZFS to use
-                the default compression algorithm. The default compression algorithm
-                used by ZFS will be either lzjb or, if the lz4_compress feature is
-                enabled, lz4. Compression property can be edited after the volume
-                has been created. The change will only be applied to the newly-written
-                data. For instance, if the Volume was created with "off" and the next
-                day the compression was modified to "on", the data written prior to
-                setting "on" will not be compressed. Default Value: off.'
-              pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
-              type: string
-            dedup:
-              description: 'Deduplication is the process for removing redundant data
-                at the block level, reducing the total amount of data stored. If a
-                file system has the dedup property enabled, duplicate data blocks
-                are removed synchronously. The result is that only unique data is
-                stored and common components are shared among files. Deduplication
-                can consume significant processing power (CPU) and memory as well
-                as generate additional disk IO. Before creating a pool with deduplication
-                enabled, ensure that you have planned your hardware requirements appropriately
-                and implemented appropriate recovery practices, such as regular backups.
-                As an alternative to deduplication consider using compression=lz4,
-                as a less resource-intensive alternative. should be enabled on the
-                zvol. Dedup property can be edited after the volume has been created.
-                Default Value: off.'
-              enum:
-              - "on"
-              - "off"
-              type: string
-            encryption:
-              description: 'Enabling the encryption feature allows for the creation
-                of encrypted filesystems and volumes. ZFS will encrypt file and zvol
-                data, file attributes, ACLs, permission bits, directory listings,
-                FUID mappings, and userused / groupused data. ZFS will not encrypt
-                metadata related to the pool structure, including dataset and snapshot
-                names, dataset hierarchy, properties, file size, file holes, and deduplication
-                tables (though the deduplicated data itself is encrypted). Default
-                Value: off.'
-              pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
-              type: string
-            fsType:
-              description: 'FsType specifies filesystem type for the zfs volume/dataset.
-                If FsType is provided as "zfs", then the driver will create a ZFS
-                dataset, formatting is not required as underlying filesystem is ZFS
-                anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver will
-                create a ZVOL and format the volume accordingly. FsType can not be
-                modified once volume has been provisioned. Default Value: ext4.'
-              type: string
-            keyformat:
-              description: KeyFormat specifies format of the encryption key The supported
-                KeyFormats are passphrase, raw, hex.
-              enum:
-              - passphrase
-              - raw
-              - hex
-              type: string
-            keylocation:
-              description: KeyLocation is the location of key for the encryption
-              type: string
-            ownerNodeID:
-              description: OwnerNodeID is the Node ID where the ZPOOL is running which
-                is where the volume has been provisioned. OwnerNodeID can not be edited
-                after the volume has been provisioned.
-              minLength: 1
-              type: string
-            poolName:
-              description: poolName specifies the name of the pool where the volume
-                has been created. PoolName can not be edited after the volume has
-                been provisioned.
-              minLength: 1
-              type: string
-            recordsize:
-              description: 'Specifies a suggested block size for files in the file
-                system. The size specified must be a power of two greater than or
-                equal to 512 and less than or equal to 128 Kbytes. RecordSize property
-                can be edited after the volume has been created. Changing the file
-                system''s recordsize affects only files created afterward; existing
-                files are unaffected. Default Value: 128k.'
-              minLength: 1
-              type: string
-            shared:
-              description: Shared specifies whether the volume can be shared among
-                multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
-                will not allow the volumes to be mounted by more than one pods.
-              enum:
-              - "yes"
-              - "no"
-              type: string
-            snapname:
-              description: SnapName specifies the name of the snapshot where the volume
-                has been cloned from. Snapname can not be edited after the volume
-                has been provisioned.
-              type: string
-            thinProvision:
-              description: 'ThinProvision describes whether space reservation for
-                the source volume is required or not. The value "yes" indicates that
-                volume should be thin provisioned and "no" means thick provisioning
-                of the volume. If thinProvision is set to "yes" then volume can be
-                provisioned even if the ZPOOL does not have the enough capacity. If
-                thinProvision is set to "no" then volume can be provisioned only if
-                the ZPOOL has enough capacity and capacity required by volume can
-                be reserved. ThinProvision can not be modified once volume has been
-                provisioned. Default Value: no.'
-              enum:
-              - "yes"
-              - "no"
-              type: string
-            volblocksize:
-              description: 'VolBlockSize specifies the block size for the zvol. The
-                volsize can only be set to a multiple of volblocksize, and cannot
-                be zero. VolBlockSize can not be edited after the volume has been
-                provisioned. Default Value: 8k.'
-              minLength: 1
-              type: string
-            volumeType:
-              description: volumeType determines whether the volume is of type "DATASET"
-                or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
-                of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
-                is mentioned as fstype in the storageclass, then a volume of type
-                zvol will be created, which will be further formatted as the fstype
-                provided in the storageclass. VolumeType can not be modified once
-                volume has been provisioned.
-              enum:
-              - ZVOL
-              - DATASET
-              type: string
-          required:
-          - capacity
-          - ownerNodeID
-          - poolName
-          - volumeType
-          type: object
-      required:
-      - spec
-      - status
-      type: object
-  version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ZFSRestore describes a cstor restore resource created as a custom
+          resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ZFSRestoreSpec is the spec for a ZFSRestore resource
+            properties:
+              ownerNodeID:
+                description: owner node name where restore volume is present
+                minLength: 1
+                type: string
+              restoreSrc:
+                description: it can be ip:port in case of restore from remote or volumeName
+                  in case of local restore
+                minLength: 1
+                pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
+                type: string
+              volumeName:
+                description: volume name to where restore has to be performed
+                minLength: 1
+                type: string
+            required:
+            - ownerNodeID
+            - restoreSrc
+            - volumeName
+            type: object
+          status:
+            description: ZFSRestoreStatus is to hold result of action.
+            enum:
+            - Init
+            - Done
+            - Failed
+            - Pending
+            - InProgress
+            - Invalid
+            type: string
+          volSpec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
+                  to be applied to the ZFS Volume. The value "on" indicates ZFS to
+                  use the default compression algorithm. The default compression algorithm
+                  used by ZFS will be either lzjb or, if the lz4_compress feature
+                  is enabled, lz4. Compression property can be edited after the volume
+                  has been created. The change will only be applied to the newly-written
+                  data. For instance, if the Volume was created with "off" and the
+                  next day the compression was modified to "on", the data written
+                  prior to setting "on" will not be compressed. Default Value: off.'
+                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
+                  data at the block level, reducing the total amount of data stored.
+                  If a file system has the dedup property enabled, duplicate data
+                  blocks are removed synchronously. The result is that only unique
+                  data is stored and common components are shared among files. Deduplication
+                  can consume significant processing power (CPU) and memory as well
+                  as generate additional disk IO. Before creating a pool with deduplication
+                  enabled, ensure that you have planned your hardware requirements
+                  appropriately and implemented appropriate recovery practices, such
+                  as regular backups. As an alternative to deduplication consider
+                  using compression=lz4, as a less resource-intensive alternative.
+                  should be enabled on the zvol. Dedup property can be edited after
+                  the volume has been created. Default Value: off.'
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
+                  of encrypted filesystems and volumes. ZFS will encrypt file and
+                  zvol data, file attributes, ACLs, permission bits, directory listings,
+                  FUID mappings, and userused / groupused data. ZFS will not encrypt
+                  metadata related to the pool structure, including dataset and snapshot
+                  names, dataset hierarchy, properties, file size, file holes, and
+                  deduplication tables (though the deduplicated data itself is encrypted).
+                  Default Value: off.'
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  If FsType is provided as "zfs", then the driver will create a ZFS
+                  dataset, formatting is not required as underlying filesystem is
+                  ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
+                  will create a ZVOL and format the volume accordingly. FsType can
+                  not be modified once volume has been provisioned. Default Value:
+                  ext4.'
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
+                  system. The size specified must be a power of two greater than or
+                  equal to 512 and less than or equal to 128 Kbytes. RecordSize property
+                  can be edited after the volume has been created. Changing the file
+                  system''s recordsize affects only files created afterward; existing
+                  files are unaffected. Default Value: 128k.'
+                minLength: 1
+                type: string
+              shared:
+                description: Shared specifies whether the volume can be shared among
+                  multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
+                  will not allow the volumes to be mounted by more than one pods.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
+                  the source volume is required or not. The value "yes" indicates
+                  that volume should be thin provisioned and "no" means thick provisioning
+                  of the volume. If thinProvision is set to "yes" then volume can
+                  be provisioned even if the ZPOOL does not have the enough capacity.
+                  If thinProvision is set to "no" then volume can be provisioned only
+                  if the ZPOOL has enough capacity and capacity required by volume
+                  can be reserved. ThinProvision can not be modified once volume has
+                  been provisioned. Default Value: no.'
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
+                  The volsize can only be set to a multiple of volblocksize, and cannot
+                  be zero. VolBlockSize can not be edited after the volume has been
+                  provisioned. Default Value: 8k.'
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+        required:
+        - spec
+        - status
+        type: object
     served: true
     storage: true
 status:

--- a/deploy/yamls/zfssnapshot-crd.yaml
+++ b/deploy/yamls/zfssnapshot-crd.yaml
@@ -11,11 +11,11 @@
 # to generate the CRD definition
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.8
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: zfssnapshots.zfs.openebs.io
 spec:
@@ -27,9 +27,7 @@ spec:
     shortNames:
     - zfssnap
     singular: zfssnapshot
-  preserveUnknownFields: false
   scope: Namespaced
-  version: v1
   versions:
   - name: v1
     schema:

--- a/deploy/yamls/zfsvolume-crd.yaml
+++ b/deploy/yamls/zfsvolume-crd.yaml
@@ -11,39 +11,14 @@
 # to generate the CRD definition
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.8
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: zfsvolumes.zfs.openebs.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.poolName
-    description: ZFS Pool where the volume is created
-    name: ZPool
-    type: string
-  - JSONPath: .spec.ownerNodeID
-    description: Node where the volume is created
-    name: Node
-    type: string
-  - JSONPath: .spec.capacity
-    description: Size of the volume
-    name: Size
-    type: string
-  - JSONPath: .status.state
-    description: Status of the volume
-    name: Status
-    type: string
-  - JSONPath: .spec.fsType
-    description: filesystem created on the volume
-    name: Filesystem
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of the volume
-    name: Age
-    type: date
   group: zfs.openebs.io
   names:
     kind: ZFSVolume
@@ -53,12 +28,34 @@ spec:
     - zfsvol
     - zv
     singular: zfsvolume
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: ZFS Pool where the volume is created
+      jsonPath: .spec.poolName
+      name: ZPool
+      type: string
+    - description: Node where the volume is created
+      jsonPath: .spec.ownerNodeID
+      name: Node
+      type: string
+    - description: Size of the volume
+      jsonPath: .spec.capacity
+      name: Size
+      type: string
+    - description: Status of the volume
+      jsonPath: .status.state
+      name: Status
+      type: string
+    - description: filesystem created on the volume
+      jsonPath: .spec.fsType
+      name: Filesystem
+      type: string
+    - description: Age of the volume
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: ZFSVolume represents a ZFS based volume
@@ -241,7 +238,33 @@ spec:
         type: object
     served: true
     storage: true
-  - name: v1alpha1
+    subresources: {}
+  - additionalPrinterColumns:
+    - description: ZFS Pool where the volume is created
+      jsonPath: .spec.poolName
+      name: ZPool
+      type: string
+    - description: Node where the volume is created
+      jsonPath: .spec.ownerNodeID
+      name: Node
+      type: string
+    - description: Size of the volume
+      jsonPath: .spec.capacity
+      name: Size
+      type: string
+    - description: Status of the volume
+      jsonPath: .status.state
+      name: Status
+      type: string
+    - description: filesystem created on the volume
+      jsonPath: .spec.fsType
+      name: Filesystem
+      type: string
+    - description: Age of the volume
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ZFSVolume represents a ZFS based volume
@@ -416,6 +439,7 @@ spec:
         type: object
     served: true
     storage: false
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -32,39 +32,14 @@ metadata:
 # to generate the CRD definition
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.8
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: zfsvolumes.zfs.openebs.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.poolName
-    description: ZFS Pool where the volume is created
-    name: ZPool
-    type: string
-  - JSONPath: .spec.ownerNodeID
-    description: Node where the volume is created
-    name: Node
-    type: string
-  - JSONPath: .spec.capacity
-    description: Size of the volume
-    name: Size
-    type: string
-  - JSONPath: .status.state
-    description: Status of the volume
-    name: Status
-    type: string
-  - JSONPath: .spec.fsType
-    description: filesystem created on the volume
-    name: Filesystem
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of the volume
-    name: Age
-    type: date
   group: zfs.openebs.io
   names:
     kind: ZFSVolume
@@ -74,12 +49,34 @@ spec:
     - zfsvol
     - zv
     singular: zfsvolume
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: ZFS Pool where the volume is created
+      jsonPath: .spec.poolName
+      name: ZPool
+      type: string
+    - description: Node where the volume is created
+      jsonPath: .spec.ownerNodeID
+      name: Node
+      type: string
+    - description: Size of the volume
+      jsonPath: .spec.capacity
+      name: Size
+      type: string
+    - description: Status of the volume
+      jsonPath: .status.state
+      name: Status
+      type: string
+    - description: filesystem created on the volume
+      jsonPath: .spec.fsType
+      name: Filesystem
+      type: string
+    - description: Age of the volume
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: ZFSVolume represents a ZFS based volume
@@ -262,7 +259,33 @@ spec:
         type: object
     served: true
     storage: true
-  - name: v1alpha1
+    subresources: {}
+  - additionalPrinterColumns:
+    - description: ZFS Pool where the volume is created
+      jsonPath: .spec.poolName
+      name: ZPool
+      type: string
+    - description: Node where the volume is created
+      jsonPath: .spec.ownerNodeID
+      name: Node
+      type: string
+    - description: Size of the volume
+      jsonPath: .spec.capacity
+      name: Size
+      type: string
+    - description: Status of the volume
+      jsonPath: .status.state
+      name: Status
+      type: string
+    - description: filesystem created on the volume
+      jsonPath: .spec.fsType
+      name: Filesystem
+      type: string
+    - description: Age of the volume
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ZFSVolume represents a ZFS based volume
@@ -437,6 +460,7 @@ spec:
         type: object
     served: true
     storage: false
+    subresources: {}
 status:
   acceptedNames:
     kind: ""
@@ -456,11 +480,11 @@ status:
 # to generate the CRD definition
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.8
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: zfssnapshots.zfs.openebs.io
 spec:
@@ -472,9 +496,7 @@ spec:
     shortNames:
     - zfssnap
     singular: zfssnapshot
-  preserveUnknownFields: false
   scope: Namespaced
-  version: v1
   versions:
   - name: v1
     schema:
@@ -841,27 +863,14 @@ status:
 # to generate the CRD definition
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.8
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: zfsbackups.zfs.openebs.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.prevSnapName
-    description: Previous snapshot for backup
-    name: PrevSnap
-    type: string
-  - JSONPath: .status
-    description: Backup status
-    name: Status
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of the volume
-    name: Age
-    type: date
   group: zfs.openebs.io
   names:
     kind: ZFSBackup
@@ -870,74 +879,87 @@ spec:
     shortNames:
     - zb
     singular: zfsbackup
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: ZFSBackup describes a zfs backup resource created as a custom resource
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ZFSBackupSpec is the spec for a ZFSBackup resource
-          properties:
-            backupDest:
-              description: BackupDest is the remote address for backup transfer
-              minLength: 1
-              pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
-              type: string
-            ownerNodeID:
-              description: OwnerNodeID is a name of the nodes where the source volume
-                is
-              minLength: 1
-              type: string
-            prevSnapName:
-              description: PrevSnapName is the last completed-backup's snapshot name
-              type: string
-            snapName:
-              description: SnapName is the snapshot name for backup
-              minLength: 1
-              type: string
-            volumeName:
-              description: VolumeName is a name of the volume for which this backup
-                is destined
-              minLength: 1
-              type: string
-          required:
-          - backupDest
-          - ownerNodeID
-          - volumeName
-          type: object
-        status:
-          description: ZFSBackupStatus is to hold status of backup
-          enum:
-          - Init
-          - Done
-          - Failed
-          - Pending
-          - InProgress
-          - Invalid
-          type: string
-      required:
-      - spec
-      - status
-      type: object
-  version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Previous snapshot for backup
+      jsonPath: .spec.prevSnapName
+      name: PrevSnap
+      type: string
+    - description: Backup status
+      jsonPath: .status
+      name: Status
+      type: string
+    - description: Age of the volume
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ZFSBackup describes a zfs backup resource created as a custom
+          resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ZFSBackupSpec is the spec for a ZFSBackup resource
+            properties:
+              backupDest:
+                description: BackupDest is the remote address for backup transfer
+                minLength: 1
+                pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is a name of the nodes where the source volume
+                  is
+                minLength: 1
+                type: string
+              prevSnapName:
+                description: PrevSnapName is the last completed-backup's snapshot
+                  name
+                type: string
+              snapName:
+                description: SnapName is the snapshot name for backup
+                minLength: 1
+                type: string
+              volumeName:
+                description: VolumeName is a name of the volume for which this backup
+                  is destined
+                minLength: 1
+                type: string
+            required:
+            - backupDest
+            - ownerNodeID
+            - volumeName
+            type: object
+          status:
+            description: ZFSBackupStatus is to hold status of backup
+            enum:
+            - Init
+            - Done
+            - Failed
+            - Pending
+            - InProgress
+            - Invalid
+            type: string
+        required:
+        - spec
+        - status
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""
@@ -957,11 +979,11 @@ status:
 # to generate the CRD definition
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.8
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: zfsrestores.zfs.openebs.io
 spec:
@@ -971,209 +993,209 @@ spec:
     listKind: ZFSRestoreList
     plural: zfsrestores
     singular: zfsrestore
-  preserveUnknownFields: false
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: ZFSRestore describes a cstor restore resource created as a custom
-        resource
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ZFSRestoreSpec is the spec for a ZFSRestore resource
-          properties:
-            ownerNodeID:
-              description: owner node name where restore volume is present
-              minLength: 1
-              type: string
-            restoreSrc:
-              description: it can be ip:port in case of restore from remote or volumeName
-                in case of local restore
-              minLength: 1
-              pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
-              type: string
-            volumeName:
-              description: volume name to where restore has to be performed
-              minLength: 1
-              type: string
-          required:
-          - ownerNodeID
-          - restoreSrc
-          - volumeName
-          type: object
-        status:
-          description: ZFSRestoreStatus is to hold result of action.
-          enum:
-          - Init
-          - Done
-          - Failed
-          - Pending
-          - InProgress
-          - Invalid
-          type: string
-        volSpec:
-          description: VolumeInfo defines ZFS volume parameters for all modes in which
-            ZFS volumes can be created like - ZFS volume with filesystem, ZFS Volume
-            exposed as zfs or ZFS volume exposed as raw block device. Some of the
-            parameters can be only set during creation time (as specified in the details
-            of the parameter), and a few are editable. In case of Cloned volumes,
-            the parameters are assigned the same values as the source volume.
-          properties:
-            capacity:
-              description: Capacity of the volume
-              minLength: 1
-              type: string
-            compression:
-              description: 'Compression specifies the block-level compression algorithm
-                to be applied to the ZFS Volume. The value "on" indicates ZFS to use
-                the default compression algorithm. The default compression algorithm
-                used by ZFS will be either lzjb or, if the lz4_compress feature is
-                enabled, lz4. Compression property can be edited after the volume
-                has been created. The change will only be applied to the newly-written
-                data. For instance, if the Volume was created with "off" and the next
-                day the compression was modified to "on", the data written prior to
-                setting "on" will not be compressed. Default Value: off.'
-              pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
-              type: string
-            dedup:
-              description: 'Deduplication is the process for removing redundant data
-                at the block level, reducing the total amount of data stored. If a
-                file system has the dedup property enabled, duplicate data blocks
-                are removed synchronously. The result is that only unique data is
-                stored and common components are shared among files. Deduplication
-                can consume significant processing power (CPU) and memory as well
-                as generate additional disk IO. Before creating a pool with deduplication
-                enabled, ensure that you have planned your hardware requirements appropriately
-                and implemented appropriate recovery practices, such as regular backups.
-                As an alternative to deduplication consider using compression=lz4,
-                as a less resource-intensive alternative. should be enabled on the
-                zvol. Dedup property can be edited after the volume has been created.
-                Default Value: off.'
-              enum:
-              - "on"
-              - "off"
-              type: string
-            encryption:
-              description: 'Enabling the encryption feature allows for the creation
-                of encrypted filesystems and volumes. ZFS will encrypt file and zvol
-                data, file attributes, ACLs, permission bits, directory listings,
-                FUID mappings, and userused / groupused data. ZFS will not encrypt
-                metadata related to the pool structure, including dataset and snapshot
-                names, dataset hierarchy, properties, file size, file holes, and deduplication
-                tables (though the deduplicated data itself is encrypted). Default
-                Value: off.'
-              pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
-              type: string
-            fsType:
-              description: 'FsType specifies filesystem type for the zfs volume/dataset.
-                If FsType is provided as "zfs", then the driver will create a ZFS
-                dataset, formatting is not required as underlying filesystem is ZFS
-                anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver will
-                create a ZVOL and format the volume accordingly. FsType can not be
-                modified once volume has been provisioned. Default Value: ext4.'
-              type: string
-            keyformat:
-              description: KeyFormat specifies format of the encryption key The supported
-                KeyFormats are passphrase, raw, hex.
-              enum:
-              - passphrase
-              - raw
-              - hex
-              type: string
-            keylocation:
-              description: KeyLocation is the location of key for the encryption
-              type: string
-            ownerNodeID:
-              description: OwnerNodeID is the Node ID where the ZPOOL is running which
-                is where the volume has been provisioned. OwnerNodeID can not be edited
-                after the volume has been provisioned.
-              minLength: 1
-              type: string
-            poolName:
-              description: poolName specifies the name of the pool where the volume
-                has been created. PoolName can not be edited after the volume has
-                been provisioned.
-              minLength: 1
-              type: string
-            recordsize:
-              description: 'Specifies a suggested block size for files in the file
-                system. The size specified must be a power of two greater than or
-                equal to 512 and less than or equal to 128 Kbytes. RecordSize property
-                can be edited after the volume has been created. Changing the file
-                system''s recordsize affects only files created afterward; existing
-                files are unaffected. Default Value: 128k.'
-              minLength: 1
-              type: string
-            shared:
-              description: Shared specifies whether the volume can be shared among
-                multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
-                will not allow the volumes to be mounted by more than one pods.
-              enum:
-              - "yes"
-              - "no"
-              type: string
-            snapname:
-              description: SnapName specifies the name of the snapshot where the volume
-                has been cloned from. Snapname can not be edited after the volume
-                has been provisioned.
-              type: string
-            thinProvision:
-              description: 'ThinProvision describes whether space reservation for
-                the source volume is required or not. The value "yes" indicates that
-                volume should be thin provisioned and "no" means thick provisioning
-                of the volume. If thinProvision is set to "yes" then volume can be
-                provisioned even if the ZPOOL does not have the enough capacity. If
-                thinProvision is set to "no" then volume can be provisioned only if
-                the ZPOOL has enough capacity and capacity required by volume can
-                be reserved. ThinProvision can not be modified once volume has been
-                provisioned. Default Value: no.'
-              enum:
-              - "yes"
-              - "no"
-              type: string
-            volblocksize:
-              description: 'VolBlockSize specifies the block size for the zvol. The
-                volsize can only be set to a multiple of volblocksize, and cannot
-                be zero. VolBlockSize can not be edited after the volume has been
-                provisioned. Default Value: 8k.'
-              minLength: 1
-              type: string
-            volumeType:
-              description: volumeType determines whether the volume is of type "DATASET"
-                or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
-                of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
-                is mentioned as fstype in the storageclass, then a volume of type
-                zvol will be created, which will be further formatted as the fstype
-                provided in the storageclass. VolumeType can not be modified once
-                volume has been provisioned.
-              enum:
-              - ZVOL
-              - DATASET
-              type: string
-          required:
-          - capacity
-          - ownerNodeID
-          - poolName
-          - volumeType
-          type: object
-      required:
-      - spec
-      - status
-      type: object
-  version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ZFSRestore describes a cstor restore resource created as a custom
+          resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ZFSRestoreSpec is the spec for a ZFSRestore resource
+            properties:
+              ownerNodeID:
+                description: owner node name where restore volume is present
+                minLength: 1
+                type: string
+              restoreSrc:
+                description: it can be ip:port in case of restore from remote or volumeName
+                  in case of local restore
+                minLength: 1
+                pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
+                type: string
+              volumeName:
+                description: volume name to where restore has to be performed
+                minLength: 1
+                type: string
+            required:
+            - ownerNodeID
+            - restoreSrc
+            - volumeName
+            type: object
+          status:
+            description: ZFSRestoreStatus is to hold result of action.
+            enum:
+            - Init
+            - Done
+            - Failed
+            - Pending
+            - InProgress
+            - Invalid
+            type: string
+          volSpec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
+                  to be applied to the ZFS Volume. The value "on" indicates ZFS to
+                  use the default compression algorithm. The default compression algorithm
+                  used by ZFS will be either lzjb or, if the lz4_compress feature
+                  is enabled, lz4. Compression property can be edited after the volume
+                  has been created. The change will only be applied to the newly-written
+                  data. For instance, if the Volume was created with "off" and the
+                  next day the compression was modified to "on", the data written
+                  prior to setting "on" will not be compressed. Default Value: off.'
+                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
+                  data at the block level, reducing the total amount of data stored.
+                  If a file system has the dedup property enabled, duplicate data
+                  blocks are removed synchronously. The result is that only unique
+                  data is stored and common components are shared among files. Deduplication
+                  can consume significant processing power (CPU) and memory as well
+                  as generate additional disk IO. Before creating a pool with deduplication
+                  enabled, ensure that you have planned your hardware requirements
+                  appropriately and implemented appropriate recovery practices, such
+                  as regular backups. As an alternative to deduplication consider
+                  using compression=lz4, as a less resource-intensive alternative.
+                  should be enabled on the zvol. Dedup property can be edited after
+                  the volume has been created. Default Value: off.'
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
+                  of encrypted filesystems and volumes. ZFS will encrypt file and
+                  zvol data, file attributes, ACLs, permission bits, directory listings,
+                  FUID mappings, and userused / groupused data. ZFS will not encrypt
+                  metadata related to the pool structure, including dataset and snapshot
+                  names, dataset hierarchy, properties, file size, file holes, and
+                  deduplication tables (though the deduplicated data itself is encrypted).
+                  Default Value: off.'
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  If FsType is provided as "zfs", then the driver will create a ZFS
+                  dataset, formatting is not required as underlying filesystem is
+                  ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
+                  will create a ZVOL and format the volume accordingly. FsType can
+                  not be modified once volume has been provisioned. Default Value:
+                  ext4.'
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
+                  system. The size specified must be a power of two greater than or
+                  equal to 512 and less than or equal to 128 Kbytes. RecordSize property
+                  can be edited after the volume has been created. Changing the file
+                  system''s recordsize affects only files created afterward; existing
+                  files are unaffected. Default Value: 128k.'
+                minLength: 1
+                type: string
+              shared:
+                description: Shared specifies whether the volume can be shared among
+                  multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
+                  will not allow the volumes to be mounted by more than one pods.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
+                  the source volume is required or not. The value "yes" indicates
+                  that volume should be thin provisioned and "no" means thick provisioning
+                  of the volume. If thinProvision is set to "yes" then volume can
+                  be provisioned even if the ZPOOL does not have the enough capacity.
+                  If thinProvision is set to "no" then volume can be provisioned only
+                  if the ZPOOL has enough capacity and capacity required by volume
+                  can be reserved. ThinProvision can not be modified once volume has
+                  been provisioned. Default Value: no.'
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
+                  The volsize can only be set to a multiple of volblocksize, and cannot
+                  be zero. VolBlockSize can not be edited after the volume has been
+                  provisioned. Default Value: 8k.'
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+        required:
+        - spec
+        - status
+        type: object
     served: true
     storage: true
 status:
@@ -1186,7 +1208,7 @@ status:
 ---
 
 # Create the CSI Driver object
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: zfs.csi.openebs.io


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

**Why is this PR required? What issue does it fix?**:
With k8s v1.22 the v1beta1 for various resources will no longer be supported. This PR updates the storage and apiexention version to v1.

**Does this PR require any upgrade changes?**: No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Manually verified the control plane upgrade and it works fine.

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:


