### PR TITLE
chore(github-action): Avoid builds for pushes to helm chart, docs and changelog directories

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,12 @@
 # limitations under the License.
 name: build
 
-on: ['push']
+on:
+  push:
+    paths-ignore:
+    - 'docs/**'
+    - 'deploy/helm/**'
+    - 'changelogs/**'
 
 jobs:
   lint:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,9 @@ name: ci
 on:
   pull_request:
     paths-ignore:
+      - 'docs/**'
       - 'deploy/helm/**'
+      - 'changelogs/**'
     branches:
       # on pull requests to master and release branches
       - master


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

The build.yml and pull_request.yml workflows will ignore pushes made to `docs/`, `deploy/helm/` and `changelogs/` directories. This will result in images not built for pushes made to above directories.