### PR TITLE
chore(doc): add caution while running kernel zfs and cStor on same set of nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,19 @@ $ kubectl delete -f pvc.yaml
 persistentvolumeclaim "csi-zfspv" deleted
 ```
 
+<h2 style="color:red;"> CAUTION: </h2>
+
+Follow below practice while running kernel ZFS along with cStor on the same set of nodes
+- Disable zfs-import-scan.service service that will avoid importing all pools by scanning all the available devices in the system, disabling scan service will avoid importing pools that are not created by kernel. Disabling scan service will not cause harm since zfs-import-cache.service is enabled and it is the best way to import pools by looking at cache file during boot time.
+```sh
+sudo systemctl stop zfs-import-scan.service
+sudo systemctl disable zfs-import-scan.service
+```
+- Always maintain upto date /etc/zfs/zpool.cache while performing operations any day2 operations on zfs pools(zpool set cachefile=/etc/zfs/zpool.cache <pool dataset name>).
+
+Note: Following above two step kernel ZFS will not import the pools created by cStor
+
+
 Features
 ---
 


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
This PR reminds the user to be a bit more cautious while running kernel zfs & cStor on the same set of nodes

**What this PR does?**:
Add caution while running kernel zfs & cStor on the same set of nodes

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>