### PR TITLE
Adding the feature to get "used capacity" using kubectl describe zfsnodes

### DIFF
--- a/deploy/helm/charts/crds/zfsnode.yaml
+++ b/deploy/helm/charts/crds/zfsnode.yaml
@@ -60,6 +60,13 @@ spec:
                   description: Free specifies the available capacity of zfs pool.
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
+                used:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: Used specifies the used capacity of zfs pool.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
                 name:
                   description: Name of the zfs pool.
                   minLength: 1
@@ -70,6 +77,7 @@ spec:
                   type: string
               required:
               - free
+              - used
               - name
               - uuid
               type: object

--- a/deploy/yamls/zfsnode-crd.yaml
+++ b/deploy/yamls/zfsnode-crd.yaml
@@ -60,6 +60,13 @@ spec:
                   description: Free specifies the available capacity of zfs pool.
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
+                used:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: Used specifies the used capacity of zfs pool.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
                 name:
                   description: Name of the zfs pool.
                   minLength: 1
@@ -70,6 +77,7 @@ spec:
                   type: string
               required:
               - free
+              - used
               - name
               - uuid
               type: object

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -1267,6 +1267,13 @@ spec:
                   description: Free specifies the available capacity of zfs pool.
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
+                used:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: Used specifies the used capacity of zfs pool.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
                 name:
                   description: Name of the zfs pool.
                   minLength: 1
@@ -1277,6 +1284,7 @@ spec:
                   type: string
               required:
               - free
+              - used
               - name
               - uuid
               type: object

--- a/pkg/apis/openebs.io/zfs/v1/zfsnode.go
+++ b/pkg/apis/openebs.io/zfs/v1/zfsnode.go
@@ -53,6 +53,10 @@ type Pool struct {
 	// Free specifies the available capacity of zfs pool.
 	// +kubebuilder:validation:Required
 	Free resource.Quantity `json:"free"`
+
+	// Used specifies the used capacity of zfs pool.
+	// +kubebuilder:validation:Required
+	Used resource.Quantity `json:"used"`
 }
 
 // ZFSNodeList is a collection of ZFSNode resources

--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -922,7 +922,7 @@ func CreateRestore(rstr *apis.ZFSRestore) error {
 func ListZFSPool() ([]apis.Pool, error) {
 	args := []string{
 		ZFSListArg, "-d", "1", "-s", "name",
-		"-o", "name,guid,available",
+		"-o", "name,guid,available,used",
 		"-H", "-p",
 	}
 	cmd := exec.Command(ZFSVolCmd, args...)
@@ -956,6 +956,13 @@ func decodeListOutput(raw []byte) ([]apis.Pool, error) {
 				return pools, err
 			}
 			pool.Free = *resource.NewQuantity(sizeBytes, resource.BinarySI)
+			sizeBytes1, err1 := strconv.ParseInt(items[3],
+				10, 64)
+			if err1 != nil {
+				err1 = fmt.Errorf("cannot get free size for pool %v: %v", pool.Name, err1)
+				return pools, err1
+			}
+			pool.Used = *resource.NewQuantity(sizeBytes1, resource.BinarySI)
 			pools = append(pools, pool)
 		}
 	}


### PR DESCRIPTION
modifications made to get the "used capacity" of zpools using "kubectl describe zfsnodes" in order to calculate to total capacity of the pools (by adding that to the free capacity already available using "kubectl describe zfsnodes" )