### PR TITLE
refact(e2e): Enable debug log level in velero deployment

### DIFF
--- a/e2e-tests/experiments/functional/backup_and_restore/setup_dependency.yml
+++ b/e2e-tests/experiments/functional/backup_and_restore/setup_dependency.yml
@@ -31,6 +31,28 @@
          --use-restic \
          --backup-location-config region=minio,s3ForcePathStyle="true",s3Url=http://minio.velero.svc:9000
 
+   - name: Get the velero deployment name
+     shell: kubectl get deploy -n velero -l component=velero -o custom-columns=:.metadata.name --no-headers
+     args: 
+       executable: /bin/bash
+     register: velero_deployment
+
+   - name: Patch velero deployment to enable `debug` log-level
+     shell: >
+       kubectl patch deployment \
+       {{ velero_deployment.stdout }} \
+       --namespace velero \
+       --type='json' \
+       -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args", "value": [
+       "server",
+       "--features=",
+       "--log-level=debug"
+       ]}]'
+     args:
+       executable: /bin/bash
+     register: debug_patch_status
+     failed_when: "debug_patch_status.rc != 0"
+ 
    - name: Check velero server pod status 
      shell: kubectl get pod -n velero -l deploy=velero -o jsonpath='{.items[0].status.phase}'
      register: velero_pod_status


### PR DESCRIPTION
Signed-off-by: w3aman <aman.gupta@mayadata.io>
- This PR enables the debug log level in velero deployment. It will be helpful in debugging e2e-tests

**Ansible Logs for changes done:**
```
TASK [Get the velero deployment name] ******************************************
task path: /e2e-tests/experiments/functional/backup_and_restore/setup_dependency.yml:34
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deploy -n velero -l component=velero -o custom-columns=:.metadata.name --no-headers", "delta": "0:00:01.346005", "end": "2021-07-21 07:59:50.633653", "rc": 0, "start": "2021-07-21 07:59:49.287648", "stderr": "", "stderr_lines": [], "stdout": "velero", "stdout_lines": ["velero"]}

TASK [Patch velero deployment to enable `debug` log-level] *********************
task path: /e2e-tests/experiments/functional/backup_and_restore/setup_dependency.yml:40
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl patch deployment velero --namespace velero --type='json' -p='[{\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/args\", \"value\": [ \"server\", \"--features=\", \"--log-level=debug\" ]}]'", "delta": "0:00:01.091490", "end": "2021-07-21 07:59:51.920868", "failed_when_result": false, "rc": 0, "start": "2021-07-21 07:59:50.829378", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps/velero patched", "stdout_lines": ["deployment.apps/velero patched"]}

TASK [Check velero server pod status] ******************************************
task path: /e2e-tests/experiments/functional/backup_and_restore/setup_dependency.yml:56
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n velero -l deploy=velero -o jsonpath='{.items[0].status.phase}'", "delta": "0:00:01.088622", "end": "2021-07-21 07:59:53.178519", "rc": 0, "start": "2021-07-21 07:59:52.089897", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}
```