### PR TITLE
fix(actions): updated the build workflow condition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   lint:
-    if: ${{ (github.event.ref_type == 'branch') }} # to ignore builds on release
+    if: ${{ (github.event.ref_type != 'tag') }} # to ignore builds on release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -44,7 +44,7 @@ jobs:
 
 
   unit-test:
-    if: ${{ (github.event.ref_type == 'branch') }} # to ignore builds on release
+    if: ${{ (github.event.ref_type != 'tag') }} # to ignore builds on release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

**Why is this PR required? What issue does it fix?**:
This PR fixes the build workflow criteria. When a PR is merged the `ref` is `remote` instead of `branch`. As we only want to skip the build on release the condition is changed to `!= tag` as tag is only created on release.
Tested this by merging a PR to my local fork repo.

**What this PR does?**:

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: