### PR TITLE
fix(crash): reuse the err variable

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -290,7 +290,8 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 
 	// try volume creation sequentially on all nodes
 	for _, node := range prfList {
-		nodeid, err := zfs.GetNodeID(node)
+		var nodeid string
+		nodeid, err = zfs.GetNodeID(node)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
fixes: https://github.com/openebs/zfs-localpv/issues/351

Signed-off-by: Pawan <pawan@mayadata.io>


**What this PR does?**:

The error variable is being redeclared, so this is not
accessible outside of the loop and the provisioner is crashing
while return in case of error as it tries to access err.Error
and err is nil outside of the loop.

The controller will not crash unless there is grpc timeout or controller is not able to provision the volume on any one of the nodes.

**Does this PR require any upgrade changes?**:

no

