### PR TITLE
docs(README): Clarify that the kubelet location note

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $ kubectl apply -f https://openebs.github.io/charts/zfs-operator.yaml
 
 We can also install it via kustomize using `kubectl apply -k deploy/yamls`, check the [kustomize yaml](deploy/yamls/kustomization.yaml).
 
-**NOTE:** For some Kubernetes distributions, the `kubelet` directory must be changed at all relevant places in the YAML powering the operator (both the `openebs-zfs-controller` and `openebs-zfs-node`). 
+**NOTE:** If you are running a custom Kubelet location, or a Kubernetes distribution that uses a custom Kubelet location, the `kubelet` directory must be changed at all relevant places in the YAML powering the operator (both the `openebs-zfs-controller` and `openebs-zfs-node`). 
 
 - For `microk8s`, we need to change the kubelet directory to `/var/snap/microk8s/common/var/lib/kubelet/`, we need to replace `/var/lib/kubelet/` with `/var/snap/microk8s/common/var/lib/kubelet/` at all the places in the operator yaml and then we can apply it on microk8s.
 


### PR DESCRIPTION
Specify that any custom Kubelet location must be fixed in the Yaml and not only for some distributions such as microk8s.

After wasting a couple hours on this issue and skipping over the `Note : for some Kubernetes distributions` because I'm not using a different distribution, I'm only running a custom kubelet location, I decided to submit this small documentation improvement p-r.

## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**:
Better documentation about the custom Kubelet location issue.

**What this PR does?**:

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
I have a custom kubelet location using the official Kubernetes distribution : editing the yaml fixed it for me.

Before editing the config I had an issue of the driver not registering properly. Now it registers.

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_
I'm really trying hard not to troll too much filling this way too long p-r template for a one line documentation change.

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: