### PR TITLE
[stable/zfs-localpv]: update charts to 2.0.0

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: zfs-localpv
 description: Helm chart for CSI Driver for dynamic provisioning of ZFS Persistent Local Volumes. For instructions on how to use this helm chart, see - https://openebs.github.io/zfs-localpv/
-version: 1.9.8
-appVersion: 1.9.3
+version: 2.0.0
+appVersion: 2.0.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/
 keywords:

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -78,7 +78,8 @@ The following table lists the configurable parameters of the OpenEBS ZFS Localpv
 | `zfsPlugin.image.registry`| Registry for openebs-zfs-plugin image| `""`|
 | `zfsPlugin.image.repository`| Image repository for openebs-zfs-plugin| `openebs/zfs-driver`|
 | `zfsPlugin.image.pullPolicy`| Image pull policy for openebs-zfs-plugin| `IfNotPresent`|
-| `zfsPlugin.image.tag`| Image tag for openebs-zfs-plugin| `1.9.1`|
+| `zfsPlugin.image.tag`| Image tag for openebs-zfs-plugin| `2.0.0`|
+| `zfsNode.allowedTopologyKeys`| Custom topology keys required for provisioning| `"kubernetes.io/hostname,"`|
 | `zfsNode.driverRegistrar.image.registry`| Registry for csi-node-driver-registrar image| `k8s.gcr.io/`|
 | `zfsNode.driverRegistrar.image.repository`| Image repository for csi-node-driver-registrar| `sig-storage/csi-node-driver-registrar`|
 | `zfsNode.driverRegistrar.image.pullPolicy`| Image pull policy for csi-node-driver-registrar| `IfNotPresent`|

--- a/deploy/helm/charts/crds/zfsrestore.yaml
+++ b/deploy/helm/charts/crds/zfsrestore.yaml
@@ -100,7 +100,7 @@ spec:
                   data. For instance, if the Volume was created with "off" and the
                   next day the compression was modified to "on", the data written
                   prior to setting "on" will not be compressed. Default Value: off.'
-                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                pattern: ^(on|off|lzjb|zstd|gzip|gzip-[1-9]|zle|lz4)$
                 type: string
               dedup:
                 description: 'Deduplication is the process for removing redundant

--- a/deploy/helm/charts/crds/zfssnapshot.yaml
+++ b/deploy/helm/charts/crds/zfssnapshot.yaml
@@ -69,7 +69,7 @@ spec:
                   data. For instance, if the Volume was created with "off" and the
                   next day the compression was modified to "on", the data written
                   prior to setting "on" will not be compressed. Default Value: off.'
-                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                pattern: ^(on|off|lzjb|zstd|gzip|gzip-[1-9]|zle|lz4)$
                 type: string
               dedup:
                 description: 'Deduplication is the process for removing redundant

--- a/deploy/helm/charts/crds/zfsvolume.yaml
+++ b/deploy/helm/charts/crds/zfsvolume.yaml
@@ -95,7 +95,7 @@ spec:
                   data. For instance, if the Volume was created with "off" and the
                   next day the compression was modified to "on", the data written
                   prior to setting "on" will not be compressed. Default Value: off.'
-                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                pattern: ^(on|off|lzjb|zstd|gzip|gzip-[1-9]|zle|lz4)$
                 type: string
               dedup:
                 description: 'Deduplication is the process for removing redundant

--- a/deploy/helm/charts/templates/zfs-node.yaml
+++ b/deploy/helm/charts/templates/zfs-node.yaml
@@ -82,6 +82,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: ALLOWED_TOPOLOGIES
+              value: "{{ .Values.zfsNode.allowedTopologyKeys }}"
           volumeMounts:
             - name: plugin-dir
               mountPath: /plugin

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 release:
-  version: "1.9.3"
+  version: "2.0.0"
 
 imagePullSecrets:
 # - name: "image-pull-secret"
@@ -53,6 +53,12 @@ zfsNode:
   priorityClass:
     create: true
     name: zfs-csi-node-critical
+  # allowed topologykeys for csi driver
+  # The desired comma separated keys can be added here,
+  # by default all the node label keys are allowed.
+  # For example:
+  # allowedTopologyKeys: "kubernetes.io/hostname,openebs.io/rack"
+  allowedTopologyKeys: "All"
 
 # zfsController contains the configurables for
 # the zfs controller statefulset
@@ -133,7 +139,7 @@ zfsPlugin:
     repository: openebs/zfs-driver
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 1.9.3
+    tag: 2.0.0
 
 role: openebs-zfs
 


### PR DESCRIPTION
Signed-off-by: shubham <shubham14bajpai@gmail.com>

**Why is this PR required? What issue does it fix?**:

**What this PR does?**:
This PR bumps the chart release to 2.0.0. This also cherry-pick operator changes the from PRs: 
- [x] https://github.com/openebs/zfs-localpv/pull/395
- [x] https://github.com/openebs/zfs-localpv/pull/401
**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

