### PR TITLE
feat(migration): adding support to migrate the PV to a new node

### DIFF
--- a/changelogs/304-pawanpraka1
+++ b/changelogs/304-pawanpraka1
@@ -1,0 +1,1 @@
+adding support to migrate the PV to other nodes

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -88,7 +88,7 @@ func run(config *config.Config) {
 
 	klog.Infof("ZFS Driver Version :- %s - commit :- %s", version.Current(), version.GetGitCommit())
 	klog.Infof(
-		"DriverName: %s Plugin: %s EndPoint: %s NodeID: %s",
+		"DriverName: %s Plugin: %s EndPoint: %s Node Name: %s",
 		config.DriverName,
 		config.PluginType,
 		config.Endpoint,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,7 +55,7 @@ func main() {
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 
 	cmd.PersistentFlags().StringVar(
-		&config.NodeID, "nodeid", zfs.NodeID, "NodeID to identify the node running this driver",
+		&config.Nodename, "nodename", zfs.NodeID, "Nodename to identify the node running this driver",
 	)
 
 	cmd.PersistentFlags().StringVar(
@@ -92,7 +92,7 @@ func run(config *config.Config) {
 		config.DriverName,
 		config.PluginType,
 		config.Endpoint,
-		config.NodeID,
+		config.Nodename,
 	)
 
 	err := driver.New(config).Run()

--- a/deploy/yamls/zfs-driver.yaml
+++ b/deploy/yamls/zfs-driver.yaml
@@ -805,6 +805,8 @@ spec:
               value: "zfs-operator"
             - name: OPENEBS_IO_ENABLE_ANALYTICS
               value: "true"
+            - name: NODE_AFFINITY_KEY
+              value: kubernetes.io/hostname
           args :
             - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
             - "--plugin=$(OPENEBS_CONTROLLER_DRIVER)"
@@ -997,11 +999,11 @@ spec:
           image: openebs/zfs-driver:ci
           imagePullPolicy: IfNotPresent
           args:
-            - "--nodeid=$(OPENEBS_NODE_ID)"
+            - "--nodeid=$(OPENEBS_NODE_NAME)"
             - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
             - "--plugin=$(OPENEBS_NODE_DRIVER)"
           env:
-            - name: OPENEBS_NODE_ID
+            - name: OPENEBS_NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
@@ -1011,6 +1013,8 @@ spec:
               value: agent
             - name: OPENEBS_NAMESPACE
               value: openebs
+            - name: NODE_AFFINITY_KEY
+              value: kubernetes.io/hostname
           volumeMounts:
             - name: plugin-dir
               mountPath: /plugin

--- a/deploy/yamls/zfs-driver.yaml
+++ b/deploy/yamls/zfs-driver.yaml
@@ -999,7 +999,7 @@ spec:
           image: openebs/zfs-driver:ci
           imagePullPolicy: IfNotPresent
           args:
-            - "--nodeid=$(OPENEBS_NODE_NAME)"
+            - "--nodename=$(OPENEBS_NODE_NAME)"
             - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
             - "--plugin=$(OPENEBS_NODE_DRIVER)"
           env:

--- a/deploy/yamls/zfs-driver.yaml
+++ b/deploy/yamls/zfs-driver.yaml
@@ -805,8 +805,6 @@ spec:
               value: "zfs-operator"
             - name: OPENEBS_IO_ENABLE_ANALYTICS
               value: "true"
-            - name: NODE_AFFINITY_KEY
-              value: kubernetes.io/hostname
           args :
             - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
             - "--plugin=$(OPENEBS_CONTROLLER_DRIVER)"
@@ -1013,8 +1011,6 @@ spec:
               value: agent
             - name: OPENEBS_NAMESPACE
               value: openebs
-            - name: NODE_AFFINITY_KEY
-              value: kubernetes.io/hostname
           volumeMounts:
             - name: plugin-dir
               mountPath: /plugin

--- a/deploy/yamls/zfsvolume-crd.yaml
+++ b/deploy/yamls/zfsvolume-crd.yaml
@@ -37,7 +37,7 @@ spec:
       type: string
     - description: Node where the volume is created
       jsonPath: .spec.ownerNodeID
-      name: Node
+      name: NodeID
       type: string
     - description: Size of the volume
       jsonPath: .spec.capacity

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -58,7 +58,7 @@ spec:
       type: string
     - description: Node where the volume is created
       jsonPath: .spec.ownerNodeID
-      name: Node
+      name: NodeID
       type: string
     - description: Size of the volume
       jsonPath: .spec.capacity
@@ -2012,6 +2012,8 @@ spec:
               value: "zfs-operator"
             - name: OPENEBS_IO_ENABLE_ANALYTICS
               value: "true"
+            - name: NODE_AFFINITY_KEY
+              value: kubernetes.io/hostname
           args :
             - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
             - "--plugin=$(OPENEBS_CONTROLLER_DRIVER)"
@@ -2204,11 +2206,11 @@ spec:
           image: openebs/zfs-driver:ci
           imagePullPolicy: IfNotPresent
           args:
-            - "--nodeid=$(OPENEBS_NODE_ID)"
+            - "--nodeid=$(OPENEBS_NODE_NAME)"
             - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
             - "--plugin=$(OPENEBS_NODE_DRIVER)"
           env:
-            - name: OPENEBS_NODE_ID
+            - name: OPENEBS_NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
@@ -2218,6 +2220,8 @@ spec:
               value: agent
             - name: OPENEBS_NAMESPACE
               value: openebs
+            - name: NODE_AFFINITY_KEY
+              value: kubernetes.io/hostname
           volumeMounts:
             - name: plugin-dir
               mountPath: /plugin

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -2012,8 +2012,6 @@ spec:
               value: "zfs-operator"
             - name: OPENEBS_IO_ENABLE_ANALYTICS
               value: "true"
-            - name: NODE_AFFINITY_KEY
-              value: kubernetes.io/hostname
           args :
             - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
             - "--plugin=$(OPENEBS_CONTROLLER_DRIVER)"
@@ -2220,8 +2218,6 @@ spec:
               value: agent
             - name: OPENEBS_NAMESPACE
               value: openebs
-            - name: NODE_AFFINITY_KEY
-              value: kubernetes.io/hostname
           volumeMounts:
             - name: plugin-dir
               mountPath: /plugin

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -2206,7 +2206,7 @@ spec:
           image: openebs/zfs-driver:ci
           imagePullPolicy: IfNotPresent
           args:
-            - "--nodeid=$(OPENEBS_NODE_NAME)"
+            - "--nodename=$(OPENEBS_NODE_NAME)"
             - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
             - "--plugin=$(OPENEBS_NODE_DRIVER)"
           env:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -254,4 +254,4 @@ Now, when a node is not accesible, we need to do below steps
 $ kubectl label node node-4 openebs.io/nodeid=custom-value-3
 ```
 
-Once the above steps are done, the pod should be able to run on this new node with all the data it has on the old node. Here, there is one limitation that we can only move the PVs to the new node, we can not move the PVs to the node which was already used in the cluster as there is only one allowed value for the custom key for setting the node label.
+Once the above steps are done, the pod should be able to run on this new node with all the data it has on the old node. Here, there is one limitation that we can only move the PVs to the new node, we can not move the PVs to the node which were already used in the cluster as there is only one allowed value for the custom key for setting the node label.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -224,3 +224,33 @@ Then driver will find the nearest size in Mi, the size allocated will be ((1G + 
 
 PVC size as zero in not a valid capacity. The minimum allocatable size for the ZFS-LocalPV driver is 1Mi, which means that if we are requesting 1 byte of storage space then 1Mi will be allocated for the volume.
 
+### 8. How to migrate PVs to the new node in case old node is not accessible
+
+The ZFS-LocalPV driver will set affinity on the PV to make the volume stick to the node so that pod gets scheduled to that node only where the volume is present. Now the problem here is when that node is not accesible due to some reason and we moved the disks to a new node and imported the pool there, the pods will not be scheduled to this node as k8s scheduler will be looking for that node only to schedule the pod.
+
+Now with the release of 1.7.0, ZFS-LocalPV driver has the ability to pass the affinity key at the deployment time. So, now the driver will use the provided key(default kubernetes.io/hostname) to set the affinity on the PV.
+
+While deploying the ZFS-LocalPV driver, we should label the node first using some custom key and some unique value
+```
+$ kubectl label node node-1 custom.openebs.io/nodeid=custom-node-1
+```
+
+In the above command the custom key is `custom.openebs.io/nodeid` and value is `custom-node-1`. You can pick your own key and value, just make sure that the value is unique for each node. We have to label all the nodes in the cluster with the unique value. For example node-2 and node-3 can be labelled as below:
+
+```
+$ kubectl label node node-2 custom.openebs.io/nodeid=custom-node-2
+$ kubectl label node node-3 custom.openebs.io/nodeid=custom-node-3
+```
+
+Now, we need to pass the above custom key to ZFS-LocalPV driver, we can update the `NODE_AFFINITY_KEY` env in the zfs-operator yaml (total 2 places, controller and agent both needs this info) with the above key. By default, the driver uses `kubernetes.io/hostname` as the affinity key.
+
+
+Now, when a node is not accesible, we need to do below steps
+
+1. remove the old node from the cluster or we can just remove the above node label from the node which we want to remove.
+2. add a new node in the cluster
+3. move the disks to this new node
+4. import the zfs pools on the new nodes
+5. label the new node with same custom key and value.
+
+Once the above steps are done, the pod should be able to run on this new node with all the data it has on the old node. Here, there is one limitation that we can only move the PVs to the new node, we can not move the PVs to the node which was already used in the cluster as there is only one allowed value for the custom key for setting the node label.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -254,4 +254,4 @@ Now, when a node is not accesible, we need to do below steps
 $ kubectl label node node-4 openebs.io/nodeid=custom-value-3
 ```
 
-Once the above steps are done, the pod should be able to run on this new node with all the data it has on the old node. Here, there is one limitation that we can only move the PVs to the new node, we can not move the PVs to the node which were already used in the cluster as there is only one allowed value for the custom key for setting the node label.
+Once the above steps are done, the pod should be able to run on this new node with all the data it has on the old node. Here, there is one limitation that we can only move the PVs to the new node, we can not move the PVs to the node which was already used in the cluster as there is only one allowed value for the custom key for setting the node label.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -228,7 +228,7 @@ PVC size as zero in not a valid capacity. The minimum allocatable size for the Z
 
 The ZFS-LocalPV driver will set affinity on the PV to make the volume stick to the node so that pod gets scheduled to that node only where the volume is present. Now, the problem here is, when that node is not accesible due to some reason and we move the disks to a new node and import the pool there, the pods will not be scheduled to this node as k8s scheduler will be looking for that node only to schedule the pod.
 
-Now, with the release of 1.7.0, ZFS-LocalPV driver has the ability to use the user defined affinity for creating the PV. While deploying the ZFS-LocalPV driver, we should label all the nodes first using the key `openebs.io/nodeid` with some unique value
+From release 1.7.0 of ZFS-LocalPV, the driver has the ability to use the user defined affinity for creating the PV. While deploying the ZFS-LocalPV driver, first we should label all the nodes using the key `openebs.io/nodeid` with some unique value.
 ```
 $ kubectl label node node-1 openebs.io/nodeid=custom-value-1
 ```

--- a/pkg/apis/openebs.io/zfs/v1/zfsvolume.go
+++ b/pkg/apis/openebs.io/zfs/v1/zfsvolume.go
@@ -29,7 +29,7 @@ import (
 // +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Namespaced,shortName=zfsvol;zv
 // +kubebuilder:printcolumn:name="ZPool",type=string,JSONPath=`.spec.poolName`,description="ZFS Pool where the volume is created"
-// +kubebuilder:printcolumn:name="Node",type=string,JSONPath=`.spec.ownerNodeID`,description="Node where the volume is created"
+// +kubebuilder:printcolumn:name="NodeID",type=string,JSONPath=`.spec.ownerNodeID`,description="Node where the volume is created"
 // +kubebuilder:printcolumn:name="Size",type=string,JSONPath=`.spec.capacity`,description="Size of the volume"
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.state`,description="Status of the volume"
 // +kubebuilder:printcolumn:name="Filesystem",type=string,JSONPath=`.spec.fsType`,description="filesystem created on the volume"

--- a/pkg/builder/volbuilder/build.go
+++ b/pkg/builder/volbuilder/build.go
@@ -136,9 +136,9 @@ func (b *Builder) WithThinProv(thinprov string) *Builder {
 	return b
 }
 
-// WithOwnerNode sets owner node for the ZFSVolume where the volume should be provisioned
-func (b *Builder) WithOwnerNode(host string) *Builder {
-	b.volume.Object.Spec.OwnerNodeID = host
+// WithOwnerNodeID sets owner nodeid for the ZFSVolume where the volume should be provisioned
+func (b *Builder) WithOwnerNodeID(nodeid string) *Builder {
+	b.volume.Object.Spec.OwnerNodeID = nodeid
 	return b
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,11 +37,10 @@ type Config struct {
 	//  - This will be a unix based socket
 	Endpoint string
 
-	// NodeID helps in differentiating the nodes on
-	// which node drivers are running. This is useful
-	// in case of topologies and publishing or
-	// unpublishing volumes on nodes
-	NodeID string
+	// Nodename helps in differentiating the nodes on
+	// which node drivers are running. This is used
+	// to set the topologies for the driver
+	Nodename string
 }
 
 // Default returns a new instance of config

--- a/pkg/driver/agent.go
+++ b/pkg/driver/agent.go
@@ -229,8 +229,10 @@ func (ns *node) NodeGetInfo(
 	// support all the keys that node has
 	topology := node.Labels
 
-	// add driver's topology key
-	topology[zfs.ZFSTopologyKey] = ns.driver.config.Nodename
+	// add driver's topology key if not labelled already
+	if _, ok := topology[zfs.ZFSTopologyKey]; !ok {
+		topology[zfs.ZFSTopologyKey] = ns.driver.config.Nodename
+	}
 
 	return &csi.NodeGetInfoResponse{
 		NodeId: ns.driver.config.Nodename,

--- a/pkg/driver/agent.go
+++ b/pkg/driver/agent.go
@@ -204,9 +204,9 @@ func (ns *node) NodeGetInfo(
 	req *csi.NodeGetInfoRequest,
 ) (*csi.NodeGetInfoResponse, error) {
 
-	node, err := k8sapi.GetNode(ns.driver.config.NodeID)
+	node, err := k8sapi.GetNode(ns.driver.config.Nodename)
 	if err != nil {
-		klog.Errorf("failed to get the node %s", ns.driver.config.NodeID)
+		klog.Errorf("failed to get the node %s", ns.driver.config.Nodename)
 		return nil, err
 	}
 	/*
@@ -230,10 +230,10 @@ func (ns *node) NodeGetInfo(
 	topology := node.Labels
 
 	// add driver's topology key
-	topology[zfs.ZFSTopologyKey] = ns.driver.config.NodeID
+	topology[zfs.ZFSTopologyKey] = ns.driver.config.Nodename
 
 	return &csi.NodeGetInfoResponse{
-		NodeId: ns.driver.config.NodeID,
+		NodeId: ns.driver.config.Nodename,
 		AccessibleTopology: &csi.Topology{
 			Segments: topology,
 		},

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -227,7 +227,12 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 
 	// try volume creation sequentially on all nodes
 	for _, node := range prfList {
-		vol, _ := volbuilder.BuildFrom(volObj).WithOwnerNode(node).WithVolumeStatus(zfs.ZFSStatusPending).Build()
+		nodeid, err := zfs.GetNodeID(node)
+		if err != nil {
+			continue
+		}
+
+		vol, _ := volbuilder.BuildFrom(volObj).WithOwnerNodeID(nodeid).WithVolumeStatus(zfs.ZFSStatusPending).Build()
 
 		timeout := false
 
@@ -392,7 +397,12 @@ func (cs *controller) CreateVolume(
 
 	sendEventOrIgnore(pvcName, volName, strconv.FormatInt(int64(size), 10), "zfs-localpv", analytics.VolumeProvision)
 
-	topology := map[string]string{zfs.ZFSTopologyKey: selected}
+	nodeid, err := zfs.GetNodeID(selected)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "GetNodeID failed : %s", err.Error())
+	}
+
+	topology := map[string]string{zfs.ZFSAffinityKey: nodeid}
 	cntx := map[string]string{zfs.PoolNameKey: pool}
 
 	return csipayload.NewCreateVolumeResponseBuilder().

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -402,7 +402,7 @@ func (cs *controller) CreateVolume(
 		return nil, status.Errorf(codes.Internal, "GetNodeID failed : %s", err.Error())
 	}
 
-	topology := map[string]string{zfs.ZFSAffinityKey: nodeid}
+	topology := map[string]string{zfs.ZFSTopologyKey: nodeid}
 	cntx := map[string]string{zfs.PoolNameKey: pool}
 
 	return csipayload.NewCreateVolumeResponseBuilder().

--- a/pkg/zfs/volume.go
+++ b/pkg/zfs/volume.go
@@ -177,7 +177,7 @@ func ProvisionVolume(
 	}
 
 	if err != nil {
-		klog.Infof("zfs: volume %s/%s provisioning failed on node %s err: %s",
+		klog.Infof("zfs: volume %s/%s provisioning failed on nodeid %s err: %s",
 			vol.Spec.PoolName, vol.Name, vol.Spec.OwnerNodeID, err.Error())
 	}
 


### PR DESCRIPTION
Signed-off-by: Pawan <pawan@mayadata.io>

**Why is this PR required? What issue does it fix?**:

Here we are setting the node affinity on PV using nodename, so we can not migrate the pods to the new node as k8s scheduler will try to schedule on the old node only.

**What this PR does?**:

Here, we can now label the nodes with the unique values using the key `openebs.io/nodeid`. The ZFS LocalPV driver will pick the value from the nodes and set the affinity accordingly.

Now to migrate the PV to the other node, we have to move the disks to the other node and remove the old node from the cluster and set the same label on the new node using the same key and value, which will let k8s scheduler to schedule the pods to the that node.

**Refactoring?**:

We are using nodename as NodeID in code, refactored the code and made it NodeName to have better code readability. Also changed the ZFSVolume display string to `NodeID` from the strting `Node` to tell that it is the NodeID.

**Limitation?**:

we can only move the PVs to the new node, we can not move the PVs to the node which was already used in the cluster as there is only one allowed value for the custom key for setting the node label.
