### PR TITLE
feat(helm): Allow specifying path to zfs binary

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: zfs-localpv
 description: Helm chart for CSI Driver for dynamic provisioning of ZFS Persistent Local Volumes. For instructions on how to use this helm chart, see - https://openebs.github.io/zfs-localpv/
-version: 1.9.5
+version: 1.9.6
 appVersion: 1.9.1
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/

--- a/deploy/helm/charts/templates/configmap.yaml
+++ b/deploy/helm/charts/templates/configmap.yaml
@@ -13,5 +13,5 @@ data:
     elif [ -x /host/usr/sbin/zfs ]; then
       chroot /host /usr/sbin/zfs "$@"
     else
-      chroot /host zfs "$@"
+      chroot /host "{{ .Values.zfs.bin }}" "$@"
     fi

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -156,7 +156,6 @@ serviceAccount:
 
 analytics:
   enabled: true
-```suggestion
  
 zfs:
   # If you use a non-standard path to the zfs binary, specify it here

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -156,7 +156,8 @@ serviceAccount:
 
 analytics:
   enabled: true
-  
+```suggestion
+
 zfs:
   # If you use a non-standard path to the zfs binary, specify it here
   # bin: /run/current-system/sw/bin/zfs

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -156,3 +156,8 @@ serviceAccount:
 
 analytics:
   enabled: true
+  
+zfs:
+  # If you use a non-standard path to the zfs binary, specify it here
+  # bin: /run/current-system/sw/bin/zfs
+  bin: zfs

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -157,7 +157,7 @@ serviceAccount:
 analytics:
   enabled: true
 ```suggestion
-
+ 
 zfs:
   # If you use a non-standard path to the zfs binary, specify it here
   # bin: /run/current-system/sw/bin/zfs

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -156,7 +156,6 @@ serviceAccount:
 
 analytics:
   enabled: true
- 
 zfs:
   # If you use a non-standard path to the zfs binary, specify it here
   # bin: /run/current-system/sw/bin/zfs


### PR DESCRIPTION

## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**:

Some linux/UNIX distributions, do not follow standard path conventions. The driver currently assumes the zfs binary is in /sbin or /usr/sbin, but on NixOS, for example, it's in /run/current-system/sw/bin.

**What this PR does?**:

This adds an option to specify the directory manually. This is dumped into the config map that appears to invoke zfs (you should probably use exec btw)

**Does this PR require any upgrade changes?**:

I don't think so. Sorry I'm not super familiar with helm.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?**

No

