### PR TITLE
feat(charts): set default fstype to ext4 in csi-provisioner

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: zfs-localpv
 description: CSI Driver for dynamic provisioning of ZFS Persistent Local Volumes.
-version: 1.7.0
+version: 1.7.1
 appVersion: 1.7.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/

--- a/deploy/helm/charts/templates/zfs-contoller.yaml
+++ b/deploy/helm/charts/templates/zfs-contoller.yaml
@@ -78,6 +78,7 @@ spec:
             - "--strict-topology"
             - "--leader-election"
             - "--extra-create-metadata=true"
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/deploy/yamls/zfs-driver.yaml
+++ b/deploy/yamls/zfs-driver.yaml
@@ -788,6 +788,7 @@ spec:
             - "--strict-topology"
             - "--leader-election"
             - "--extra-create-metadata=true"
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -2082,6 +2082,7 @@ spec:
             - "--strict-topology"
             - "--leader-election"
             - "--extra-create-metadata=true"
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock


### PR DESCRIPTION
Set default fstype to ext4 in csi-provisioner. This will be helpful when fsType is not mention in storageclass.
