### PR TITLE
Add missing cas-type key for zfs under volume attributes.

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -472,7 +472,7 @@ func (cs *controller) CreateVolume(
 	}
 
 	topology := map[string]string{zfs.ZFSTopologyKey: nodeid}
-	cntx := map[string]string{zfs.PoolNameKey: pool}
+	cntx := map[string]string{zfs.PoolNameKey: pool, zfs.OpenEBSCasTypeKey: zfs.ZFSCasTypeName}
 
 	return csipayload.NewCreateVolumeResponseBuilder().
 		WithName(volName).

--- a/pkg/zfs/volume.go
+++ b/pkg/zfs/volume.go
@@ -58,6 +58,10 @@ const (
 	ZFSStatusFailed string = "Failed"
 	// ZFSStatusReady shows object has been processed
 	ZFSStatusReady string = "Ready"
+	// OpenEBSCasTypeKey for the cas-type label
+	OpenEBSCasTypeKey string = "openebs.io/cas-type"
+	// ZFSCasTypeName for the name of the cas-type
+	ZFSCasTypeName string = "localpv-zfs"
 )
 
 var (


### PR DESCRIPTION
Signed-off-by: Abhinandan-Purkait <abhinandan.purkait@mayadata.io>

**Why is this PR required? What issue does it fix?**:
- LocalPV ZFS currently does not have any cas-type label to indicate its cas-type.

**What this PR does?**:
- This PR adds the cas-type label to the volume attributes. 

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: