### PR TITLE
feat(usedcapcity): kubectl describe zfsnode should show the used capacity information

### DIFF
--- a/deploy/yamls/zfsnode-crd.yaml
+++ b/deploy/yamls/zfsnode-crd.yaml
@@ -60,6 +60,13 @@ spec:
                   description: Free specifies the available capacity of zfs pool.
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
+                used:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: Used specifies the used capacity of zfs pool.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
                 name:
                   description: Name of the zfs pool.
                   minLength: 1
@@ -70,6 +77,7 @@ spec:
                   type: string
               required:
               - free
+              - used
               - name
               - uuid
               type: object

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -1267,6 +1267,13 @@ spec:
                   description: Free specifies the available capacity of zfs pool.
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
+                used:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: Used specifies the used capacity of zfs pool.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
                 name:
                   description: Name of the zfs pool.
                   minLength: 1
@@ -1277,6 +1284,7 @@ spec:
                   type: string
               required:
               - free
+              - used
               - name
               - uuid
               type: object

--- a/pkg/apis/openebs.io/zfs/v1/zfsnode.go
+++ b/pkg/apis/openebs.io/zfs/v1/zfsnode.go
@@ -53,6 +53,10 @@ type Pool struct {
 	// Free specifies the available capacity of zfs pool.
 	// +kubebuilder:validation:Required
 	Free resource.Quantity `json:"free"`
+
+	// Used specifies the used capacity of zfs pool.
+	// +kubebuilder:validation:Required
+	Used resource.Quantity `json:"used"`
 }
 
 // ZFSNodeList is a collection of ZFSNode resources

--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -922,7 +922,7 @@ func CreateRestore(rstr *apis.ZFSRestore) error {
 func ListZFSPool() ([]apis.Pool, error) {
 	args := []string{
 		ZFSListArg, "-d", "1", "-s", "name",
-		"-o", "name,guid,available",
+		"-o", "name,guid,available,used",
 		"-H", "-p",
 	}
 	cmd := exec.Command(ZFSVolCmd, args...)
@@ -956,6 +956,13 @@ func decodeListOutput(raw []byte) ([]apis.Pool, error) {
 				return pools, err
 			}
 			pool.Free = *resource.NewQuantity(sizeBytes, resource.BinarySI)
+			usedBytes, err := strconv.ParseInt(items[3],
+				10, 64)
+			if err != nil {
+				err = fmt.Errorf("cannot get free size for pool %v: %v", pool.Name, err)
+				return pools, err
+			}
+			pool.Used = *resource.NewQuantity(usedBytes, resource.BinarySI)
 			pools = append(pools, pool)
 		}
 	}


### PR DESCRIPTION

## Pull Request template

**Why is this PR required? What issue does it fix?**:

Used Capcity information is not shown as part of `kubectl describe zfsnode` command output.

**What this PR does?**:
With this code change, We can see the used capcity details with `kubectl describe zfsnode` command.

**Does this PR require any upgrade changes?**:
No
