### PR TITLE
refact(actions): use build & push action instead of makefile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,20 @@
 # limitations under the License.
 name: build
 
-on: ['push']
+on: 
+  create:
+  push:
+    branches:
+    - master
+    - 'v*'
+    paths-ignore:
+    - 'docs/**'
+    - 'changelogs/**'
+    - 'deploy/helm/**'
 
 jobs:
   lint:
+    if: ${{ (github.event.ref_type == 'branch') }} # to ignore builds on release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,6 +43,7 @@ jobs:
 
 
   unit-test:
+    if: ${{ (github.event.ref_type == 'branch') }} # to ignore builds on release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -45,6 +56,7 @@ jobs:
         uses: codecov/codecov-action@v1
 
   bdd-test:
+    if: ${{ (github.event.ref_type == 'branch') }} # to ignore builds on release
     needs: ['unit-test']
     runs-on: ubuntu-latest
     strategy:
@@ -91,11 +103,18 @@ jobs:
           make sanity 
 
   csi-driver:
+    if: ${{ (github.event.ref_type == 'branch') }} # to ignore builds on release
     runs-on: ubuntu-latest
     needs: ['lint', 'bdd-test']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Set Image Org
+        # sets the default IMAGE_ORG to openebs
+        run: |
+          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG}}
+          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
 
       - name: Set Tag
         run: |
@@ -107,10 +126,28 @@ jobs:
           echo "TAG=${CI_TAG}" >> $GITHUB_ENV
           echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
 
+      - name: Set Build Date
+        id: date
+        run: |
+          echo "::set-output name=DATE::$(date -u +'%Y-%m-%dT%H:%M:%S%Z')"
+      
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          # add each registry to which the image needs to be pushed here
+          images: |
+            ${{ env.IMAGE_ORG }}/zfs-driver
+            quay.io/${{ env.IMAGE_ORG }}/zfs-driver
+          tag-latest: false
+          tag-custom-only: true
+          tag-custom: |
+            ${{ env.TAG }}
+      
       - name: Print Tag info
         run: |
           echo "BRANCH: ${BRANCH}"
-          echo "TAG: ${TAG}"
+          echo "${{ steps.docker_meta.outputs.tags }}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -129,9 +166,24 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
       - name: Build & Push Image
-        env:
-          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
-        run: |
-          make docker.buildx.csi-driver
-          make buildx.push.csi-driver
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./buildscripts/zfs-driver/zfs-driver.Dockerfile
+          push: true
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          build-args: |
+            DBUILD_DATE=${{ steps.date.outputs.DATE }}
+            DBUILD_REPO_URL=https://github.com/openebs/zfs-localpv
+            DBUILD_SITE_URL=https://openebs.io
+            BRANCH=${{ env.BRANCH }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ on:
     - 'docs/**'
     - 'changelogs/**'
     - 'deploy/helm/**'
+    - 'CHANGELOG.md'
 
 jobs:
   lint:
@@ -56,7 +57,6 @@ jobs:
         uses: codecov/codecov-action@v1
 
   bdd-test:
-    if: ${{ (github.event.ref_type == 'branch') }} # to ignore builds on release
     needs: ['unit-test']
     runs-on: ubuntu-latest
     strategy:
@@ -103,7 +103,6 @@ jobs:
           make sanity 
 
   csi-driver:
-    if: ${{ (github.event.ref_type == 'branch') }} # to ignore builds on release
     runs-on: ubuntu-latest
     needs: ['lint', 'bdd-test']
     steps:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,6 +20,7 @@ on:
       - 'deploy/helm/**'
       - 'docs/**'
       - 'changelogs/**'
+      - 'CHANGELOG.md'
     branches:
       # on pull requests to master and release branches
       - master

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           version: v0.4.2
 
-      - name: Build & Push Image
+      - name: Build
         uses: docker/build-push-action@v2
         with:
           context: .

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,6 +18,8 @@ on:
   pull_request:
     paths-ignore:
       - 'deploy/helm/**'
+      - 'docs/**'
+      - 'changelogs/**'
     branches:
       # on pull requests to master and release branches
       - master
@@ -116,7 +118,12 @@ jobs:
         with:
           version: v0.4.2
 
-      - name: Build Image
-        env:
-          IMG_RESULT: cache
-        run: make docker.buildx.csi-driver
+      - name: Build & Push Image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./buildscripts/zfs-driver/zfs-driver.Dockerfile
+          push: false
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            openebs/zfs-driver:ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,9 @@
 name: release
 
 on:
-  push:
+  release:
+    types:
+      - "created"
     tags:
       - 'v*'
 
@@ -24,6 +26,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+      
+      - name: Set Image Org
+        # sets the default IMAGE_ORG to openebs
+        run: |
+          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG}}
+          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
 
       - name: Set Tag
         run: |
@@ -31,8 +39,26 @@ jobs:
           echo "TAG=${TAG}" >> $GITHUB_ENV
           echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
 
+      - name: Set Build Date
+        id: date
+        run: |
+          echo "::set-output name=DATE::$(date -u +'%Y-%m-%dT%H:%M:%S%Z')"
+      
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          # add each registry to which the image needs to be pushed here
+          images: |
+            ${{ env.IMAGE_ORG }}/zfs-driver
+            quay.io/${{ env.IMAGE_ORG }}/zfs-driver
+          tag-latest: true
+          tag-semver: |
+            {{version}}
+      
       - name: Print Tag info
         run: |
+          echo "${{ steps.docker_meta.outputs.tags }}"
           echo "RELEASE TAG: ${RELEASE_TAG}"
 
       - name: Set up QEMU
@@ -51,10 +77,25 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Build & Push Image
-        env:
-          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
-        run: |
-          make docker.buildx.csi-driver
-          make buildx.push.csi-driver
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./buildscripts/zfs-driver/zfs-driver.Dockerfile
+          push: true
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          build-args: |
+            DBUILD_DATE=${{ steps.date.outputs.DATE }}
+            DBUILD_REPO_URL=https://github.com/openebs/zfs-localpv
+            DBUILD_SITE_URL=https://openebs.io
+            RELEASE_TAG=${{ env.RELEASE_TAG }}

--- a/buildscripts/generate-manifests.sh
+++ b/buildscripts/generate-manifests.sh
@@ -46,6 +46,7 @@ echo '
 
 cat deploy/yamls/zfs.openebs.io_zfsvolumes.yaml >> deploy/yamls/zfsvolume-crd.yaml
 rm deploy/yamls/zfs.openebs.io_zfsvolumes.yaml
+cp deploy/yamls/zfsvolume-crd.yaml deploy/helm/charts/crds/zfsvolume.yaml
 
 echo '
 
@@ -61,7 +62,7 @@ echo '
 
 cat deploy/yamls/zfs.openebs.io_zfssnapshots.yaml >> deploy/yamls/zfssnapshot-crd.yaml
 rm deploy/yamls/zfs.openebs.io_zfssnapshots.yaml
-
+cp deploy/yamls/zfssnapshot-crd.yaml deploy/helm/charts/crds/zfssnapshot.yaml
 
 echo '
 
@@ -77,7 +78,7 @@ echo '
 
 cat deploy/yamls/zfs.openebs.io_zfsbackups.yaml >> deploy/yamls/zfsbackup-crd.yaml
 rm deploy/yamls/zfs.openebs.io_zfsbackups.yaml
-
+cp deploy/yamls/zfsbackup-crd.yaml deploy/helm/charts/crds/zfsbackup.yaml
 
 echo '
 
@@ -93,6 +94,7 @@ echo '
 
 cat deploy/yamls/zfs.openebs.io_zfsrestores.yaml >> deploy/yamls/zfsrestore-crd.yaml
 rm deploy/yamls/zfs.openebs.io_zfsrestores.yaml
+cp deploy/yamls/zfsrestore-crd.yaml deploy/helm/charts/crds/zfsrestore.yaml
 
 ## create the operator file using all the yamls
 


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

**What this PR does?**:
This PR
  - make use of build and push action in workflow for better multi repo (docker and quay) push support for mulit-arch build
  - updates the generated crd changes in helm charts
  - adds quay.io repo to push images
  - avoids builds when release is create
  - adds proper ignore paths for pull requests and builds
 
**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
quay login details need to be added before merging the PR

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: