### PR TITLE
fix(path): handle trailing slash (/) in kubelet directory

### DIFF
--- a/deploy/helm/charts/templates/_helpers.tpl
+++ b/deploy/helm/charts/templates/_helpers.tpl
@@ -147,3 +147,10 @@ Enable zfsController containers leader election if replicas > 1
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Ensure that the path to kubelet ends with a slash
+*/}}
+{{- define "zfslocalpv.zfsNode.kubeletDir" -}}
+{{- printf "%s/" (.Values.zfsNode.kubeletDir | trimSuffix "/") -}}
+{{- end }}

--- a/deploy/helm/charts/templates/zfs-node.yaml
+++ b/deploy/helm/charts/templates/zfs-node.yaml
@@ -55,7 +55,7 @@ spec:
             - name: ADDRESS
               value: /plugin/csi.sock
             - name: DRIVER_REG_SOCK_PATH
-              value: {{ if hasSuffix .Values.zfsNode.kubeletDir "/" }}{{ .Values.zfsNode.kubeletDir }}{{ else }}{{ .Values.zfsNode.kubeletDir }}/{{ end }}plugins/zfs-localpv/csi.sock
+              value: {{ printf "%s%s" (include "zfslocalpv.zfsNode.kubeletDir" .) "plugins/zfs-localpv/csi.sock" | quote }}
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -107,7 +107,7 @@ spec:
               mountPropagation: "HostToContainer"
               readOnly: true
             - name: pods-mount-dir
-              mountPath: {{ if hasSuffix .Values.zfsNode.kubeletDir "/" }}{{ .Values.zfsNode.kubeletDir }}{{ else }}{{ .Values.zfsNode.kubeletDir }}/{{ end }}
+              mountPath: {{ include "zfslocalpv.zfsNode.kubeletDir" . | quote }}
               # needed so that any mounts setup inside this container are
               # propagated back to the host machine.
               mountPropagation: "Bidirectional"
@@ -130,15 +130,15 @@ spec:
             type: Directory
         - name: registration-dir
           hostPath:
-            path: {{ if hasSuffix .Values.zfsNode.kubeletDir "/" }}{{ .Values.zfsNode.kubeletDir }}{{ else }}{{ .Values.zfsNode.kubeletDir }}/{{ end }}plugins_registry/
+            path: {{ printf "%s%s" (include "zfslocalpv.zfsNode.kubeletDir" .) "plugins_registry/" | quote }}
             type: DirectoryOrCreate
         - name: plugin-dir
           hostPath:
-            path: {{ if hasSuffix .Values.zfsNode.kubeletDir "/" }}{{ .Values.zfsNode.kubeletDir }}{{ else }}{{ .Values.zfsNode.kubeletDir }}/{{ end }}plugins/zfs-localpv/
+            path: {{ printf "%s%s" (include "zfslocalpv.zfsNode.kubeletDir" .) "plugins/zfs-localpv/" | quote }}
             type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
-            path: {{ if hasSuffix .Values.zfsNode.kubeletDir "/" }}{{ .Values.zfsNode.kubeletDir }}{{ else }}{{ .Values.zfsNode.kubeletDir }}/{{ end }}
+            path: {{ include "zfslocalpv.zfsNode.kubeletDir" . | quote }}
             type: Directory
 {{- if .Values.zfsNode.additionalVolumes }}
 {{- range $name, $config := .Values.zfsNode.additionalVolumes }}

--- a/deploy/helm/charts/templates/zfs-node.yaml
+++ b/deploy/helm/charts/templates/zfs-node.yaml
@@ -55,7 +55,7 @@ spec:
             - name: ADDRESS
               value: /plugin/csi.sock
             - name: DRIVER_REG_SOCK_PATH
-              value: {{ .Values.zfsNode.kubeletDir }}plugins/zfs-localpv/csi.sock
+              value: {{ if hasSuffix .Values.zfsNode.kubeletDir "/" }}{{ .Values.zfsNode.kubeletDir }}{{ else }}{{ .Values.zfsNode.kubeletDir }}/{{ end }}plugins/zfs-localpv/csi.sock
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -107,7 +107,7 @@ spec:
               mountPropagation: "HostToContainer"
               readOnly: true
             - name: pods-mount-dir
-              mountPath: {{ .Values.zfsNode.kubeletDir }}
+              mountPath: {{ if hasSuffix .Values.zfsNode.kubeletDir "/" }}{{ .Values.zfsNode.kubeletDir }}{{ else }}{{ .Values.zfsNode.kubeletDir }}/{{ end }}
               # needed so that any mounts setup inside this container are
               # propagated back to the host machine.
               mountPropagation: "Bidirectional"
@@ -130,15 +130,15 @@ spec:
             type: Directory
         - name: registration-dir
           hostPath:
-            path: {{ .Values.zfsNode.kubeletDir }}plugins_registry/
+            path: {{ if hasSuffix .Values.zfsNode.kubeletDir "/" }}{{ .Values.zfsNode.kubeletDir }}{{ else }}{{ .Values.zfsNode.kubeletDir }}/{{ end }}plugins_registry/
             type: DirectoryOrCreate
         - name: plugin-dir
           hostPath:
-            path: {{ .Values.zfsNode.kubeletDir }}plugins/zfs-localpv/
+            path: {{ if hasSuffix .Values.zfsNode.kubeletDir "/" }}{{ .Values.zfsNode.kubeletDir }}{{ else }}{{ .Values.zfsNode.kubeletDir }}/{{ end }}plugins/zfs-localpv/
             type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
-            path: {{ .Values.zfsNode.kubeletDir }}
+            path: {{ if hasSuffix .Values.zfsNode.kubeletDir "/" }}{{ .Values.zfsNode.kubeletDir }}{{ else }}{{ .Values.zfsNode.kubeletDir }}/{{ end }}
             type: Directory
 {{- if .Values.zfsNode.additionalVolumes }}
 {{- range $name, $config := .Values.zfsNode.additionalVolumes }}


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

Fixes: https://github.com/openebs/zfs-localpv/issues/530

**What this PR does?**:

Handle the condition where user may or may not give the kubelet path with trailing slash (/) in --set command for custom kubelet configuration. 

