### PR TITLE
fix: crds getting removed on helm upgrades

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -17,3 +17,4 @@ sources:
 dependencies:
   - name: crds
     version: "2.5.1"
+    condition: crds.enabled

--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -16,5 +16,5 @@ sources:
 - https://github.com/openebs/zfs-localpv
 dependencies:
   - name: crds
-    version: "2.5.1"
+    version: 2.5.1
     condition: crds.enabled

--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: zfs-localpv
 description: Helm chart for CSI Driver for dynamic provisioning of ZFS Persistent Local Volumes. For instructions on how to use this helm chart, see - https://openebs.github.io/zfs-localpv/
-version: 2.5.0
+version: 2.5.1
 appVersion: 2.5.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: https://openebs.io/
@@ -16,4 +16,4 @@ sources:
 - https://github.com/openebs/zfs-localpv
 dependencies:
   - name: crds
-    version: "2.5.0"
+    version: "2.5.1"

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -78,7 +78,7 @@ The following table lists the configurable parameters of the OpenEBS ZFS Localpv
 | `zfsPlugin.image.registry`| Registry for openebs-zfs-plugin image| `""`|
 | `zfsPlugin.image.repository`| Image repository for openebs-zfs-plugin| `openebs/zfs-driver`|
 | `zfsPlugin.image.pullPolicy`| Image pull policy for openebs-zfs-plugin| `IfNotPresent`|
-| `zfsPlugin.image.tag`| Image tag for openebs-zfs-plugin| `2.3.0`|
+| `zfsPlugin.image.tag`| Image tag for openebs-zfs-plugin| `2.5.0`|
 | `zfsNode.allowedTopologyKeys`| Custom topology keys required for provisioning| `"kubernetes.io/hostname,"`|
 | `zfsNode.driverRegistrar.image.registry`| Registry for csi-node-driver-registrar image| `registry.k8s.io/`|
 | `zfsNode.driverRegistrar.image.repository`| Image repository for csi-node-driver-registrar| `sig-storage/csi-node-driver-registrar`|

--- a/deploy/helm/charts/charts/crds/Chart.yaml
+++ b/deploy/helm/charts/charts/crds/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: crds
-version: 2.5.0
+version: 2.5.1
 description: A Helm chart that collects CustomResourceDefinitions (CRDs) from zfs-localpv.

--- a/deploy/helm/charts/charts/crds/templates/_helpers.tpl
+++ b/deploy/helm/charts/charts/crds/templates/_helpers.tpl
@@ -1,17 +1,19 @@
-{{/*
-    This returns a "1" if the CRD is absent in the cluster
-    Usage:
-      {{- if (include "crdIsAbsent" (list <crd-name>)) -}}
-      # CRD Yaml
-      {{- end -}}
-*/}}
-{{- define "crdIsAbsent" -}}
-    {{- $crdName := index . 0 -}}
-    {{- $crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" $crdName -}}
-    {{- $output := "1" -}}
-    {{- if $crd -}}
-        {{- $output = "" -}}
-    {{- end -}}
+{{/* vim: set filetype=mustache: */}}
 
-    {{- $output -}}
+{{/*
+    Adds extra annotations to CRDs. This targets two scenarios: preventing CRD recycling in case
+    the chart is removed; and adding custom annotations.
+    NOTE: This function assumes the element `metadata.annotations` already exists.
+
+    Usage:
+      {{- include "crds.extraAnnotations" .Values.csi.volumeSnapshots | nindent 4 }}
+*/}}
+
+{{- define "crds.extraAnnotations" -}}
+{{- if .keep -}}
+helm.sh/resource-policy: keep
+{{ end }}
+{{- with .annotations }}
+  {{- toYaml . }}
+{{- end }}
 {{- end -}}

--- a/deploy/helm/charts/charts/crds/templates/csi-volume-snapshot-class.yaml
+++ b/deploy/helm/charts/charts/crds/templates/csi-volume-snapshot-class.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.csi.volumeSnapshots.enabled -}}
-{{- $crdName := "volumesnapshotclasses.snapshot.storage.k8s.io" -}}
-{{- if (include "crdIsAbsent" (list $crdName)) -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-csi/external-snapshotter/pull/814
     controller-gen.kubebuilder.io/version: v0.11.3
+    {{- include "crds.extraAnnotations" .Values.csi.volumeSnapshots | nindent 4 }}
   creationTimestamp: null
   name: volumesnapshotclasses.snapshot.storage.k8s.io
 spec:
@@ -148,5 +147,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end -}}
 {{- end -}}

--- a/deploy/helm/charts/charts/crds/templates/csi-volume-snapshot-content.yaml
+++ b/deploy/helm/charts/charts/crds/templates/csi-volume-snapshot-content.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.csi.volumeSnapshots.enabled -}}
-{{- $crdName := "volumesnapshotcontents.snapshot.storage.k8s.io" -}}
-{{- if (include "crdIsAbsent" (list $crdName)) -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-csi/external-snapshotter/pull/814
     controller-gen.kubebuilder.io/version: v0.11.3
+    {{- include "crds.extraAnnotations" .Values.csi.volumeSnapshots | nindent 4 }}
   creationTimestamp: null
   name: volumesnapshotcontents.snapshot.storage.k8s.io
 spec:
@@ -486,5 +485,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end -}}
 {{- end -}}

--- a/deploy/helm/charts/charts/crds/templates/csi-volume-snapshot.yaml
+++ b/deploy/helm/charts/charts/crds/templates/csi-volume-snapshot.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.csi.volumeSnapshots.enabled -}}
-{{- $crdName := "volumesnapshots.snapshot.storage.k8s.io" -}}
-{{- if (include "crdIsAbsent" (list $crdName)) -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-csi/external-snapshotter/pull/814
     controller-gen.kubebuilder.io/version: v0.11.3
+    {{- include "crds.extraAnnotations" .Values.csi.volumeSnapshots | nindent 4 }}
   creationTimestamp: null
   name: volumesnapshots.snapshot.storage.k8s.io
 spec:
@@ -388,5 +387,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end -}}
 {{- end -}}

--- a/deploy/helm/charts/charts/crds/templates/zfsbackup.yaml
+++ b/deploy/helm/charts/charts/crds/templates/zfsbackup.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.zfsLocalPv.enabled -}}
-{{- $crdName := "zfsbackups.zfs.openebs.io" -}}
-{{- if (include "crdIsAbsent" (list $crdName)) -}}
 ##############################################
 ###########                       ############
 ###########   ZFSBackup CRD       ############
@@ -17,6 +15,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
+    {{- include "crds.extraAnnotations" .Values.zfsLocalPv | nindent 4 }}
   creationTimestamp: null
   name: zfsbackups.zfs.openebs.io
 spec:
@@ -115,5 +114,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end -}}
 {{- end -}}

--- a/deploy/helm/charts/charts/crds/templates/zfsnode.yaml
+++ b/deploy/helm/charts/charts/crds/templates/zfsnode.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.zfsLocalPv.enabled -}}
-{{- $crdName := "zfsnodes.zfs.openebs.io" -}}
-{{- if (include "crdIsAbsent" (list $crdName)) -}}
 ##############################################
 ###########                       ############
 ###########     ZFSNode CRD       ############
@@ -17,6 +15,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
+    {{- include "crds.extraAnnotations" .Values.zfsLocalPv | nindent 4 }}
   creationTimestamp: null
   name: zfsnodes.zfs.openebs.io
 spec:
@@ -95,5 +94,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end -}}
 {{- end -}}

--- a/deploy/helm/charts/charts/crds/templates/zfsrestore.yaml
+++ b/deploy/helm/charts/charts/crds/templates/zfsrestore.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.zfsLocalPv.enabled -}}
-{{- $crdName := "zfsrestores.zfs.openebs.io" -}}
-{{- if (include "crdIsAbsent" (list $crdName)) -}}
 ##############################################
 ###########                       ############
 ###########   ZFSRestore CRD      ############
@@ -17,6 +15,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
+    {{- include "crds.extraAnnotations" .Values.zfsLocalPv | nindent 4 }}
   creationTimestamp: null
   name: zfsrestores.zfs.openebs.io
 spec:
@@ -237,5 +236,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end -}}
 {{- end -}}

--- a/deploy/helm/charts/charts/crds/templates/zfssnapshot.yaml
+++ b/deploy/helm/charts/charts/crds/templates/zfssnapshot.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.zfsLocalPv.enabled -}}
-{{- $crdName := "zfssnapshots.zfs.openebs.io" -}}
-{{- if (include "crdIsAbsent" (list $crdName)) -}}
 ##############################################
 ###########                       ############
 ###########   ZFSSnapshot CRD     ############
@@ -17,6 +15,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
+    {{- include "crds.extraAnnotations" .Values.zfsLocalPv | nindent 4 }}
   creationTimestamp: null
   name: zfssnapshots.zfs.openebs.io
 spec:
@@ -382,5 +381,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end -}}
 {{- end -}}

--- a/deploy/helm/charts/charts/crds/templates/zfsvolume.yaml
+++ b/deploy/helm/charts/charts/crds/templates/zfsvolume.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.zfsLocalPv.enabled -}}
-{{- $crdName := "zfsvolumes.zfs.openebs.io" -}}
-{{- if (include "crdIsAbsent" (list $crdName)) -}}
 ##############################################
 ###########                       ############
 ###########   ZFSVolume CRD       ############
@@ -17,6 +15,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
+    {{- include "crds.extraAnnotations" .Values.zfsLocalPv | nindent 4 }}
   creationTimestamp: null
   name: zfsvolumes.zfs.openebs.io
 spec:
@@ -448,5 +447,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end -}}
 {{- end -}}

--- a/deploy/helm/charts/charts/crds/values.yaml
+++ b/deploy/helm/charts/charts/crds/values.yaml
@@ -1,8 +1,12 @@
 zfsLocalPv:
   # Install zfs-localpv CRDs
   enabled: true
+  # -- Keep CRDs on chart uninstall
+  keep: true
 
 csi:
   volumeSnapshots:
     # Install Volume Snapshot CRDs
     enabled: true
+    # -- Keep CRDs on chart uninstall
+    keep: true

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 release:
-  version: "2.5.0"
+  version: "2.5.1"
 
 imagePullSecrets:
 # - name: "image-pull-secret"


### PR DESCRIPTION
#### Why do we need this PR?

It was seen that on upgrade to 1.5.x the CRDs get removed causing the removal of CRs. This would prevent it.
It also adds annotations to let helm keep the CRDs on uninstall, which is configurable.