### PR TITLE
fix(plugin): Fix ability to have custom value for openebs.io/nodeid

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Configure the custom topology keys (if needed). This can be used for many purpos
 https://github.com/openebs/zfs-localpv/blob/HEAD/docs/faq.md#6-how-to-add-custom-topology-key
 
 ### Installation
+In order to support moving data to a new node later on, you must label each node with a unique value for `openebs.io/nodeid`.
+For more information on migrating data, please [see here](docs/faq.md#8-how-to-migrate-pvs-to-the-new-node-in-case-old-node-is-not-accessible)
 
 We can install the latest release of OpenEBS ZFS driver by running the following command:
 ```bash

--- a/changelogs/unreleased/450-nodeid-fix.md
+++ b/changelogs/unreleased/450-nodeid-fix.md
@@ -1,0 +1,1 @@
+fix regression introduced with v2.0.0 that caused the plugin code to not be able to start when a user sets openebs.io/nodeid

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -918,7 +918,12 @@ func (cs *controller) GetCapacity(
 
 	var availableCapacity int64
 	for _, nodeName := range nodeNames {
-		v, exists, err := zfsNodesCache.GetByKey(zfs.OpenEBSNamespace + "/" + nodeName)
+		mappedNodeId, mapErr := zfs.GetNodeID(nodeName)
+		if mapErr != nil {
+			klog.Warningf("Unable to find mapped node id for %s", nodeName)
+			mappedNodeId = nodeName
+		}
+		v, exists, err := zfsNodesCache.GetByKey(zfs.OpenEBSNamespace + "/" + mappedNodeId)
 		if err != nil {
 			klog.Warning("unexpected error after querying the zfsNode informer cache")
 			continue

--- a/pkg/mgmt/zfsnode/start.go
+++ b/pkg/mgmt/zfsnode/start.go
@@ -19,10 +19,12 @@ package zfsnode
 import (
 	"context"
 	"fmt"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/klog/v2"
+	"os"
 	"sync"
 	"time"
 
@@ -64,26 +66,39 @@ func Start(controllerMtx *sync.RWMutex, stopCh <-chan struct{}) error {
 			options.FieldSelector = fields.OneTermEqualSelector("metadata.name", zfs.NodeID).String()
 		}))
 
-	topologyRequirement, requirementError := labels.NewRequirement(zfs.ZFSTopologyKey, selection.Equals, []string{zfs.NodeID})
-	if requirementError != nil {
-		return errors.Wrapf(requirementError, "Unable to retrieve node by %s for node id %s", zfs.ZFSTopologyKey, zfs.NodeID)
+	var k8sNode *v1.Node
+	nodeName := os.Getenv("OPENEBS_NODE_NAME")
+	if nodeName != zfs.NodeID {
+		topologyRequirement, requirementError := labels.NewRequirement(zfs.ZFSTopologyKey, selection.Equals, []string{zfs.NodeID})
+		if requirementError != nil {
+			return errors.Wrapf(requirementError, "Unable to retrieve node by %s for node id %s", zfs.ZFSTopologyKey, zfs.NodeID)
+		}
+		topologySelector := labels.NewSelector().Add(*topologyRequirement).String()
+		klog.Infof("The topology selector is %s", topologySelector)
+
+		k8sNodeCandidates, listError := kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
+			LabelSelector: topologySelector,
+		})
+
+		if listError != nil {
+			return errors.Wrapf(err, "fetch k8s node %s", zfs.NodeID)
+		}
+
+		if k8sNodeCandidates == nil || len(k8sNodeCandidates.Items) != 1 {
+			return fmt.Errorf("unable to retrieve a single node by %s for %s", zfs.ZFSTopologyKey, zfs.NodeID)
+		}
+
+		k8sNode = &k8sNodeCandidates.Items[0]
+	} else {
+		byName, byNameErr := kubeClient.CoreV1().Nodes().Get(context.TODO(), zfs.NodeID, metav1.GetOptions{})
+
+		if byNameErr != nil {
+			return errors.Wrapf(err, "fetch k8s node %s", zfs.NodeID)
+		}
+
+		k8sNode = byName
 	}
-	topologySelector := labels.NewSelector().Add(*topologyRequirement).String()
-	klog.Infof("The topology selector is %s", topologySelector)
 
-	k8sNodeCandidates, err := kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: topologySelector,
-	})
-
-	if err != nil {
-		return errors.Wrapf(err, "fetch k8s node %s", zfs.NodeID)
-	}
-
-	if k8sNodeCandidates == nil || len(k8sNodeCandidates.Items) != 1 {
-		return fmt.Errorf("unable to retrieve a single node by %s for %s", zfs.ZFSTopologyKey, zfs.NodeID)
-	}
-
-	k8sNode := k8sNodeCandidates.Items[0]
 	isTrue := true
 	// as object returned by client go clears all TypeMeta from it.
 	nodeGVK := &schema.GroupVersionKind{

--- a/pkg/mgmt/zfsnode/start.go
+++ b/pkg/mgmt/zfsnode/start.go
@@ -90,11 +90,11 @@ func Start(controllerMtx *sync.RWMutex, stopCh <-chan struct{}) error {
 		k8sNodeCandidate, err := kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
 			LabelSelector: topologySelector,
 		})
-		if k8sNodeCandidate == nil || len(k8sNodeCandidate.Items) != 1 {
-			return fmt.Errorf("unable to retrieve a single node by %s for %s", zfs.ZFSTopologyKey, zfs.NodeID)
-		}
 		if err != nil {
 			return errors.Wrapf(err, "error trying to find node with label %s having value %s", zfs.ZFSTopologyKey, zfs.NodeID)
+		}
+		if k8sNodeCandidate == nil || len(k8sNodeCandidate.Items) != 1 {
+			return fmt.Errorf("unable to retrieve a single node by %s for %s", zfs.ZFSTopologyKey, zfs.NodeID)
 		}
 		k8sNode = k8sNodeCandidate.Items[0]
 	}

--- a/pkg/mgmt/zfsnode/start.go
+++ b/pkg/mgmt/zfsnode/start.go
@@ -19,11 +19,13 @@ package zfsnode
 import (
 	"context"
 	"fmt"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/klog/v2"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -66,32 +68,37 @@ func Start(controllerMtx *sync.RWMutex, stopCh <-chan struct{}) error {
 		}))
 
 	nodeName := os.Getenv("OPENEBS_NODE_NAME")
-	var searchLabel string
-	if nodeName == zfs.NodeID {
-		searchLabel = zfs.ZFSTopoNodenameKey
+	var k8sNode v1.Node
+
+	if len(strings.TrimSpace(zfs.NodeID)) == 0 || nodeName == zfs.NodeID {
+		k8sNodeCandidate, err := kubeClient.CoreV1().Nodes().Get(context.TODO(), zfs.NodeID, metav1.GetOptions{})
+
+		if err != nil {
+			return errors.Wrapf(err, "fetch k8s node %s", zfs.NodeID)
+		}
+
+		k8sNode = *k8sNodeCandidate
+
 	} else {
-		searchLabel = zfs.ZFSTopologyKey
-	}
-	topologyRequirement, requirementError := labels.NewRequirement(searchLabel, selection.Equals, []string{zfs.NodeID})
-	if requirementError != nil {
-		return errors.Wrapf(requirementError, "Unable to retrieve node by %s for node id %s", zfs.ZFSTopologyKey, zfs.NodeID)
-	}
-	topologySelector := labels.NewSelector().Add(*topologyRequirement).String()
-	klog.Infof("The topology selector is %s", topologySelector)
+		topologyRequirement, requirementError := labels.NewRequirement(zfs.ZFSTopologyKey, selection.Equals, []string{zfs.NodeID})
+		if requirementError != nil {
+			return errors.Wrapf(requirementError, "Unable to generate topology requirement by %s for node id %s", zfs.ZFSTopologyKey, zfs.NodeID)
+		}
+		topologySelector := labels.NewSelector().Add(*topologyRequirement).String()
+		klog.Infof("The topology selector is %s", topologySelector)
 
-	k8sNodeCandidates, err := kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: topologySelector,
-	})
-
-	if err != nil {
-		return errors.Wrapf(err, "fetch k8s node %s", zfs.NodeID)
-	}
-
-	if k8sNodeCandidates == nil || len(k8sNodeCandidates.Items) != 1 {
-		return fmt.Errorf("unable to retrieve a single node by %s for %s", zfs.ZFSTopologyKey, zfs.NodeID)
+		k8sNodeCandidate, err := kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
+			LabelSelector: topologySelector,
+		})
+		if k8sNodeCandidate == nil || len(k8sNodeCandidate.Items) != 1 {
+			return fmt.Errorf("unable to retrieve a single node by %s for %s", zfs.ZFSTopologyKey, zfs.NodeID)
+		}
+		if err != nil {
+			return errors.Wrapf(err, "error trying to find node with label %s having value %s", zfs.ZFSTopologyKey, zfs.NodeID)
+		}
+		k8sNode = k8sNodeCandidate.Items[0]
 	}
 
-	k8sNode := k8sNodeCandidates.Items[0]
 	isTrue := true
 	// as object returned by client go clears all TypeMeta from it.
 	nodeGVK := &schema.GroupVersionKind{


### PR DESCRIPTION
## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**:
This PR is required in order to allow a ZFS volume to be moved to another node
**What this PR does?**:
This pr fixes existing logic that attempts to retrieve a node using the name and instead retrieves the node using the nodeid label
**Does this PR require any upgrade changes?**:
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:
These changes were manually verified by doing the following:

1. Labeled all nodes via `kubectl label node <Node> openebs.io/nodeid=value-1`
2. Created persistent volumes
3. Ensured that the ZFSNode resources were created correctly.
4. Performed manual upgrade of the cluster
5. Attached the label with distinct value to each of the new nodes
6. Started test application to ensure that the volumes were mounted and accessible

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes #450
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [x] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [x] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

