### PR TITLE
refact(e2e): Cleanup csi-driver CR before applying update operator yaml

### DIFF
--- a/e2e-tests/experiments/upgrade-zfs-localpv/test.yml
+++ b/e2e-tests/experiments/upgrade-zfs-localpv/test.yml
@@ -117,6 +117,15 @@
             regexp: "replicas: 1"
             replace: "replicas: {{ zfs_ctrl_replicas }}"
 
+        ## Due to Newly added `storageCapacity` Parameter in csidriver spec
+        ## Reapply with updated yaml will fail due to change in immutable field.
+        - name: Clean up the CSIDriver CR before upgrade operator
+          shell: kubectl delete csidriver zfs.csi.openebs.io
+          args:
+            executable: /bin/bash
+          register: csidriver
+          failed_when: "csidriver.rc != 0"
+
         - name: Apply the zfs_operator file to deploy zfs-driver components to the newer version
           shell: 
             kubectl apply -f ./new_zfs_operator.yml


### PR DESCRIPTION
Signed-off-by: w3aman <aman.gupta@mayadata.io>

- Due to Change in CSI_driver spec, we need to delete csi-driver CR before apply the updated operator yaml, otherwise csi-driver will no get updated as of immutable spec fields. 

```
The CSIDriver "zfs.csi.openebs.io" is invalid: spec.storageCapacity: Invalid value: true: field is immutable

```