### PR TITLE
fix(yaml): Don't rely on zfs being in sh's default PATH

### DIFF
--- a/deploy/yamls/zfs-driver.yaml
+++ b/deploy/yamls/zfs-driver.yaml
@@ -959,7 +959,7 @@ data:
     elif [ -x /host/usr/sbin/zfs ]; then
       chroot /host /usr/sbin/zfs "$@"
     else
-      chroot /host zfs "$@"
+      chroot /host /bin/sh -c ". /etc/profile && zfs $*"
     fi
 
 ---

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -2252,7 +2252,7 @@ data:
     elif [ -x /host/usr/sbin/zfs ]; then
       chroot /host /usr/sbin/zfs "$@"
     else
-      chroot /host zfs "$@"
+      chroot /host /bin/sh -c ". /etc/profile && zfs $*"
     fi
 
 ---

--- a/e2e-tests/experiments/zfs-localpv-provisioner/zfs_utils_ds.yml
+++ b/e2e-tests/experiments/zfs-localpv-provisioner/zfs_utils_ds.yml
@@ -12,7 +12,7 @@ data:
     elif [ -x /host/usr/sbin/zfs ]; then
       chroot /host /usr/sbin/zfs "$@"
     else
-      chroot /host zfs "$@"
+      chroot /host /bin/sh -c ". /etc/profile && zfs $*"
     fi
 
 ---


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

Fixes usage of zfs-localpv on NixOS/derivative hosts where `zfs` lives somewhere other than sh's default PATH.

**What this PR does?**:

Sources /etc/profile before attempting to call `zfs`

**Does this PR require any upgrade changes?**:

No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

- Tested on Ubuntu
- Tested on NixOS

**Checklist:**
- [x] Fixes #<issue number>
  - n/a
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated?
- [x] Commit has unit tests
- [x] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: