### PR TITLE
refact(e2e): load key's passphrase in dataset after node-power-failure test case

### DIFF
--- a/e2e-tests/chaoslib/service_failure/service_chaos.yml
+++ b/e2e-tests/chaoslib/service_failure/service_chaos.yml
@@ -25,12 +25,29 @@
     
     - block:
        
-       - name: stop the {{ svc_type }} service on node where application pod is scheduled
+       - name: stop the docker service on node where application pod is scheduled
          shell: > 
            sshpass -p {{ node_pwd }} ssh -o StrictHostKeyChecking=no {{ user }}@{{ node_ip_add }}
-           "echo {{ node_pwd }} | sudo -S su -c 'systemctl stop {{ svc_type }}.service'"
+           "echo {{ node_pwd }} | sudo -S su -c 'systemctl stop docker.socket'"
          args:
            executable: /bin/bash
+         when: svc_type == "docker"
+
+       - name: stop the container runtime (if containerd, or crio) services on the application node
+         shell: > 
+           sshpass -p {{ node_pwd }} ssh -o StrictHostKeyChecking=no {{ user }}@{{ node_ip_add }}
+           "echo {{ node_pwd }} | sudo -S su -c 'systemctl stop {{ svc_type }}.service'"    
+         args:
+           executable: /bin/bash
+         when: svc_type == "containerd" or svc_type == "crio"
+
+       - name: stop the kubelet service on node where application pod is scheduled
+         shell: > 
+           sshpass -p {{ node_pwd }} ssh -o StrictHostKeyChecking=no {{ user }}@{{ node_ip_add }}
+           "echo {{ node_pwd }} | sudo -S su -c 'systemctl stop kubelet.service'"
+         args:
+           executable: /bin/bash
+         when: svc_type == "kubelet"
 
        - name: Check for the {{ svc_type }} service status
          shell: >
@@ -91,12 +108,29 @@
   
 - block: 
 
-   - name: Start the {{ svc_type }} services
+   - name: Start the docker services
+     shell: > 
+       sshpass -p {{ node_pwd }} ssh -o StrictHostKeyChecking=no {{ user }}@{{ node_ip_add }}
+       "echo {{ node_pwd }} | sudo -S su -c 'systemctl start docker.socket'"    
+     args:
+       executable: /bin/bash
+     when: svc_type == "docker"
+
+   - name: Start the container runtime (if containerd, or crio) services
      shell: > 
        sshpass -p {{ node_pwd }} ssh -o StrictHostKeyChecking=no {{ user }}@{{ node_ip_add }}
        "echo {{ node_pwd }} | sudo -S su -c 'systemctl start {{ svc_type }}.service'"    
      args:
        executable: /bin/bash
+     when: svc_type == "containerd" or svc_type == "crio"
+
+   - name: Start the kubelet services
+     shell: > 
+       sshpass -p {{ node_pwd }} ssh -o StrictHostKeyChecking=no {{ user }}@{{ node_ip_add }}
+       "echo {{ node_pwd }} | sudo -S su -c 'systemctl start kubelet.service'"    
+     args:
+       executable: /bin/bash
+     when: svc_type == "kubelet"
 
    - name: Check for the {{ svc_type }} services status
      shell: >

--- a/e2e-tests/experiments/infra-chaos/node_failure/run_e2e_test.yml
+++ b/e2e-tests/experiments/infra-chaos/node_failure/run_e2e_test.yml
@@ -82,6 +82,9 @@ spec:
           - name: ZPOOL_NAME
             value: ''
 
+          - name: ZPOOL_ENCRYPTION_PASSWORD
+            value: 'test1234'
+
           - name: ESX_PASSWORD
             valueFrom:
               secretKeyRef:

--- a/e2e-tests/experiments/infra-chaos/node_failure/test.yml
+++ b/e2e-tests/experiments/infra-chaos/node_failure/test.yml
@@ -194,6 +194,24 @@
           delay: 10
           retries: 30
 
+        - name: Check encryption keystatus on node
+          shell: >
+            sshpass -p {{ node_pwd }} ssh -o StrictHostKeyChecking=no {{ user }}@{{ node_ip_add }} "zfs get keystatus | grep {{ zpool_name }}"
+          args:
+            executable: /bin/bash
+          register: keystatus
+          failed_when: "keystatus.rc != 0"
+
+        - name: Load key's passphrase into datasets on the node
+          shell: >
+            sshpass -p {{ node_pwd }} ssh -o StrictHostKeyChecking=no {{ user }}@{{ node_ip_add }}
+            "echo {{ node_pwd }} | sudo -S su -c 'echo {{ enc_pwd }} | zfs load-key -L prompt {{ zpool_name }}'"
+          args:
+            executable: /bin/bash
+          register: key_load_status
+          failed_when: "key_load_status.rc != 0"
+          when: "'unavailable' in keystatus.stdout"
+
         - name: check the newly scheduled application pod status
           shell: kubectl get pod {{ new_app_pod }} -n {{ namespace }} --no-headers -o custom-columns=:.status.phase
           args:

--- a/e2e-tests/experiments/infra-chaos/node_failure/test_vars.yml
+++ b/e2e-tests/experiments/infra-chaos/node_failure/test_vars.yml
@@ -21,4 +21,6 @@ user: "{{ lookup('env','USERNAME') }}"
 
 zpool_name: "{{ lookup('env','ZPOOL_NAME') }}"
 
+enc_pwd: "{{ lookup('env','ZPOOL_ENCRYPTION_PASSWORD') }}"
+
 node_pwd: "{{ lookup('env','NODE_PASSWORD') }}"


### PR DESCRIPTION

Signed-off-by: w3aman <aman.gupta@mayadata.io>

- This PR refactors the node-power failure infra-chaos test. It adds those manual step where we have to load key's passphrase into dataset on the node after node failure cases.

- For docker-restart test-case if we try to stop docker services on node with the command something like: 
` systemctl stop docker.service`

it can give such warning
```
Warning: Stopping docker.service, but it can still be activated by:
  docker.socket
```
And then docker services will still be running.
So we can stop docker via socket and can execute following command:
` systemctl stop docker.socket`
