### PR TITLE
feat(deploy/helm): make snapshotcontroller optional

### DIFF
--- a/deploy/helm/charts/templates/zfs-contoller.yaml
+++ b/deploy/helm/charts/templates/zfs-contoller.yaml
@@ -78,6 +78,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+        {{- if .Values.zfsController.snapshotController.enabled }}
         - name: {{ .Values.zfsController.snapshotController.name }}
           image: "{{ .Values.zfsController.snapshotController.image.registry }}{{ .Values.zfsController.snapshotController.image.repository }}:{{ .Values.zfsController.snapshotController.image.tag }}"
           args:
@@ -87,6 +88,7 @@ spec:
             - {{ tpl . $ | quote }}
           {{- end }}
           imagePullPolicy: {{ .Values.zfsController.snapshotController.image.pullPolicy }}
+        {{- end }}
         - name: {{ .Values.zfsController.provisioner.name }}
           image: "{{ .Values.zfsController.provisioner.image.registry }}{{ .Values.zfsController.provisioner.image.repository }}:{{ .Values.zfsController.provisioner.image.tag }}"
           imagePullPolicy: {{ .Values.zfsController.provisioner.image.pullPolicy }}

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -94,6 +94,7 @@ zfsController:
       tag: v6.2.2
     extraArgs: []
   snapshotController:
+    enabled: true
     name: "snapshot-controller"
     image:
       # Make sure that registry name end with a '/'.


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

The CSI Snapshot Controler is already deployed by some Kubernetes distributions
such as RKE2. Make it possible to omit from the zfs-localpv chart for those cases.

**What this PR does?**:

Add `zfsController.snapshotController.enabled` Helm value, defaulting to true.
When set to false, the snapshot controller container is not created.

**Does this PR require any upgrade changes?**:

No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
