### PR TITLE
fix (localpv): CSIStorageClass shows zero if SC "poolname" includes dataset path

### DIFF
--- a/changelogs/unreleased/392-zero-cap-nonroot-ds
+++ b/changelogs/unreleased/392-zero-cap-nonroot-ds
@@ -1,0 +1,3 @@
+Fixes GetCapacity in pkg/driver/controller.go to report the ZFS pool
+capacity even when using a child dataset at the storage class' poolname
+attribute.

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -877,6 +877,21 @@ func (cs *controller) GetCapacity(
 	params := req.GetParameters()
 
 	poolParam := helpers.GetInsensitiveParameter(&params, "poolname")
+
+	// The "poolname" parameter can either be the name of a ZFS pool
+	// (e.g. "zpool"), or a path to a child dataset (e.g. "zpool/k8s/localpv").
+	//
+	// We parse the "poolname" parameter so the name of the ZFS pool and the
+	// path to the dataset is available separately.
+	//
+	// The dataset path is not used now. It could be used later to query the
+	// capacity of the child dataset, which could be smaller than the capacity
+	// of the whole pool.
+	//
+	// This is necessary because capacity calculation currently only works with
+	// ZFS pool names. This is why it always returns the capacitry of the whole
+	// pool, even if the child dataset given as the "poolname" parameter has a
+	// smaller capacity than the whole pool.
 	poolParamPool, _ := func() (string, string) {
 		poolParamSliced := strings.SplitN(poolParam, "/", 2)
 		if len(poolParamSliced) == 2 {

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -873,8 +873,18 @@ func (cs *controller) GetCapacity(
 	}
 
 	zfsNodesCache := cs.zfsNodeInformer.GetIndexer()
+
 	params := req.GetParameters()
+
 	poolParam := helpers.GetInsensitiveParameter(&params, "poolname")
+	poolParamPool, _ := func() (string, string) {
+		poolParamSliced := strings.SplitN(poolParam, "/", 2)
+		if len(poolParamSliced) == 2 {
+			return poolParamSliced[0], poolParamSliced[1]
+		} else {
+			return poolParamSliced[0], ""
+		}
+	}()
 
 	var availableCapacity int64
 	for _, nodeName := range nodeNames {
@@ -892,7 +902,7 @@ func (cs *controller) GetCapacity(
 		// See https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1472-storage-capacity-tracking#available-capacity-vs-maximum-volume-size &
 		// https://github.com/container-storage-interface/spec/issues/432 for more details
 		for _, zpool := range zfsNode.Pools {
-			if zpool.Name != poolParam {
+			if zpool.Name != poolParamPool {
 				continue
 			}
 			freeCapacity := zpool.Free.Value()

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -892,7 +892,7 @@ func (cs *controller) GetCapacity(
 	// ZFS pool names. This is why it always returns the capacitry of the whole
 	// pool, even if the child dataset given as the "poolname" parameter has a
 	// smaller capacity than the whole pool.
-	poolParamPool, _ := func() (string, string) {
+	poolname, _ := func() (string, string) {
 		poolParamSliced := strings.SplitN(poolParam, "/", 2)
 		if len(poolParamSliced) == 2 {
 			return poolParamSliced[0], poolParamSliced[1]
@@ -917,7 +917,7 @@ func (cs *controller) GetCapacity(
 		// See https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1472-storage-capacity-tracking#available-capacity-vs-maximum-volume-size &
 		// https://github.com/container-storage-interface/spec/issues/432 for more details
 		for _, zpool := range zfsNode.Pools {
-			if zpool.Name != poolParamPool {
+			if zpool.Name != poolname {
 				continue
 			}
 			freeCapacity := zpool.Free.Value()


### PR DESCRIPTION
Signed-off-by: Fábián Tamás László <giganetom@gmail.com>

**Why is this PR required? What issue does it fix?**:

It fixes #392 "GetCapacity reports zero when using non-root dataset"

**What this PR does?**:

Amends pkg/driver/controller.go to return the root dataset's capacity when using a child dataset as the pool name.

I'm aware that this is not the ideal solution, as the child dataset may offer less capacitry than the whole pool, but this is most definitely better than returning a straigh zero like it's now.

The situation could further be improved if the Node could return the capacity of a child dataset.

**Does this PR require any upgrade changes?**:

No, this is just a simple fix in the capacity calculation.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

I've manually verified that the storage capacity returns the pool's capacity when a child dataset is used, and also when the "poolname" is really just the pool's name.

**Any additional information for your reviewer?** :

This is just a small, standalone fix, not part of anything greater.
