### PR TITLE
fix(helm): Possibility to override zfs encryption keys directory

### DIFF
--- a/changelogs/unreleased/487-trunet.md
+++ b/changelogs/unreleased/487-trunet.md
@@ -1,0 +1,1 @@
+fix(helm): Possibility to override zfs encryption keys directory

--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: zfs-localpv
 description: Helm chart for CSI Driver for dynamic provisioning of ZFS Persistent Local Volumes. For instructions on how to use this helm chart, see - https://openebs.github.io/zfs-localpv/
-version: 2.3.1
+version: 2.3.2
 appVersion: 2.3.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: https://openebs.io/

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -86,6 +86,7 @@ The following table lists the configurable parameters of the OpenEBS ZFS Localpv
 | `zfsNode.driverRegistrar.image.tag`| Image tag for csi-node-driver-registrar| `v2.8.0`|
 | `zfsNode.updateStrategy.type`| Update strategy for zfsnode daemonset | `RollingUpdate` |
 | `zfsNode.kubeletDir`| Kubelet mount point for zfsnode daemonset| `"/var/lib/kubelet/"` |
+| `zfsNode.encrKeysDir` | Zfs encryption key directory| `"/home/keys"` |
 | `zfsNode.annotations` | Annotations for zfsnode daemonset metadata| `""`|
 | `zfsNode.podAnnotations`| Annotations for zfsnode daemonset's pods metadata | `""`|
 | `zfsNode.resources`| Resource and request and limit for zfsnode daemonset containers | `""`|

--- a/deploy/helm/charts/templates/zfs-node.yaml
+++ b/deploy/helm/charts/templates/zfs-node.yaml
@@ -118,7 +118,7 @@ spec:
             type: Directory
         - name: encr-keys
           hostPath:
-            path: /home/keys
+            path: {{ .Values.zfsNode.encrKeysDir }}
             type: DirectoryOrCreate
         - name: chroot-zfs
           configMap:

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -38,6 +38,7 @@ zfsNode:
   # This can be configured to run on various different k8s distributions like
   # microk8s where kubelet dir is different
   kubeletDir: "/var/lib/kubelet/"
+  encrKeysDir: "/home/keys"
   # limits:
   #   cpu: 10m
   #   memory: 32Mi


### PR DESCRIPTION
## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**: Being able to deploy in distributions with /home mounted as read-only.

**What this PR does?**: Add a value to helm charts to be able to set a hardcoded location.

**Does this PR require any upgrade changes?**: No

**If the changes in this PR are manually verified, list down the scenarios covered:**: I manage to install on a distribution with /home mounted as read-only, just setting `zfsNode.encrKeysDir` to something else.

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes #477
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: