### PR TITLE
fix(localpv): restore size to return as part of snapshotshot create response

### DIFF
--- a/pkg/zfs/volume.go
+++ b/pkg/zfs/volume.go
@@ -313,6 +313,24 @@ func GetZFSSnapshotStatus(snapID string) (string, error) {
 	return snap.Status.State, nil
 }
 
+// GetZFSSnapshotCapacity return capacity converted to int64
+func GetZFSSnapshotCapacity(snap *apis.ZFSSnapshot) (int64, error) {
+	if snap == nil {
+		return 0, fmt.Errorf("expect non-nil snapshot")
+	}
+
+	if snap.Spec.Capacity == "" {
+		return 0, nil
+	}
+
+	capacity, err := strconv.ParseInt(snap.Spec.Capacity, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("convert %s to integer failed", snap.Spec.Capacity)
+	}
+
+	return capacity, nil
+}
+
 // UpdateSnapInfo updates ZFSSnapshot CR with node id and finalizer
 func UpdateSnapInfo(snap *apis.ZFSSnapshot) error {
 	finalizers := []string{ZFSFinalizer}


### PR DESCRIPTION
## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**:
#416 

**What this PR does?**:
return extra size info when return CreateSnapshot response

**Does this PR require any upgrade changes?**:
I think normal flow doesn't change, only affect external repo, like kubevirt depends on it to create PVC success.

**If the changes in this PR are manually verified, list down the scenarios covered:**:
After this fix, the snapshot should have non-zero restore size.

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes #416
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:


