### PR TITLE
fix(destroy): making ZFS-LocalPV aware of pool import

### DIFF
--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -621,6 +621,15 @@ func SetVolumeProp(vol *apis.ZFSVolume) error {
 // DestroyVolume deletes the zfs volume
 func DestroyVolume(vol *apis.ZFSVolume) error {
 	volume := vol.Spec.PoolName + "/" + vol.Name
+	parentDataset := vol.Spec.PoolName
+
+	// check if parent dataset is present or not before attempting to delete the volume
+	if err := getVolume(parentDataset); err != nil {
+		klog.Errorf(
+			"destroy: parent dataset %v is not present, error: %s", parentDataset, err.Error(),
+		)
+		return err
+	}
 
 	if err := getVolume(volume); err != nil {
 		klog.Errorf(
@@ -696,6 +705,17 @@ func DestroySnapshot(snap *apis.ZFSSnapshot) error {
 
 	volume := snap.Labels[ZFSVolKey]
 	snapDataset := snap.Spec.PoolName + "/" + volume + "@" + snap.Name
+
+	parentDataset := snap.Spec.PoolName
+
+	// check if parent dataset is present or not before attempting to delete the snapshot
+	if err := getVolume(parentDataset); err != nil {
+		klog.Errorf(
+			"destroy: snapshot's(%v) parent dataset %v is not present, error: %s",
+			snapDataset, parentDataset, err.Error(),
+		)
+		return err
+	}
 
 	if err := getVolume(snapDataset); err != nil {
 		klog.Errorf(


### PR DESCRIPTION
fixes: https://github.com/openebs/zfs-localpv/issues/398

If we are destroying a volume/snapshot and pool is not
imported, the ZFS-LocalPV driver assumes that the volume/snapshot
is not there and deletes the corresponding zfsvolume and zfssnap CR.

Here we are checking the parent dataset presence before attempting
to delete the volume or snapshot.

Signed-off-by: Pawan <pawan@mayadata.io>

