### PR TITLE
fix(ci): upgrade minikube action version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        kubernetes: [v1.20.1]
+        kubernetes: [v1.25.10]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -80,9 +80,9 @@ jobs:
           go-version: 1.16.5
 
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.3.0
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
-          minikube version: v1.16.0
+          minikube version: v1.30.1
           kubernetes version: ${{ matrix.kubernetes }}
           github token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        kubernetes: [v1.20.1]
+        kubernetes: [v1.25.10]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -80,9 +80,9 @@ jobs:
           go-version: 1.16.5
 
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.3.0
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
-          minikube version: v1.16.0
+          minikube version: v1.30.1
           kubernetes version: ${{ matrix.kubernetes }}
           github token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This PR fixes the CI build and pull_request jobs by upgrading the minikube version , the manusa/actions-setup-minikube version, the kubernetes version.

manusa/actions-setup-minikube: 2.3.0 -> 2.7.2
minikube: 1.16.0 -> 1.30.1
k8s version: 1.20.1 -> 1.25.10