### PR TITLE
fix(chart): remove zfsNode.podLabels.name from values

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: zfs-localpv
 description: CSI Driver for dynamic provisioning of ZFS Persistent Local Volumes.
-version: 1.8.2
+version: 1.8.3
 appVersion: 1.8.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -41,8 +41,7 @@ zfsNode:
   #   cpu: 10m
   #   memory: 32Mi
   ## Labels to be added to openebs-zfs node pods
-  podLabels:
-    name: openebs-zfs-node
+  podLabels: {}
   nodeSelector: {}
   tolerations: []
   securityContext: {}


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
Fix node "name" label declared twice.
See https://github.com/openebs/zfs-localpv/blob/273bf148d460a015f645b26668f3741d0c538675/deploy/helm/charts/templates/_helpers.tpl#L97

**What this PR does?**:
Just remove zfsNode.podLabels.name from chart values.

**Does this PR require any upgrade changes?**:
No.

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: