### PR TITLE
fix(helm): Add extra args to zfsController containers and leader election inteligence

### DIFF
--- a/changelogs/unreleased/492-trunet.md
+++ b/changelogs/unreleased/492-trunet.md
@@ -1,0 +1,1 @@
+fix(helm): Add extra args to zfsController containers and leader election inteligence

--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: zfs-localpv
 description: Helm chart for CSI Driver for dynamic provisioning of ZFS Persistent Local Volumes. For instructions on how to use this helm chart, see - https://openebs.github.io/zfs-localpv/
-version: 2.4.0
-appVersion: 2.4.0
+version: 2.4.1
+appVersion: 2.4.1
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: https://openebs.io/
 keywords:

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -99,21 +99,26 @@ The following table lists the configurable parameters of the OpenEBS ZFS Localpv
 | `zfsController.resizer.image.repository`| Image repository for csi-resizer| `sig-storage/csi-resizer`|
 | `zfsController.resizer.image.pullPolicy`| Image pull policy for csi-resizer| `IfNotPresent`|
 | `zfsController.resizer.image.tag`| Image tag for csi-resizer| `v1.8.0`|
+| `zfsController.resizer.extraArgs`| Extra command line arguments| `[]`|
 | `zfsController.snapshotter.image.registry`| Registry for csi-snapshotter image| `registry.k8s.io/`|
 | `zfsController.snapshotter.image.repository`| Image repository for csi-snapshotter| `sig-storage/csi-snapshotter`|
 | `zfsController.snapshotter.image.pullPolicy`| Image pull policy for csi-snapshotter| `IfNotPresent`|
 | `zfsController.snapshotter.image.tag`| Image tag for csi-snapshotter| `v6.2.2`|
+| `zfsController.snapshotter.extraArgs`| Extra command line arguments| `[]`|
 | `zfsController.snapshotController.image.registry`| Registry for snapshot-controller image| `registry.k8s.io/`|
 | `zfsController.snapshotController.image.repository`| Image repository for snapshot-controller| `sig-storage/snapshot-controller`|
 | `zfsController.snapshotController.image.pullPolicy`| Image pull policy for snapshot-controller| `IfNotPresent`|
 | `zfsController.snapshotController.image.tag`| Image tag for snapshot-controller| `v6.2.2`|
+| `zfsController.snapshotController.extraArgs`| Extra command line arguments| `[]`|
 | `zfsController.provisioner.image.registry`| Registry for csi-provisioner image| `registry.k8s.io/`|
 | `zfsController.provisioner.image.repository`| Image repository for csi-provisioner| `sig-storage/csi-provisioner`|
 | `zfsController.provisioner.image.pullPolicy`| Image pull policy for csi-provisioner| `IfNotPresent`|
 | `zfsController.provisioner.image.tag`| Image tag for csi-provisioner| `v3.5.0`|
+| `zfsController.provisioner.extraArgs`| Extra command line arguments| `[]`|
 | `zfsController.updateStrategy.type`| Update strategy for zfs localpv controller statefulset | `RollingUpdate` |
 | `zfsController.annotations` | Annotations for zfs localpv controller statefulset metadata| `""`|
 | `zfsController.podAnnotations`| Annotations for zfs localpv controller statefulset's pods metadata | `""`|
+| `zfsController.replicas` | Number of zfs localpv controller replicas | `1` |
 | `zfsController.resources`| Resource and request and limit for zfs localpv controller statefulset containers | `""`|
 | `zfsController.labels`| Labels for zfs localpv controller statefulset metadata | `""`|
 | `zfsController.podLabels`| Appends labels to the zfs localpv controller statefulset pods| `""`|

--- a/deploy/helm/charts/templates/_helpers.tpl
+++ b/deploy/helm/charts/templates/_helpers.tpl
@@ -136,3 +136,14 @@ Create the name of the priority class for csi controller plugin
 {{- printf "%s" .Values.zfsController.priorityClass.name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Enable zfsController containers leader election if replicas > 1
+*/}}
+{{- define "zfslocalpv.zfsController.leaderElection" -}}
+{{- with .Values.zfsController.replicas | int }}
+{{- if gt . 1 }}
+- "--leader-election"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/charts/templates/zfs-contoller.yaml
+++ b/deploy/helm/charts/templates/zfs-contoller.yaml
@@ -52,7 +52,10 @@ spec:
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
-            - "--leader-election"
+            {{- include "zfslocalpv.zfsController.leaderElection" . | indent 12 }}
+          {{- range .Values.zfsController.resizer.extraArgs }}
+            - {{ tpl . $ | quote }}
+          {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -65,7 +68,10 @@ spec:
           imagePullPolicy: {{ .Values.zfsController.snapshotter.image.pullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
-            - "--leader-election"
+            {{- include "zfslocalpv.zfsController.leaderElection" . | indent 12 }}
+          {{- range .Values.zfsController.snapshotter.extraArgs }}
+            - {{ tpl . $ | quote }}
+          {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -76,7 +82,10 @@ spec:
           image: "{{ .Values.zfsController.snapshotController.image.registry }}{{ .Values.zfsController.snapshotController.image.repository }}:{{ .Values.zfsController.snapshotController.image.tag }}"
           args:
             - "--v=5"
-            - "--leader-election=true"
+            {{- include "zfslocalpv.zfsController.leaderElection" . | indent 12 }}
+          {{- range .Values.zfsController.snapshotController.extraArgs }}
+            - {{ tpl . $ | quote }}
+          {{- end }}
           imagePullPolicy: {{ .Values.zfsController.snapshotController.image.pullPolicy }}
         - name: {{ .Values.zfsController.provisioner.name }}
           image: "{{ .Values.zfsController.provisioner.image.registry }}{{ .Values.zfsController.provisioner.image.repository }}:{{ .Values.zfsController.provisioner.image.tag }}"
@@ -86,10 +95,13 @@ spec:
             - "--v=5"
             - "--feature-gates=Topology=true"
             - "--strict-topology"
-            - "--leader-election"
             - "--enable-capacity={{ .Values.feature.storageCapacity }}"
             - "--extra-create-metadata=true"
             - "--default-fstype=ext4"
+            {{- include "zfslocalpv.zfsController.leaderElection" . | indent 12 }}
+          {{- range .Values.zfsController.provisioner.extraArgs }}
+            - {{ tpl . $ | quote }}
+          {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -81,6 +81,7 @@ zfsController:
       pullPolicy: IfNotPresent
       # Overrides the image tag whose default is the chart appVersion.
       tag: v1.8.0
+    extraArgs: []
   snapshotter:
     name: "csi-snapshotter"
     image:
@@ -91,6 +92,7 @@ zfsController:
       pullPolicy: IfNotPresent
       # Overrides the image tag whose default is the chart appVersion.
       tag: v6.2.2
+    extraArgs: []
   snapshotController:
     name: "snapshot-controller"
     image:
@@ -101,6 +103,7 @@ zfsController:
       pullPolicy: IfNotPresent
       # Overrides the image tag whose default is the chart appVersion.
       tag: v6.2.2
+    extraArgs: []
   provisioner:
     name: "csi-provisioner"
     image:
@@ -111,6 +114,7 @@ zfsController:
       pullPolicy: IfNotPresent
       # Overrides the image tag whose default is the chart appVersion.
       tag: v3.5.0
+    extraArgs: []
   updateStrategy:
     type: RollingUpdate
   annotations: {}


### PR DESCRIPTION
Added zfsController extraArgs variable to pass extra argumenta to containers command line.

Also adding inteligence to enable leader election only when number of replicas is more than one.

Fixes #486

## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**: It'll fix a high number of restarts on slow clusters by disabling leader election when replicas < 2

**What this PR does?**: It'll add option to add extra arguments to zfsController containers and enable leader election only when  replicas > 1

**Does this PR require any upgrade changes?**: No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- helm install with default values
- helm install --set zfsController.replicas=2
- helm install --set zfsController.replicas=2 --set zfsController.resizer.extraArgs={--leader-election-lease-duration 60}

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes #486
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: