### PR TITLE
perf(zfs): optimise pool listing for pools with many datasets

### DIFF
--- a/changelogs/unreleased/440-lowjoel
+++ b/changelogs/unreleased/440-lowjoel
@@ -1,0 +1,1 @@
+optimise pool listing for pools with many datasets

--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -921,7 +921,7 @@ func CreateRestore(rstr *apis.ZFSRestore) error {
 // pools in the node.
 func ListZFSPool() ([]apis.Pool, error) {
 	args := []string{
-		ZFSListArg, "-s", "name",
+		ZFSListArg, "-d", "1", "-s", "name",
 		"-o", "name,guid,available",
 		"-H", "-p",
 	}


### PR DESCRIPTION
## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**:

Restricting the `zfs list` command to depth 1 saves a lot of time for pools with many datasets/zvols.

In my case, before:
```
$ time zfs list -s name -o name,guid,available -H -p >/dev/null
real    0m3.853s
user    0m0.171s
sys     0m3.539s
```

After:
```
$ time zfs list -d 1 -s name -o name,guid,available -H -p >/dev/null
real    0m0.027s
user    0m0.002s
sys     0m0.026s
```

**What this PR does?**:

This adds the `-d 1` argument to ListZFSPool.

**Does this PR require any upgrade changes?**:

No, this change should be backward compatible.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_
