### PR TITLE
fix(charts): correct default chart values

### DIFF
--- a/changelogs/unreleased/505-default-chart-values.md
+++ b/changelogs/unreleased/505-default-chart-values.md
@@ -1,0 +1,1 @@
+correct the default values for initContainers and additionalVolumes

--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: zfs-localpv
 description: Helm chart for CSI Driver for dynamic provisioning of ZFS Persistent Local Volumes. For instructions on how to use this helm chart, see - https://openebs.github.io/zfs-localpv/
-version: 2.4.1
-appVersion: 2.4.1
+version: 2.4.2
+appVersion: 2.4.2
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: https://openebs.io/
 keywords:

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -60,15 +60,15 @@ zfsNode:
   # For example:
   # allowedTopologyKeys: "kubernetes.io/hostname,openebs.io/rack"
   allowedTopologyKeys: "All"
-  initContainers: []
-  additionalVolumes: []
+  initContainers: {}
+  additionalVolumes: {}
 
 # zfsController contains the configurables for
 # the zfs controller statefulset
 zfsController:
   componentName: openebs-zfs-controller
-  initContainers: []
-  additionalVolumes: []
+  initContainers: {}
+  additionalVolumes: {}
   replicas: 1
   serviceName: openebs-zfs
   resizer:


### PR DESCRIPTION
## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**:
Gets rid of warning message when deploying helm chart

**What this PR does?**:
Corrects the default values for the helm chart. The usage in the chart expects these values to be dictionaries, not arrays.

**Does this PR require any upgrade changes?**:
no

**If the changes in this PR are manually verified, list down the scenarios covered:**:
deployed chart locally with changes to ensure warning message went away and verified successful deployment

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes #505 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated?
- [x] Commit has unit tests
- [x] Commit has integration tests
- [x] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [x] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

