### PR TITLE
feat(zfs-localpv): add option for choosing between refquota and quota

### DIFF
--- a/deploy/helm/charts/charts/crds/templates/zfsrestore.yaml
+++ b/deploy/helm/charts/charts/crds/templates/zfsrestore.yaml
@@ -159,8 +159,8 @@ spec:
                   type is of type "quota" or "refquota". QuotaType can not be modified
                   once volume has been provisioned. Default Value: quota.'
                 enum:
-                  - quota
-                  - refquota
+                - quota
+                - refquota
                 type: string
               recordsize:
                 description: 'Specifies a suggested block size for files in the file

--- a/deploy/helm/charts/charts/crds/templates/zfsrestore.yaml
+++ b/deploy/helm/charts/charts/crds/templates/zfsrestore.yaml
@@ -154,6 +154,14 @@ spec:
                   been provisioned.
                 minLength: 1
                 type: string
+              quotaType:
+                description: 'quotaType determines whether the dataset volume quota
+                  type is of type "quota" or "refquota". QuotaType can not be modified
+                  once volume has been provisioned. Default Value: quota.'
+                enum:
+                  - quota
+                  - refquota
+                type: string
               recordsize:
                 description: 'Specifies a suggested block size for files in the file
                   system. The size specified must be a power of two greater than or

--- a/deploy/helm/charts/charts/crds/templates/zfssnapshot.yaml
+++ b/deploy/helm/charts/charts/crds/templates/zfssnapshot.yaml
@@ -123,6 +123,14 @@ spec:
                   been provisioned.
                 minLength: 1
                 type: string
+              quotaType:
+                description: 'quotaType determines whether the dataset volume quota
+                  type is of type "quota" or "refquota". QuotaType can not be modified
+                  once volume has been provisioned. Default Value: quota.'
+                enum:
+                  - quota
+                  - refquota
+                type: string
               recordsize:
                 description: 'Specifies a suggested block size for files in the file
                   system. The size specified must be a power of two greater than or

--- a/deploy/helm/charts/charts/crds/templates/zfssnapshot.yaml
+++ b/deploy/helm/charts/charts/crds/templates/zfssnapshot.yaml
@@ -128,8 +128,8 @@ spec:
                   type is of type "quota" or "refquota". QuotaType can not be modified
                   once volume has been provisioned. Default Value: quota.'
                 enum:
-                  - quota
-                  - refquota
+                - quota
+                - refquota
                 type: string
               recordsize:
                 description: 'Specifies a suggested block size for files in the file

--- a/deploy/helm/charts/charts/crds/templates/zfsvolume.yaml
+++ b/deploy/helm/charts/charts/crds/templates/zfsvolume.yaml
@@ -154,8 +154,8 @@ spec:
                   type is of type "quota" or "refquota". QuotaType can not be modified
                   once volume has been provisioned. Default Value: quota.'
                 enum:
-                  - quota
-                  - refquota
+                - quota
+                - refquota
                 type: string
               recordsize:
                 description: 'Specifies a suggested block size for files in the file

--- a/deploy/helm/charts/charts/crds/templates/zfsvolume.yaml
+++ b/deploy/helm/charts/charts/crds/templates/zfsvolume.yaml
@@ -149,6 +149,14 @@ spec:
                   been provisioned.
                 minLength: 1
                 type: string
+              quotaType:
+                description: 'quotaType determines whether the dataset volume quota
+                  type is of type "quota" or "refquota". QuotaType can not be modified
+                  once volume has been provisioned. Default Value: quota.'
+                enum:
+                  - quota
+                  - refquota
+                type: string
               recordsize:
                 description: 'Specifies a suggested block size for files in the file
                   system. The size specified must be a power of two greater than or

--- a/deploy/yamls/zfsrestore-crd.yaml
+++ b/deploy/yamls/zfsrestore-crd.yaml
@@ -152,6 +152,14 @@ spec:
                   been provisioned.
                 minLength: 1
                 type: string
+              quotaType:
+                description: 'quotaType determines whether the dataset volume quota
+                  type is of type "quota" or "refquota". QuotaType can not be modified
+                  once volume has been provisioned. Default Value: quota.'
+                enum:
+                - quota
+                - refquota
+                type: string
               recordsize:
                 description: 'Specifies a suggested block size for files in the file
                   system. The size specified must be a power of two greater than or

--- a/deploy/yamls/zfssnapshot-crd.yaml
+++ b/deploy/yamls/zfssnapshot-crd.yaml
@@ -121,6 +121,14 @@ spec:
                   been provisioned.
                 minLength: 1
                 type: string
+              quotaType:
+                description: 'quotaType determines whether the dataset volume quota
+                  type is of type "quota" or "refquota". QuotaType can not be modified
+                  once volume has been provisioned. Default Value: quota.'
+                enum:
+                - quota
+                - refquota
+                type: string
               recordsize:
                 description: 'Specifies a suggested block size for files in the file
                   system. The size specified must be a power of two greater than or

--- a/deploy/yamls/zfsvolume-crd.yaml
+++ b/deploy/yamls/zfsvolume-crd.yaml
@@ -147,6 +147,14 @@ spec:
                   been provisioned.
                 minLength: 1
                 type: string
+              quotaType:
+                description: 'quotaType determines whether the dataset volume quota
+                  type is of type "quota" or "refquota". QuotaType can not be modified
+                  once volume has been provisioned. Default Value: quota.'
+                enum:
+                - quota
+                - refquota
+                type: string
               recordsize:
                 description: 'Specifies a suggested block size for files in the file
                   system. The size specified must be a power of two greater than or

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -39,6 +39,7 @@ metadata:
   labels:
     openebs.io/version: "2.7.0-develop"
     role: "openebs-zfs"
+    app: "openebs-zfs-node"
     name: "openebs-zfs-node"
     openebs.io/component-name: "openebs-zfs-node"
 ---
@@ -51,6 +52,7 @@ metadata:
   labels:
     openebs.io/version: "2.7.0-develop"
     role: "openebs-zfs"
+    app: "openebs-zfs-node"
     name: "openebs-zfs-node"
     openebs.io/component-name: "openebs-zfs-node"
 data:
@@ -71,7 +73,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-csi/external-snapshotter/pull/814
     controller-gen.kubebuilder.io/version: v0.11.3
-
+    
   creationTimestamp: null
   name: volumesnapshotclasses.snapshot.storage.k8s.io
 spec:
@@ -221,7 +223,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-csi/external-snapshotter/pull/814
     controller-gen.kubebuilder.io/version: v0.11.3
-
+    
   creationTimestamp: null
   name: volumesnapshotcontents.snapshot.storage.k8s.io
 spec:
@@ -709,7 +711,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-csi/external-snapshotter/pull/814
     controller-gen.kubebuilder.io/version: v0.11.3
-
+    
   creationTimestamp: null
   name: volumesnapshots.snapshot.storage.k8s.io
 spec:
@@ -1098,7 +1100,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
-
+    
   creationTimestamp: null
   name: zfsbackups.zfs.openebs.io
 spec:
@@ -1108,89 +1110,89 @@ spec:
     listKind: ZFSBackupList
     plural: zfsbackups
     shortNames:
-      - zb
+    - zb
     singular: zfsbackup
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - description: Previous snapshot for backup
-          jsonPath: .spec.prevSnapName
-          name: PrevSnap
-          type: string
-        - description: Backup status
-          jsonPath: .status
-          name: Status
-          type: string
-        - description: Age of the volume
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description: ZFSBackup describes a zfs backup resource created as a custom
-            resource
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - additionalPrinterColumns:
+    - description: Previous snapshot for backup
+      jsonPath: .spec.prevSnapName
+      name: PrevSnap
+      type: string
+    - description: Backup status
+      jsonPath: .status
+      name: Status
+      type: string
+    - description: Age of the volume
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ZFSBackup describes a zfs backup resource created as a custom
+          resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ZFSBackupSpec is the spec for a ZFSBackup resource
-              properties:
-                backupDest:
-                  description: BackupDest is the remote address for backup transfer
-                  minLength: 1
-                  pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
-                  type: string
-                ownerNodeID:
-                  description: OwnerNodeID is a name of the nodes where the source volume
-                    is
-                  minLength: 1
-                  type: string
-                prevSnapName:
-                  description: PrevSnapName is the last completed-backup's snapshot
-                    name
-                  type: string
-                snapName:
-                  description: SnapName is the snapshot name for backup
-                  minLength: 1
-                  type: string
-                volumeName:
-                  description: VolumeName is a name of the volume for which this backup
-                    is destined
-                  minLength: 1
-                  type: string
-              required:
-                - backupDest
-                - ownerNodeID
-                - volumeName
-              type: object
-            status:
-              description: ZFSBackupStatus is to hold status of backup
-              enum:
-                - Init
-                - Done
-                - Failed
-                - Pending
-                - InProgress
-                - Invalid
-              type: string
-          required:
-            - spec
-            - status
-          type: object
-      served: true
-      storage: true
-      subresources: {}
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ZFSBackupSpec is the spec for a ZFSBackup resource
+            properties:
+              backupDest:
+                description: BackupDest is the remote address for backup transfer
+                minLength: 1
+                pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is a name of the nodes where the source volume
+                  is
+                minLength: 1
+                type: string
+              prevSnapName:
+                description: PrevSnapName is the last completed-backup's snapshot
+                  name
+                type: string
+              snapName:
+                description: SnapName is the snapshot name for backup
+                minLength: 1
+                type: string
+              volumeName:
+                description: VolumeName is a name of the volume for which this backup
+                  is destined
+                minLength: 1
+                type: string
+            required:
+            - backupDest
+            - ownerNodeID
+            - volumeName
+            type: object
+          status:
+            description: ZFSBackupStatus is to hold status of backup
+            enum:
+            - Init
+            - Done
+            - Failed
+            - Pending
+            - InProgress
+            - Invalid
+            type: string
+        required:
+        - spec
+        - status
+        type: object
+    served: true
+    storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""
@@ -1204,7 +1206,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
-
+    
   creationTimestamp: null
   name: zfsnodes.zfs.openebs.io
 spec:
@@ -1214,69 +1216,69 @@ spec:
     listKind: ZFSNodeList
     plural: zfsnodes
     shortNames:
-      - zfsnode
+    - zfsnode
     singular: zfsnode
   scope: Namespaced
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: ZFSNode records information about all zfs pools available in
-            a node. In general, the openebs node-agent creates the ZFSNode object &
-            periodically synchronizing the zfs pools available in the node. ZFSNode
-            has an owner reference pointing to the corresponding node object.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ZFSNode records information about all zfs pools available in
+          a node. In general, the openebs node-agent creates the ZFSNode object &
+          periodically synchronizing the zfs pools available in the node. ZFSNode
+          has an owner reference pointing to the corresponding node object.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
+            type: string
+          metadata:
+            type: object
+          pools:
+            items:
+              description: Pool specifies attributes of a given zfs pool that exists
+                on the node.
+              properties:
+                free:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: Free specifies the available capacity of zfs pool.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                name:
+                  description: Name of the zfs pool.
+                  minLength: 1
+                  type: string
+                used:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: Used specifies the used capacity of zfs pool.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                uuid:
+                  description: UUID denotes a unique identity of a zfs pool.
+                  minLength: 1
+                  type: string
+              required:
+              - free
+              - name
+              - used
+              - uuid
               type: object
-            pools:
-              items:
-                description: Pool specifies attributes of a given zfs pool that exists
-                  on the node.
-                properties:
-                  free:
-                    anyOf:
-                      - type: integer
-                      - type: string
-                    description: Free specifies the available capacity of zfs pool.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  name:
-                    description: Name of the zfs pool.
-                    minLength: 1
-                    type: string
-                  used:
-                    anyOf:
-                      - type: integer
-                      - type: string
-                    description: Used specifies the used capacity of zfs pool.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  uuid:
-                    description: UUID denotes a unique identity of a zfs pool.
-                    minLength: 1
-                    type: string
-                required:
-                  - free
-                  - name
-                  - used
-                  - uuid
-                type: object
-              type: array
-          required:
-            - pools
-          type: object
-      served: true
-      storage: true
+            type: array
+        required:
+        - pools
+        type: object
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""
@@ -1290,7 +1292,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
-
+    
   creationTimestamp: null
   name: zfsrestores.zfs.openebs.io
 spec:
@@ -1302,71 +1304,71 @@ spec:
     singular: zfsrestore
   scope: Namespaced
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: ZFSRestore describes a cstor restore resource created as a custom
-            resource
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ZFSRestore describes a cstor restore resource created as a custom
+          resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ZFSRestoreSpec is the spec for a ZFSRestore resource
-              properties:
-                ownerNodeID:
-                  description: owner node name where restore volume is present
-                  minLength: 1
-                  type: string
-                restoreSrc:
-                  description: it can be ip:port in case of restore from remote or volumeName
-                    in case of local restore
-                  minLength: 1
-                  pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
-                  type: string
-                volumeName:
-                  description: volume name to where restore has to be performed
-                  minLength: 1
-                  type: string
-              required:
-                - ownerNodeID
-                - restoreSrc
-                - volumeName
-              type: object
-            status:
-              description: ZFSRestoreStatus is to hold result of action.
-              enum:
-                - Init
-                - Done
-                - Failed
-                - Pending
-                - InProgress
-                - Invalid
-              type: string
-            volSpec:
-              description: VolumeInfo defines ZFS volume parameters for all modes in
-                which ZFS volumes can be created like - ZFS volume with filesystem,
-                ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
-                Some of the parameters can be only set during creation time (as specified
-                in the details of the parameter), and a few are editable. In case of
-                Cloned volumes, the parameters are assigned the same values as the source
-                volume.
-              properties:
-                capacity:
-                  description: Capacity of the volume
-                  minLength: 1
-                  type: string
-                compression:
-                  description: 'Compression specifies the block-level compression algorithm
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ZFSRestoreSpec is the spec for a ZFSRestore resource
+            properties:
+              ownerNodeID:
+                description: owner node name where restore volume is present
+                minLength: 1
+                type: string
+              restoreSrc:
+                description: it can be ip:port in case of restore from remote or volumeName
+                  in case of local restore
+                minLength: 1
+                pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
+                type: string
+              volumeName:
+                description: volume name to where restore has to be performed
+                minLength: 1
+                type: string
+            required:
+            - ownerNodeID
+            - restoreSrc
+            - volumeName
+            type: object
+          status:
+            description: ZFSRestoreStatus is to hold result of action.
+            enum:
+            - Init
+            - Done
+            - Failed
+            - Pending
+            - InProgress
+            - Invalid
+            type: string
+          volSpec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
                   to be applied to the ZFS Volume. The value "on" indicates ZFS to
                   use the default compression algorithm. The default compression algorithm
                   used by ZFS will be either lzjb or, if the lz4_compress feature
@@ -1375,10 +1377,10 @@ spec:
                   data. For instance, if the Volume was created with "off" and the
                   next day the compression was modified to "on", the data written
                   prior to setting "on" will not be compressed. Default Value: off.'
-                  pattern: ^(on|off|lzjb|zstd|zstd-[1-9]|zstd-1[0-9]|gzip|gzip-[1-9]|zle|lz4)$
-                  type: string
-                dedup:
-                  description: 'Deduplication is the process for removing redundant
+                pattern: ^(on|off|lzjb|zstd|zstd-[1-9]|zstd-1[0-9]|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
                   data at the block level, reducing the total amount of data stored.
                   If a file system has the dedup property enabled, duplicate data
                   blocks are removed synchronously. The result is that only unique
@@ -1391,12 +1393,12 @@ spec:
                   using compression=lz4, as a less resource-intensive alternative.
                   should be enabled on the zvol. Dedup property can be edited after
                   the volume has been created. Default Value: off.'
-                  enum:
-                    - "on"
-                    - "off"
-                  type: string
-                encryption:
-                  description: 'Enabling the encryption feature allows for the creation
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
                   of encrypted filesystems and volumes. ZFS will encrypt file and
                   zvol data, file attributes, ACLs, permission bits, directory listings,
                   FUID mappings, and userused / groupused data. ZFS will not encrypt
@@ -1404,64 +1406,72 @@ spec:
                   names, dataset hierarchy, properties, file size, file holes, and
                   deduplication tables (though the deduplicated data itself is encrypted).
                   Default Value: off.'
-                  pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
-                  type: string
-                fsType:
-                  description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
                   If FsType is provided as "zfs", then the driver will create a ZFS
                   dataset, formatting is not required as underlying filesystem is
                   ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
                   will create a ZVOL and format the volume accordingly. FsType can
                   not be modified once volume has been provisioned. Default Value:
                   ext4.'
-                  type: string
-                keyformat:
-                  description: KeyFormat specifies format of the encryption key The
-                    supported KeyFormats are passphrase, raw, hex.
-                  enum:
-                    - passphrase
-                    - raw
-                    - hex
-                  type: string
-                keylocation:
-                  description: KeyLocation is the location of key for the encryption
-                  type: string
-                ownerNodeID:
-                  description: OwnerNodeID is the Node ID where the ZPOOL is running
-                    which is where the volume has been provisioned. OwnerNodeID can
-                    not be edited after the volume has been provisioned.
-                  minLength: 1
-                  type: string
-                poolName:
-                  description: poolName specifies the name of the pool where the volume
-                    has been created. PoolName can not be edited after the volume has
-                    been provisioned.
-                  minLength: 1
-                  type: string
-                recordsize:
-                  description: 'Specifies a suggested block size for files in the file
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              quotaType:
+                description: 'quotaType determines whether the dataset volume quota
+                  type is of type "quota" or "refquota". QuotaType can not be modified
+                  once volume has been provisioned. Default Value: quota.'
+                enum:
+                - quota
+                - refquota
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
                   system. The size specified must be a power of two greater than or
                   equal to 512 and less than or equal to 128 Kbytes. RecordSize property
                   can be edited after the volume has been created. Changing the file
                   system''s recordsize affects only files created afterward; existing
                   files are unaffected. Default Value: 128k.'
-                  minLength: 1
-                  type: string
-                shared:
-                  description: Shared specifies whether the volume can be shared among
-                    multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
-                    will not allow the volumes to be mounted by more than one pods.
-                  enum:
-                    - "yes"
-                    - "no"
-                  type: string
-                snapname:
-                  description: SnapName specifies the name of the snapshot where the
-                    volume has been cloned from. Snapname can not be edited after the
-                    volume has been provisioned.
-                  type: string
-                thinProvision:
-                  description: 'ThinProvision describes whether space reservation for
+                minLength: 1
+                type: string
+              shared:
+                description: Shared specifies whether the volume can be shared among
+                  multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
+                  will not allow the volumes to be mounted by more than one pods.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
                   the source volume is required or not. The value "yes" indicates
                   that volume should be thin provisioned and "no" means thick provisioning
                   of the volume. If thinProvision is set to "yes" then volume can
@@ -1470,41 +1480,41 @@ spec:
                   if the ZPOOL has enough capacity and capacity required by volume
                   can be reserved. ThinProvision can not be modified once volume has
                   been provisioned. Default Value: no.'
-                  enum:
-                    - "yes"
-                    - "no"
-                  type: string
-                volblocksize:
-                  description: 'VolBlockSize specifies the block size for the zvol.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
                   The volsize can only be set to a multiple of volblocksize, and cannot
                   be zero. VolBlockSize can not be edited after the volume has been
                   provisioned. Default Value: 8k.'
-                  minLength: 1
-                  type: string
-                volumeType:
-                  description: volumeType determines whether the volume is of type "DATASET"
-                    or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
-                    of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
-                    is mentioned as fstype in the storageclass, then a volume of type
-                    zvol will be created, which will be further formatted as the fstype
-                    provided in the storageclass. VolumeType can not be modified once
-                    volume has been provisioned.
-                  enum:
-                    - ZVOL
-                    - DATASET
-                  type: string
-              required:
-                - capacity
-                - ownerNodeID
-                - poolName
-                - volumeType
-              type: object
-          required:
-            - spec
-            - status
-          type: object
-      served: true
-      storage: true
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+        required:
+        - spec
+        - status
+        type: object
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""
@@ -1518,7 +1528,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
-
+    
   creationTimestamp: null
   name: zfssnapshots.zfs.openebs.io
 spec:
@@ -1528,42 +1538,42 @@ spec:
     listKind: ZFSSnapshotList
     plural: zfssnapshots
     shortNames:
-      - zfssnap
+    - zfssnap
     singular: zfssnapshot
   scope: Namespaced
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: ZFSSnapshot represents a ZFS Snapshot of the zfsvolume
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ZFSSnapshot represents a ZFS Snapshot of the zfsvolume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: VolumeInfo defines ZFS volume parameters for all modes in
-                which ZFS volumes can be created like - ZFS volume with filesystem,
-                ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
-                Some of the parameters can be only set during creation time (as specified
-                in the details of the parameter), and a few are editable. In case of
-                Cloned volumes, the parameters are assigned the same values as the source
-                volume.
-              properties:
-                capacity:
-                  description: Capacity of the volume
-                  minLength: 1
-                  type: string
-                compression:
-                  description: 'Compression specifies the block-level compression algorithm
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
                   to be applied to the ZFS Volume. The value "on" indicates ZFS to
                   use the default compression algorithm. The default compression algorithm
                   used by ZFS will be either lzjb or, if the lz4_compress feature
@@ -1572,10 +1582,10 @@ spec:
                   data. For instance, if the Volume was created with "off" and the
                   next day the compression was modified to "on", the data written
                   prior to setting "on" will not be compressed. Default Value: off.'
-                  pattern: ^(on|off|lzjb|zstd|zstd-[1-9]|zstd-1[0-9]|gzip|gzip-[1-9]|zle|lz4)$
-                  type: string
-                dedup:
-                  description: 'Deduplication is the process for removing redundant
+                pattern: ^(on|off|lzjb|zstd|zstd-[1-9]|zstd-1[0-9]|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
                   data at the block level, reducing the total amount of data stored.
                   If a file system has the dedup property enabled, duplicate data
                   blocks are removed synchronously. The result is that only unique
@@ -1588,12 +1598,12 @@ spec:
                   using compression=lz4, as a less resource-intensive alternative.
                   should be enabled on the zvol. Dedup property can be edited after
                   the volume has been created. Default Value: off.'
-                  enum:
-                    - "on"
-                    - "off"
-                  type: string
-                encryption:
-                  description: 'Enabling the encryption feature allows for the creation
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
                   of encrypted filesystems and volumes. ZFS will encrypt file and
                   zvol data, file attributes, ACLs, permission bits, directory listings,
                   FUID mappings, and userused / groupused data. ZFS will not encrypt
@@ -1601,64 +1611,72 @@ spec:
                   names, dataset hierarchy, properties, file size, file holes, and
                   deduplication tables (though the deduplicated data itself is encrypted).
                   Default Value: off.'
-                  pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
-                  type: string
-                fsType:
-                  description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
                   If FsType is provided as "zfs", then the driver will create a ZFS
                   dataset, formatting is not required as underlying filesystem is
                   ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
                   will create a ZVOL and format the volume accordingly. FsType can
                   not be modified once volume has been provisioned. Default Value:
                   ext4.'
-                  type: string
-                keyformat:
-                  description: KeyFormat specifies format of the encryption key The
-                    supported KeyFormats are passphrase, raw, hex.
-                  enum:
-                    - passphrase
-                    - raw
-                    - hex
-                  type: string
-                keylocation:
-                  description: KeyLocation is the location of key for the encryption
-                  type: string
-                ownerNodeID:
-                  description: OwnerNodeID is the Node ID where the ZPOOL is running
-                    which is where the volume has been provisioned. OwnerNodeID can
-                    not be edited after the volume has been provisioned.
-                  minLength: 1
-                  type: string
-                poolName:
-                  description: poolName specifies the name of the pool where the volume
-                    has been created. PoolName can not be edited after the volume has
-                    been provisioned.
-                  minLength: 1
-                  type: string
-                recordsize:
-                  description: 'Specifies a suggested block size for files in the file
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              quotaType:
+                description: 'quotaType determines whether the dataset volume quota
+                  type is of type "quota" or "refquota". QuotaType can not be modified
+                  once volume has been provisioned. Default Value: quota.'
+                enum:
+                - quota
+                - refquota
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
                   system. The size specified must be a power of two greater than or
                   equal to 512 and less than or equal to 128 Kbytes. RecordSize property
                   can be edited after the volume has been created. Changing the file
                   system''s recordsize affects only files created afterward; existing
                   files are unaffected. Default Value: 128k.'
-                  minLength: 1
-                  type: string
-                shared:
-                  description: Shared specifies whether the volume can be shared among
-                    multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
-                    will not allow the volumes to be mounted by more than one pods.
-                  enum:
-                    - "yes"
-                    - "no"
-                  type: string
-                snapname:
-                  description: SnapName specifies the name of the snapshot where the
-                    volume has been cloned from. Snapname can not be edited after the
-                    volume has been provisioned.
-                  type: string
-                thinProvision:
-                  description: 'ThinProvision describes whether space reservation for
+                minLength: 1
+                type: string
+              shared:
+                description: Shared specifies whether the volume can be shared among
+                  multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
+                  will not allow the volumes to be mounted by more than one pods.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
                   the source volume is required or not. The value "yes" indicates
                   that volume should be thin provisioned and "no" means thick provisioning
                   of the volume. If thinProvision is set to "yes" then volume can
@@ -1667,80 +1685,80 @@ spec:
                   if the ZPOOL has enough capacity and capacity required by volume
                   can be reserved. ThinProvision can not be modified once volume has
                   been provisioned. Default Value: no.'
-                  enum:
-                    - "yes"
-                    - "no"
-                  type: string
-                volblocksize:
-                  description: 'VolBlockSize specifies the block size for the zvol.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
                   The volsize can only be set to a multiple of volblocksize, and cannot
                   be zero. VolBlockSize can not be edited after the volume has been
                   provisioned. Default Value: 8k.'
-                  minLength: 1
-                  type: string
-                volumeType:
-                  description: volumeType determines whether the volume is of type "DATASET"
-                    or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
-                    of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
-                    is mentioned as fstype in the storageclass, then a volume of type
-                    zvol will be created, which will be further formatted as the fstype
-                    provided in the storageclass. VolumeType can not be modified once
-                    volume has been provisioned.
-                  enum:
-                    - ZVOL
-                    - DATASET
-                  type: string
-              required:
-                - capacity
-                - ownerNodeID
-                - poolName
-                - volumeType
-              type: object
-            status:
-              description: SnapStatus string that reflects if the snapshot was created
-                successfully
-              properties:
-                state:
-                  type: string
-              type: object
-          required:
-            - spec
-            - status
-          type: object
-      served: true
-      storage: true
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: ZFSSnapshot represents a ZFS Snapshot of the zfsvolume
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+          status:
+            description: SnapStatus string that reflects if the snapshot was created
+              successfully
+            properties:
+              state:
+                type: string
+            type: object
+        required:
+        - spec
+        - status
+        type: object
+    served: true
+    storage: true
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ZFSSnapshot represents a ZFS Snapshot of the zfsvolume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: VolumeInfo defines ZFS volume parameters for all modes in
-                which ZFS volumes can be created like - ZFS volume with filesystem,
-                ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
-                Some of the parameters can be only set during creation time (as specified
-                in the details of the parameter), and a few are editable. In case of
-                Cloned volumes, the parameters are assigned the same values as the source
-                volume.
-              properties:
-                capacity:
-                  description: Capacity of the volume
-                  minLength: 1
-                  type: string
-                compression:
-                  description: 'Compression specifies the block-level compression algorithm
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
                   to be applied to the ZFS Volume. The value "on" indicates ZFS to
                   use the default compression algorithm. The default compression algorithm
                   used by ZFS will be either lzjb or, if the lz4_compress feature
@@ -1749,10 +1767,10 @@ spec:
                   data. For instance, if the Volume was created with "off" and the
                   next day the compression was modified to "on", the data written
                   prior to setting "on" will not be compressed. Default Value: off.'
-                  pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
-                  type: string
-                dedup:
-                  description: 'Deduplication is the process for removing redundant
+                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
                   data at the block level, reducing the total amount of data stored.
                   If a file system has the dedup property enabled, duplicate data
                   blocks are removed synchronously. The result is that only unique
@@ -1765,12 +1783,12 @@ spec:
                   using compression=lz4, as a less resource-intensive alternative.
                   should be enabled on the zvol. Dedup property can be edited after
                   the volume has been created. Default Value: off.'
-                  enum:
-                    - "on"
-                    - "off"
-                  type: string
-                encryption:
-                  description: 'Enabling the encryption feature allows for the creation
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
                   of encrypted filesystems and volumes. ZFS will encrypt file and
                   zvol data, file attributes, ACLs, permission bits, directory listings,
                   FUID mappings, and userused / groupused data. ZFS will not encrypt
@@ -1778,56 +1796,56 @@ spec:
                   names, dataset hierarchy, properties, file size, file holes, and
                   deduplication tables (though the deduplicated data itself is encrypted).
                   Default Value: off.'
-                  pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
-                  type: string
-                fsType:
-                  description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
                   If FsType is provided as "zfs", then the driver will create a ZFS
                   dataset, formatting is not required as underlying filesystem is
                   ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
                   will create a ZVOL and format the volume accordingly. FsType can
                   not be modified once volume has been provisioned. Default Value:
                   ext4.'
-                  type: string
-                keyformat:
-                  description: KeyFormat specifies format of the encryption key The
-                    supported KeyFormats are passphrase, raw, hex.
-                  enum:
-                    - passphrase
-                    - raw
-                    - hex
-                  type: string
-                keylocation:
-                  description: KeyLocation is the location of key for the encryption
-                  type: string
-                ownerNodeID:
-                  description: OwnerNodeID is the Node ID where the ZPOOL is running
-                    which is where the volume has been provisioned. OwnerNodeID can
-                    not be edited after the volume has been provisioned.
-                  minLength: 1
-                  type: string
-                poolName:
-                  description: poolName specifies the name of the pool where the volume
-                    has been created. PoolName can not be edited after the volume has
-                    been provisioned.
-                  minLength: 1
-                  type: string
-                recordsize:
-                  description: 'Specifies a suggested block size for files in the file
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
                   system. The size specified must be a power of two greater than or
                   equal to 512 and less than or equal to 128 Kbytes. RecordSize property
                   can be edited after the volume has been created. Changing the file
                   system''s recordsize affects only files created afterward; existing
                   files are unaffected. Default Value: 128k.'
-                  minLength: 1
-                  type: string
-                snapname:
-                  description: SnapName specifies the name of the snapshot where the
-                    volume has been cloned from. Snapname can not be edited after the
-                    volume has been provisioned.
-                  type: string
-                thinProvision:
-                  description: 'ThinProvision describes whether space reservation for
+                minLength: 1
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
                   the source volume is required or not. The value "yes" indicates
                   that volume should be thin provisioned and "no" means thick provisioning
                   of the volume. If thinProvision is set to "yes" then volume can
@@ -1836,48 +1854,48 @@ spec:
                   if the ZPOOL has enough capacity and capacity required by volume
                   can be reserved. ThinProvision can not be modified once volume has
                   been provisioned. Default Value: no.'
-                  enum:
-                    - "yes"
-                    - "no"
-                  type: string
-                volblocksize:
-                  description: 'VolBlockSize specifies the block size for the zvol.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
                   The volsize can only be set to a multiple of volblocksize, and cannot
                   be zero. VolBlockSize can not be edited after the volume has been
                   provisioned. Default Value: 8k.'
-                  minLength: 1
-                  type: string
-                volumeType:
-                  description: volumeType determines whether the volume is of type "DATASET"
-                    or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
-                    of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
-                    is mentioned as fstype in the storageclass, then a volume of type
-                    zvol will be created, which will be further formatted as the fstype
-                    provided in the storageclass. VolumeType can not be modified once
-                    volume has been provisioned.
-                  enum:
-                    - ZVOL
-                    - DATASET
-                  type: string
-              required:
-                - capacity
-                - ownerNodeID
-                - poolName
-                - volumeType
-              type: object
-            status:
-              description: SnapStatus string that reflects if the snapshot was created
-                successfully
-              properties:
-                state:
-                  type: string
-              type: object
-          required:
-            - spec
-            - status
-          type: object
-      served: true
-      storage: false
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+          status:
+            description: SnapStatus string that reflects if the snapshot was created
+              successfully
+            properties:
+              state:
+                type: string
+            type: object
+        required:
+        - spec
+        - status
+        type: object
+    served: true
+    storage: false
 status:
   acceptedNames:
     kind: ""
@@ -1891,7 +1909,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
-
+    
   creationTimestamp: null
   name: zfsvolumes.zfs.openebs.io
 spec:
@@ -1901,68 +1919,68 @@ spec:
     listKind: ZFSVolumeList
     plural: zfsvolumes
     shortNames:
-      - zfsvol
-      - zv
+    - zfsvol
+    - zv
     singular: zfsvolume
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - description: ZFS Pool where the volume is created
-          jsonPath: .spec.poolName
-          name: ZPool
-          type: string
-        - description: Node where the volume is created
-          jsonPath: .spec.ownerNodeID
-          name: NodeID
-          type: string
-        - description: Size of the volume
-          jsonPath: .spec.capacity
-          name: Size
-          type: string
-        - description: Status of the volume
-          jsonPath: .status.state
-          name: Status
-          type: string
-        - description: filesystem created on the volume
-          jsonPath: .spec.fsType
-          name: Filesystem
-          type: string
-        - description: Age of the volume
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description: ZFSVolume represents a ZFS based volume
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - additionalPrinterColumns:
+    - description: ZFS Pool where the volume is created
+      jsonPath: .spec.poolName
+      name: ZPool
+      type: string
+    - description: Node where the volume is created
+      jsonPath: .spec.ownerNodeID
+      name: NodeID
+      type: string
+    - description: Size of the volume
+      jsonPath: .spec.capacity
+      name: Size
+      type: string
+    - description: Status of the volume
+      jsonPath: .status.state
+      name: Status
+      type: string
+    - description: filesystem created on the volume
+      jsonPath: .spec.fsType
+      name: Filesystem
+      type: string
+    - description: Age of the volume
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ZFSVolume represents a ZFS based volume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: VolumeInfo defines ZFS volume parameters for all modes in
-                which ZFS volumes can be created like - ZFS volume with filesystem,
-                ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
-                Some of the parameters can be only set during creation time (as specified
-                in the details of the parameter), and a few are editable. In case of
-                Cloned volumes, the parameters are assigned the same values as the source
-                volume.
-              properties:
-                capacity:
-                  description: Capacity of the volume
-                  minLength: 1
-                  type: string
-                compression:
-                  description: 'Compression specifies the block-level compression algorithm
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
                   to be applied to the ZFS Volume. The value "on" indicates ZFS to
                   use the default compression algorithm. The default compression algorithm
                   used by ZFS will be either lzjb or, if the lz4_compress feature
@@ -1971,10 +1989,10 @@ spec:
                   data. For instance, if the Volume was created with "off" and the
                   next day the compression was modified to "on", the data written
                   prior to setting "on" will not be compressed. Default Value: off.'
-                  pattern: ^(on|off|lzjb|zstd|zstd-[1-9]|zstd-1[0-9]|gzip|gzip-[1-9]|zle|lz4)$
-                  type: string
-                dedup:
-                  description: 'Deduplication is the process for removing redundant
+                pattern: ^(on|off|lzjb|zstd|zstd-[1-9]|zstd-1[0-9]|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
                   data at the block level, reducing the total amount of data stored.
                   If a file system has the dedup property enabled, duplicate data
                   blocks are removed synchronously. The result is that only unique
@@ -1987,12 +2005,12 @@ spec:
                   using compression=lz4, as a less resource-intensive alternative.
                   should be enabled on the zvol. Dedup property can be edited after
                   the volume has been created. Default Value: off.'
-                  enum:
-                    - "on"
-                    - "off"
-                  type: string
-                encryption:
-                  description: 'Enabling the encryption feature allows for the creation
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
                   of encrypted filesystems and volumes. ZFS will encrypt file and
                   zvol data, file attributes, ACLs, permission bits, directory listings,
                   FUID mappings, and userused / groupused data. ZFS will not encrypt
@@ -2000,64 +2018,72 @@ spec:
                   names, dataset hierarchy, properties, file size, file holes, and
                   deduplication tables (though the deduplicated data itself is encrypted).
                   Default Value: off.'
-                  pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
-                  type: string
-                fsType:
-                  description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
                   If FsType is provided as "zfs", then the driver will create a ZFS
                   dataset, formatting is not required as underlying filesystem is
                   ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
                   will create a ZVOL and format the volume accordingly. FsType can
                   not be modified once volume has been provisioned. Default Value:
                   ext4.'
-                  type: string
-                keyformat:
-                  description: KeyFormat specifies format of the encryption key The
-                    supported KeyFormats are passphrase, raw, hex.
-                  enum:
-                    - passphrase
-                    - raw
-                    - hex
-                  type: string
-                keylocation:
-                  description: KeyLocation is the location of key for the encryption
-                  type: string
-                ownerNodeID:
-                  description: OwnerNodeID is the Node ID where the ZPOOL is running
-                    which is where the volume has been provisioned. OwnerNodeID can
-                    not be edited after the volume has been provisioned.
-                  minLength: 1
-                  type: string
-                poolName:
-                  description: poolName specifies the name of the pool where the volume
-                    has been created. PoolName can not be edited after the volume has
-                    been provisioned.
-                  minLength: 1
-                  type: string
-                recordsize:
-                  description: 'Specifies a suggested block size for files in the file
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              quotaType:
+                description: 'quotaType determines whether the dataset volume quota
+                  type is of type "quota" or "refquota". QuotaType can not be modified
+                  once volume has been provisioned. Default Value: quota.'
+                enum:
+                - quota
+                - refquota
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
                   system. The size specified must be a power of two greater than or
                   equal to 512 and less than or equal to 128 Kbytes. RecordSize property
                   can be edited after the volume has been created. Changing the file
                   system''s recordsize affects only files created afterward; existing
                   files are unaffected. Default Value: 128k.'
-                  minLength: 1
-                  type: string
-                shared:
-                  description: Shared specifies whether the volume can be shared among
-                    multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
-                    will not allow the volumes to be mounted by more than one pods.
-                  enum:
-                    - "yes"
-                    - "no"
-                  type: string
-                snapname:
-                  description: SnapName specifies the name of the snapshot where the
-                    volume has been cloned from. Snapname can not be edited after the
-                    volume has been provisioned.
-                  type: string
-                thinProvision:
-                  description: 'ThinProvision describes whether space reservation for
+                minLength: 1
+                type: string
+              shared:
+                description: Shared specifies whether the volume can be shared among
+                  multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
+                  will not allow the volumes to be mounted by more than one pods.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
                   the source volume is required or not. The value "yes" indicates
                   that volume should be thin provisioned and "no" means thick provisioning
                   of the volume. If thinProvision is set to "yes" then volume can
@@ -2066,113 +2092,113 @@ spec:
                   if the ZPOOL has enough capacity and capacity required by volume
                   can be reserved. ThinProvision can not be modified once volume has
                   been provisioned. Default Value: no.'
-                  enum:
-                    - "yes"
-                    - "no"
-                  type: string
-                volblocksize:
-                  description: 'VolBlockSize specifies the block size for the zvol.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
                   The volsize can only be set to a multiple of volblocksize, and cannot
                   be zero. VolBlockSize can not be edited after the volume has been
                   provisioned. Default Value: 8k.'
-                  minLength: 1
-                  type: string
-                volumeType:
-                  description: volumeType determines whether the volume is of type "DATASET"
-                    or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
-                    of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
-                    is mentioned as fstype in the storageclass, then a volume of type
-                    zvol will be created, which will be further formatted as the fstype
-                    provided in the storageclass. VolumeType can not be modified once
-                    volume has been provisioned.
-                  enum:
-                    - ZVOL
-                    - DATASET
-                  type: string
-              required:
-                - capacity
-                - ownerNodeID
-                - poolName
-                - volumeType
-              type: object
-            status:
-              description: VolStatus string that specifies the current state of the
-                volume provisioning request.
-              properties:
-                state:
-                  description: State specifies the current state of the volume provisioning
-                    request. The state "Pending" means that the volume creation request
-                    has not processed yet. The state "Ready" means that the volume has
-                    been created and it is ready for the use.
-                  enum:
-                    - Pending
-                    - Ready
-                    - Failed
-                  type: string
-              type: object
-          required:
-            - spec
-          type: object
-      served: true
-      storage: true
-      subresources: {}
-    - additionalPrinterColumns:
-        - description: ZFS Pool where the volume is created
-          jsonPath: .spec.poolName
-          name: ZPool
-          type: string
-        - description: Node where the volume is created
-          jsonPath: .spec.ownerNodeID
-          name: Node
-          type: string
-        - description: Size of the volume
-          jsonPath: .spec.capacity
-          name: Size
-          type: string
-        - description: Status of the volume
-          jsonPath: .status.state
-          name: Status
-          type: string
-        - description: filesystem created on the volume
-          jsonPath: .spec.fsType
-          name: Filesystem
-          type: string
-        - description: Age of the volume
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: ZFSVolume represents a ZFS based volume
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+          status:
+            description: VolStatus string that specifies the current state of the
+              volume provisioning request.
+            properties:
+              state:
+                description: State specifies the current state of the volume provisioning
+                  request. The state "Pending" means that the volume creation request
+                  has not processed yet. The state "Ready" means that the volume has
+                  been created and it is ready for the use.
+                enum:
+                - Pending
+                - Ready
+                - Failed
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+  - additionalPrinterColumns:
+    - description: ZFS Pool where the volume is created
+      jsonPath: .spec.poolName
+      name: ZPool
+      type: string
+    - description: Node where the volume is created
+      jsonPath: .spec.ownerNodeID
+      name: Node
+      type: string
+    - description: Size of the volume
+      jsonPath: .spec.capacity
+      name: Size
+      type: string
+    - description: Status of the volume
+      jsonPath: .status.state
+      name: Status
+      type: string
+    - description: filesystem created on the volume
+      jsonPath: .spec.fsType
+      name: Filesystem
+      type: string
+    - description: Age of the volume
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ZFSVolume represents a ZFS based volume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: VolumeInfo defines ZFS volume parameters for all modes in
-                which ZFS volumes can be created like - ZFS volume with filesystem,
-                ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
-                Some of the parameters can be only set during creation time (as specified
-                in the details of the parameter), and a few are editable. In case of
-                Cloned volumes, the parameters are assigned the same values as the source
-                volume.
-              properties:
-                capacity:
-                  description: Capacity of the volume
-                  minLength: 1
-                  type: string
-                compression:
-                  description: 'Compression specifies the block-level compression algorithm
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines ZFS volume parameters for all modes in
+              which ZFS volumes can be created like - ZFS volume with filesystem,
+              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+              Some of the parameters can be only set during creation time (as specified
+              in the details of the parameter), and a few are editable. In case of
+              Cloned volumes, the parameters are assigned the same values as the source
+              volume.
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              compression:
+                description: 'Compression specifies the block-level compression algorithm
                   to be applied to the ZFS Volume. The value "on" indicates ZFS to
                   use the default compression algorithm. The default compression algorithm
                   used by ZFS will be either lzjb or, if the lz4_compress feature
@@ -2181,10 +2207,10 @@ spec:
                   data. For instance, if the Volume was created with "off" and the
                   next day the compression was modified to "on", the data written
                   prior to setting "on" will not be compressed. Default Value: off.'
-                  pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
-                  type: string
-                dedup:
-                  description: 'Deduplication is the process for removing redundant
+                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                type: string
+              dedup:
+                description: 'Deduplication is the process for removing redundant
                   data at the block level, reducing the total amount of data stored.
                   If a file system has the dedup property enabled, duplicate data
                   blocks are removed synchronously. The result is that only unique
@@ -2197,12 +2223,12 @@ spec:
                   using compression=lz4, as a less resource-intensive alternative.
                   should be enabled on the zvol. Dedup property can be edited after
                   the volume has been created. Default Value: off.'
-                  enum:
-                    - "on"
-                    - "off"
-                  type: string
-                encryption:
-                  description: 'Enabling the encryption feature allows for the creation
+                enum:
+                - "on"
+                - "off"
+                type: string
+              encryption:
+                description: 'Enabling the encryption feature allows for the creation
                   of encrypted filesystems and volumes. ZFS will encrypt file and
                   zvol data, file attributes, ACLs, permission bits, directory listings,
                   FUID mappings, and userused / groupused data. ZFS will not encrypt
@@ -2210,56 +2236,56 @@ spec:
                   names, dataset hierarchy, properties, file size, file holes, and
                   deduplication tables (though the deduplicated data itself is encrypted).
                   Default Value: off.'
-                  pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
-                  type: string
-                fsType:
-                  description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                type: string
+              fsType:
+                description: 'FsType specifies filesystem type for the zfs volume/dataset.
                   If FsType is provided as "zfs", then the driver will create a ZFS
                   dataset, formatting is not required as underlying filesystem is
                   ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
                   will create a ZVOL and format the volume accordingly. FsType can
                   not be modified once volume has been provisioned. Default Value:
                   ext4.'
-                  type: string
-                keyformat:
-                  description: KeyFormat specifies format of the encryption key The
-                    supported KeyFormats are passphrase, raw, hex.
-                  enum:
-                    - passphrase
-                    - raw
-                    - hex
-                  type: string
-                keylocation:
-                  description: KeyLocation is the location of key for the encryption
-                  type: string
-                ownerNodeID:
-                  description: OwnerNodeID is the Node ID where the ZPOOL is running
-                    which is where the volume has been provisioned. OwnerNodeID can
-                    not be edited after the volume has been provisioned.
-                  minLength: 1
-                  type: string
-                poolName:
-                  description: poolName specifies the name of the pool where the volume
-                    has been created. PoolName can not be edited after the volume has
-                    been provisioned.
-                  minLength: 1
-                  type: string
-                recordsize:
-                  description: 'Specifies a suggested block size for files in the file
+                type: string
+              keyformat:
+                description: KeyFormat specifies format of the encryption key The
+                  supported KeyFormats are passphrase, raw, hex.
+                enum:
+                - passphrase
+                - raw
+                - hex
+                type: string
+              keylocation:
+                description: KeyLocation is the location of key for the encryption
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the ZPOOL is running
+                  which is where the volume has been provisioned. OwnerNodeID can
+                  not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              poolName:
+                description: poolName specifies the name of the pool where the volume
+                  has been created. PoolName can not be edited after the volume has
+                  been provisioned.
+                minLength: 1
+                type: string
+              recordsize:
+                description: 'Specifies a suggested block size for files in the file
                   system. The size specified must be a power of two greater than or
                   equal to 512 and less than or equal to 128 Kbytes. RecordSize property
                   can be edited after the volume has been created. Changing the file
                   system''s recordsize affects only files created afterward; existing
                   files are unaffected. Default Value: 128k.'
-                  minLength: 1
-                  type: string
-                snapname:
-                  description: SnapName specifies the name of the snapshot where the
-                    volume has been cloned from. Snapname can not be edited after the
-                    volume has been provisioned.
-                  type: string
-                thinProvision:
-                  description: 'ThinProvision describes whether space reservation for
+                minLength: 1
+                type: string
+              snapname:
+                description: SnapName specifies the name of the snapshot where the
+                  volume has been cloned from. Snapname can not be edited after the
+                  volume has been provisioned.
+                type: string
+              thinProvision:
+                description: 'ThinProvision describes whether space reservation for
                   the source volume is required or not. The value "yes" indicates
                   that volume should be thin provisioned and "no" means thick provisioning
                   of the volume. If thinProvision is set to "yes" then volume can
@@ -2268,55 +2294,55 @@ spec:
                   if the ZPOOL has enough capacity and capacity required by volume
                   can be reserved. ThinProvision can not be modified once volume has
                   been provisioned. Default Value: no.'
-                  enum:
-                    - "yes"
-                    - "no"
-                  type: string
-                volblocksize:
-                  description: 'VolBlockSize specifies the block size for the zvol.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volblocksize:
+                description: 'VolBlockSize specifies the block size for the zvol.
                   The volsize can only be set to a multiple of volblocksize, and cannot
                   be zero. VolBlockSize can not be edited after the volume has been
                   provisioned. Default Value: 8k.'
-                  minLength: 1
-                  type: string
-                volumeType:
-                  description: volumeType determines whether the volume is of type "DATASET"
-                    or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
-                    of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
-                    is mentioned as fstype in the storageclass, then a volume of type
-                    zvol will be created, which will be further formatted as the fstype
-                    provided in the storageclass. VolumeType can not be modified once
-                    volume has been provisioned.
-                  enum:
-                    - ZVOL
-                    - DATASET
-                  type: string
-              required:
-                - capacity
-                - ownerNodeID
-                - poolName
-                - volumeType
-              type: object
-            status:
-              description: VolStatus string that specifies the current state of the
-                volume provisioning request.
-              properties:
-                state:
-                  description: State specifies the current state of the volume provisioning
-                    request. The state "Pending" means that the volume creation request
-                    has not processed yet. The state "Ready" means that the volume has
-                    been created and it is ready for the use.
-                  enum:
-                    - Pending
-                    - Ready
-                  type: string
-              type: object
-          required:
-            - spec
-          type: object
-      served: true
-      storage: false
-      subresources: {}
+                minLength: 1
+                type: string
+              volumeType:
+                description: volumeType determines whether the volume is of type "DATASET"
+                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                  is mentioned as fstype in the storageclass, then a volume of type
+                  zvol will be created, which will be further formatted as the fstype
+                  provided in the storageclass. VolumeType can not be modified once
+                  volume has been provisioned.
+                enum:
+                - ZVOL
+                - DATASET
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - poolName
+            - volumeType
+            type: object
+          status:
+            description: VolStatus string that specifies the current state of the
+              volume provisioning request.
+            properties:
+              state:
+                description: State specifies the current state of the volume provisioning
+                  request. The state "Pending" means that the volume creation request
+                  has not processed yet. The state "Ready" means that the volume has
+                  been created and it is ready for the use.
+                enum:
+                - Pending
+                - Ready
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources: {}
 status:
   acceptedNames:
     kind: ""
@@ -2430,6 +2456,7 @@ metadata:
   labels:
     openebs.io/version: "2.7.0-develop"
     role: "openebs-zfs"
+    app: "openebs-zfs-node"
     name: "openebs-zfs-node"
     openebs.io/component-name: "openebs-zfs-node"
 rules:
@@ -2491,6 +2518,7 @@ metadata:
   labels:
     openebs.io/version: "2.7.0-develop"
     role: "openebs-zfs"
+    app: "openebs-zfs-node"
     name: "openebs-zfs-node"
     openebs.io/component-name: "openebs-zfs-node"
 subjects:
@@ -2511,11 +2539,13 @@ metadata:
   labels:
     openebs.io/version: "2.7.0-develop"
     role: "openebs-zfs"
+    app: "openebs-zfs-node"
     name: "openebs-zfs-node"
     openebs.io/component-name: "openebs-zfs-node"
 spec:
   selector:
     matchLabels:
+      app: "openebs-zfs-node"
       name: "openebs-zfs-node"
   updateStrategy:
     rollingUpdate:
@@ -2526,6 +2556,7 @@ spec:
       labels:
         openebs.io/version: "2.7.0-develop"
         role: "openebs-zfs"
+        app: "openebs-zfs-node"
         name: "openebs-zfs-node"
         openebs.io/component-name: "openebs-zfs-node"
     spec:
@@ -2660,7 +2691,7 @@ spec:
         app: "openebs-zfs-controller"
         component: "openebs-zfs-controller"
         openebs.io/component-name: "openebs-zfs-controller"
-
+        
         name: openebs-zfs-controller
     spec:
       priorityClassName: openebs-zfs-csi-controller-critical
@@ -2670,7 +2701,7 @@ spec:
           image: "registry.k8s.io/sig-storage/csi-resizer:v1.8.0"
           args:
             - "--v=5"
-            - "--csi-address=$(ADDRESS)"
+            - "--csi-address=$(ADDRESS)"            
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -2682,7 +2713,7 @@ spec:
           image: "registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2"
           imagePullPolicy: IfNotPresent
           args:
-            - "--csi-address=$(ADDRESS)"
+            - "--csi-address=$(ADDRESS)"            
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -2692,7 +2723,7 @@ spec:
         - name: snapshot-controller
           image: "registry.k8s.io/sig-storage/snapshot-controller:v6.2.2"
           args:
-            - "--v=5"
+            - "--v=5"            
           imagePullPolicy: IfNotPresent
         - name: csi-provisioner
           image: "registry.k8s.io/sig-storage/csi-provisioner:v3.5.0"
@@ -2704,7 +2735,7 @@ spec:
             - "--strict-topology"
             - "--enable-capacity=true"
             - "--extra-create-metadata=true"
-            - "--default-fstype=ext4"
+            - "--default-fstype=ext4"            
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -71,7 +71,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-csi/external-snapshotter/pull/814
     controller-gen.kubebuilder.io/version: v0.11.3
-    
+
   creationTimestamp: null
   name: volumesnapshotclasses.snapshot.storage.k8s.io
 spec:
@@ -221,7 +221,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-csi/external-snapshotter/pull/814
     controller-gen.kubebuilder.io/version: v0.11.3
-    
+
   creationTimestamp: null
   name: volumesnapshotcontents.snapshot.storage.k8s.io
 spec:
@@ -709,7 +709,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-csi/external-snapshotter/pull/814
     controller-gen.kubebuilder.io/version: v0.11.3
-    
+
   creationTimestamp: null
   name: volumesnapshots.snapshot.storage.k8s.io
 spec:
@@ -1098,7 +1098,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
-    
+
   creationTimestamp: null
   name: zfsbackups.zfs.openebs.io
 spec:
@@ -1108,89 +1108,89 @@ spec:
     listKind: ZFSBackupList
     plural: zfsbackups
     shortNames:
-    - zb
+      - zb
     singular: zfsbackup
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Previous snapshot for backup
-      jsonPath: .spec.prevSnapName
-      name: PrevSnap
-      type: string
-    - description: Backup status
-      jsonPath: .status
-      name: Status
-      type: string
-    - description: Age of the volume
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: ZFSBackup describes a zfs backup resource created as a custom
-          resource
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
+    - additionalPrinterColumns:
+        - description: Previous snapshot for backup
+          jsonPath: .spec.prevSnapName
+          name: PrevSnap
+          type: string
+        - description: Backup status
+          jsonPath: .status
+          name: Status
+          type: string
+        - description: Age of the volume
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: ZFSBackup describes a zfs backup resource created as a custom
+            resource
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ZFSBackupSpec is the spec for a ZFSBackup resource
-            properties:
-              backupDest:
-                description: BackupDest is the remote address for backup transfer
-                minLength: 1
-                pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
-                type: string
-              ownerNodeID:
-                description: OwnerNodeID is a name of the nodes where the source volume
-                  is
-                minLength: 1
-                type: string
-              prevSnapName:
-                description: PrevSnapName is the last completed-backup's snapshot
-                  name
-                type: string
-              snapName:
-                description: SnapName is the snapshot name for backup
-                minLength: 1
-                type: string
-              volumeName:
-                description: VolumeName is a name of the volume for which this backup
-                  is destined
-                minLength: 1
-                type: string
-            required:
-            - backupDest
-            - ownerNodeID
-            - volumeName
-            type: object
-          status:
-            description: ZFSBackupStatus is to hold status of backup
-            enum:
-            - Init
-            - Done
-            - Failed
-            - Pending
-            - InProgress
-            - Invalid
-            type: string
-        required:
-        - spec
-        - status
-        type: object
-    served: true
-    storage: true
-    subresources: {}
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ZFSBackupSpec is the spec for a ZFSBackup resource
+              properties:
+                backupDest:
+                  description: BackupDest is the remote address for backup transfer
+                  minLength: 1
+                  pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
+                  type: string
+                ownerNodeID:
+                  description: OwnerNodeID is a name of the nodes where the source volume
+                    is
+                  minLength: 1
+                  type: string
+                prevSnapName:
+                  description: PrevSnapName is the last completed-backup's snapshot
+                    name
+                  type: string
+                snapName:
+                  description: SnapName is the snapshot name for backup
+                  minLength: 1
+                  type: string
+                volumeName:
+                  description: VolumeName is a name of the volume for which this backup
+                    is destined
+                  minLength: 1
+                  type: string
+              required:
+                - backupDest
+                - ownerNodeID
+                - volumeName
+              type: object
+            status:
+              description: ZFSBackupStatus is to hold status of backup
+              enum:
+                - Init
+                - Done
+                - Failed
+                - Pending
+                - InProgress
+                - Invalid
+              type: string
+          required:
+            - spec
+            - status
+          type: object
+      served: true
+      storage: true
+      subresources: {}
 status:
   acceptedNames:
     kind: ""
@@ -1204,7 +1204,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
-    
+
   creationTimestamp: null
   name: zfsnodes.zfs.openebs.io
 spec:
@@ -1214,69 +1214,69 @@ spec:
     listKind: ZFSNodeList
     plural: zfsnodes
     shortNames:
-    - zfsnode
+      - zfsnode
     singular: zfsnode
   scope: Namespaced
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: ZFSNode records information about all zfs pools available in
-          a node. In general, the openebs node-agent creates the ZFSNode object &
-          periodically synchronizing the zfs pools available in the node. ZFSNode
-          has an owner reference pointing to the corresponding node object.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ZFSNode records information about all zfs pools available in
+            a node. In general, the openebs node-agent creates the ZFSNode object &
+            periodically synchronizing the zfs pools available in the node. ZFSNode
+            has an owner reference pointing to the corresponding node object.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          pools:
-            items:
-              description: Pool specifies attributes of a given zfs pool that exists
-                on the node.
-              properties:
-                free:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  description: Free specifies the available capacity of zfs pool.
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                name:
-                  description: Name of the zfs pool.
-                  minLength: 1
-                  type: string
-                used:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  description: Used specifies the used capacity of zfs pool.
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                uuid:
-                  description: UUID denotes a unique identity of a zfs pool.
-                  minLength: 1
-                  type: string
-              required:
-              - free
-              - name
-              - used
-              - uuid
+              type: string
+            metadata:
               type: object
-            type: array
-        required:
-        - pools
-        type: object
-    served: true
-    storage: true
+            pools:
+              items:
+                description: Pool specifies attributes of a given zfs pool that exists
+                  on the node.
+                properties:
+                  free:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    description: Free specifies the available capacity of zfs pool.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  name:
+                    description: Name of the zfs pool.
+                    minLength: 1
+                    type: string
+                  used:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    description: Used specifies the used capacity of zfs pool.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  uuid:
+                    description: UUID denotes a unique identity of a zfs pool.
+                    minLength: 1
+                    type: string
+                required:
+                  - free
+                  - name
+                  - used
+                  - uuid
+                type: object
+              type: array
+          required:
+            - pools
+          type: object
+      served: true
+      storage: true
 status:
   acceptedNames:
     kind: ""
@@ -1290,7 +1290,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
-    
+
   creationTimestamp: null
   name: zfsrestores.zfs.openebs.io
 spec:
@@ -1302,71 +1302,71 @@ spec:
     singular: zfsrestore
   scope: Namespaced
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: ZFSRestore describes a cstor restore resource created as a custom
-          resource
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ZFSRestore describes a cstor restore resource created as a custom
+            resource
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ZFSRestoreSpec is the spec for a ZFSRestore resource
-            properties:
-              ownerNodeID:
-                description: owner node name where restore volume is present
-                minLength: 1
-                type: string
-              restoreSrc:
-                description: it can be ip:port in case of restore from remote or volumeName
-                  in case of local restore
-                minLength: 1
-                pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
-                type: string
-              volumeName:
-                description: volume name to where restore has to be performed
-                minLength: 1
-                type: string
-            required:
-            - ownerNodeID
-            - restoreSrc
-            - volumeName
-            type: object
-          status:
-            description: ZFSRestoreStatus is to hold result of action.
-            enum:
-            - Init
-            - Done
-            - Failed
-            - Pending
-            - InProgress
-            - Invalid
-            type: string
-          volSpec:
-            description: VolumeInfo defines ZFS volume parameters for all modes in
-              which ZFS volumes can be created like - ZFS volume with filesystem,
-              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
-              Some of the parameters can be only set during creation time (as specified
-              in the details of the parameter), and a few are editable. In case of
-              Cloned volumes, the parameters are assigned the same values as the source
-              volume.
-            properties:
-              capacity:
-                description: Capacity of the volume
-                minLength: 1
-                type: string
-              compression:
-                description: 'Compression specifies the block-level compression algorithm
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ZFSRestoreSpec is the spec for a ZFSRestore resource
+              properties:
+                ownerNodeID:
+                  description: owner node name where restore volume is present
+                  minLength: 1
+                  type: string
+                restoreSrc:
+                  description: it can be ip:port in case of restore from remote or volumeName
+                    in case of local restore
+                  minLength: 1
+                  pattern: ^([0-9]+.[0-9]+.[0-9]+.[0-9]+:[0-9]+)$
+                  type: string
+                volumeName:
+                  description: volume name to where restore has to be performed
+                  minLength: 1
+                  type: string
+              required:
+                - ownerNodeID
+                - restoreSrc
+                - volumeName
+              type: object
+            status:
+              description: ZFSRestoreStatus is to hold result of action.
+              enum:
+                - Init
+                - Done
+                - Failed
+                - Pending
+                - InProgress
+                - Invalid
+              type: string
+            volSpec:
+              description: VolumeInfo defines ZFS volume parameters for all modes in
+                which ZFS volumes can be created like - ZFS volume with filesystem,
+                ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+                Some of the parameters can be only set during creation time (as specified
+                in the details of the parameter), and a few are editable. In case of
+                Cloned volumes, the parameters are assigned the same values as the source
+                volume.
+              properties:
+                capacity:
+                  description: Capacity of the volume
+                  minLength: 1
+                  type: string
+                compression:
+                  description: 'Compression specifies the block-level compression algorithm
                   to be applied to the ZFS Volume. The value "on" indicates ZFS to
                   use the default compression algorithm. The default compression algorithm
                   used by ZFS will be either lzjb or, if the lz4_compress feature
@@ -1375,10 +1375,10 @@ spec:
                   data. For instance, if the Volume was created with "off" and the
                   next day the compression was modified to "on", the data written
                   prior to setting "on" will not be compressed. Default Value: off.'
-                pattern: ^(on|off|lzjb|zstd|zstd-[1-9]|zstd-1[0-9]|gzip|gzip-[1-9]|zle|lz4)$
-                type: string
-              dedup:
-                description: 'Deduplication is the process for removing redundant
+                  pattern: ^(on|off|lzjb|zstd|zstd-[1-9]|zstd-1[0-9]|gzip|gzip-[1-9]|zle|lz4)$
+                  type: string
+                dedup:
+                  description: 'Deduplication is the process for removing redundant
                   data at the block level, reducing the total amount of data stored.
                   If a file system has the dedup property enabled, duplicate data
                   blocks are removed synchronously. The result is that only unique
@@ -1391,12 +1391,12 @@ spec:
                   using compression=lz4, as a less resource-intensive alternative.
                   should be enabled on the zvol. Dedup property can be edited after
                   the volume has been created. Default Value: off.'
-                enum:
-                - "on"
-                - "off"
-                type: string
-              encryption:
-                description: 'Enabling the encryption feature allows for the creation
+                  enum:
+                    - "on"
+                    - "off"
+                  type: string
+                encryption:
+                  description: 'Enabling the encryption feature allows for the creation
                   of encrypted filesystems and volumes. ZFS will encrypt file and
                   zvol data, file attributes, ACLs, permission bits, directory listings,
                   FUID mappings, and userused / groupused data. ZFS will not encrypt
@@ -1404,64 +1404,64 @@ spec:
                   names, dataset hierarchy, properties, file size, file holes, and
                   deduplication tables (though the deduplicated data itself is encrypted).
                   Default Value: off.'
-                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
-                type: string
-              fsType:
-                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                  type: string
+                fsType:
+                  description: 'FsType specifies filesystem type for the zfs volume/dataset.
                   If FsType is provided as "zfs", then the driver will create a ZFS
                   dataset, formatting is not required as underlying filesystem is
                   ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
                   will create a ZVOL and format the volume accordingly. FsType can
                   not be modified once volume has been provisioned. Default Value:
                   ext4.'
-                type: string
-              keyformat:
-                description: KeyFormat specifies format of the encryption key The
-                  supported KeyFormats are passphrase, raw, hex.
-                enum:
-                - passphrase
-                - raw
-                - hex
-                type: string
-              keylocation:
-                description: KeyLocation is the location of key for the encryption
-                type: string
-              ownerNodeID:
-                description: OwnerNodeID is the Node ID where the ZPOOL is running
-                  which is where the volume has been provisioned. OwnerNodeID can
-                  not be edited after the volume has been provisioned.
-                minLength: 1
-                type: string
-              poolName:
-                description: poolName specifies the name of the pool where the volume
-                  has been created. PoolName can not be edited after the volume has
-                  been provisioned.
-                minLength: 1
-                type: string
-              recordsize:
-                description: 'Specifies a suggested block size for files in the file
+                  type: string
+                keyformat:
+                  description: KeyFormat specifies format of the encryption key The
+                    supported KeyFormats are passphrase, raw, hex.
+                  enum:
+                    - passphrase
+                    - raw
+                    - hex
+                  type: string
+                keylocation:
+                  description: KeyLocation is the location of key for the encryption
+                  type: string
+                ownerNodeID:
+                  description: OwnerNodeID is the Node ID where the ZPOOL is running
+                    which is where the volume has been provisioned. OwnerNodeID can
+                    not be edited after the volume has been provisioned.
+                  minLength: 1
+                  type: string
+                poolName:
+                  description: poolName specifies the name of the pool where the volume
+                    has been created. PoolName can not be edited after the volume has
+                    been provisioned.
+                  minLength: 1
+                  type: string
+                recordsize:
+                  description: 'Specifies a suggested block size for files in the file
                   system. The size specified must be a power of two greater than or
                   equal to 512 and less than or equal to 128 Kbytes. RecordSize property
                   can be edited after the volume has been created. Changing the file
                   system''s recordsize affects only files created afterward; existing
                   files are unaffected. Default Value: 128k.'
-                minLength: 1
-                type: string
-              shared:
-                description: Shared specifies whether the volume can be shared among
-                  multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
-                  will not allow the volumes to be mounted by more than one pods.
-                enum:
-                - "yes"
-                - "no"
-                type: string
-              snapname:
-                description: SnapName specifies the name of the snapshot where the
-                  volume has been cloned from. Snapname can not be edited after the
-                  volume has been provisioned.
-                type: string
-              thinProvision:
-                description: 'ThinProvision describes whether space reservation for
+                  minLength: 1
+                  type: string
+                shared:
+                  description: Shared specifies whether the volume can be shared among
+                    multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
+                    will not allow the volumes to be mounted by more than one pods.
+                  enum:
+                    - "yes"
+                    - "no"
+                  type: string
+                snapname:
+                  description: SnapName specifies the name of the snapshot where the
+                    volume has been cloned from. Snapname can not be edited after the
+                    volume has been provisioned.
+                  type: string
+                thinProvision:
+                  description: 'ThinProvision describes whether space reservation for
                   the source volume is required or not. The value "yes" indicates
                   that volume should be thin provisioned and "no" means thick provisioning
                   of the volume. If thinProvision is set to "yes" then volume can
@@ -1470,41 +1470,41 @@ spec:
                   if the ZPOOL has enough capacity and capacity required by volume
                   can be reserved. ThinProvision can not be modified once volume has
                   been provisioned. Default Value: no.'
-                enum:
-                - "yes"
-                - "no"
-                type: string
-              volblocksize:
-                description: 'VolBlockSize specifies the block size for the zvol.
+                  enum:
+                    - "yes"
+                    - "no"
+                  type: string
+                volblocksize:
+                  description: 'VolBlockSize specifies the block size for the zvol.
                   The volsize can only be set to a multiple of volblocksize, and cannot
                   be zero. VolBlockSize can not be edited after the volume has been
                   provisioned. Default Value: 8k.'
-                minLength: 1
-                type: string
-              volumeType:
-                description: volumeType determines whether the volume is of type "DATASET"
-                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
-                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
-                  is mentioned as fstype in the storageclass, then a volume of type
-                  zvol will be created, which will be further formatted as the fstype
-                  provided in the storageclass. VolumeType can not be modified once
-                  volume has been provisioned.
-                enum:
-                - ZVOL
-                - DATASET
-                type: string
-            required:
-            - capacity
-            - ownerNodeID
-            - poolName
-            - volumeType
-            type: object
-        required:
-        - spec
-        - status
-        type: object
-    served: true
-    storage: true
+                  minLength: 1
+                  type: string
+                volumeType:
+                  description: volumeType determines whether the volume is of type "DATASET"
+                    or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                    of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                    is mentioned as fstype in the storageclass, then a volume of type
+                    zvol will be created, which will be further formatted as the fstype
+                    provided in the storageclass. VolumeType can not be modified once
+                    volume has been provisioned.
+                  enum:
+                    - ZVOL
+                    - DATASET
+                  type: string
+              required:
+                - capacity
+                - ownerNodeID
+                - poolName
+                - volumeType
+              type: object
+          required:
+            - spec
+            - status
+          type: object
+      served: true
+      storage: true
 status:
   acceptedNames:
     kind: ""
@@ -1518,7 +1518,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
-    
+
   creationTimestamp: null
   name: zfssnapshots.zfs.openebs.io
 spec:
@@ -1528,42 +1528,42 @@ spec:
     listKind: ZFSSnapshotList
     plural: zfssnapshots
     shortNames:
-    - zfssnap
+      - zfssnap
     singular: zfssnapshot
   scope: Namespaced
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: ZFSSnapshot represents a ZFS Snapshot of the zfsvolume
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ZFSSnapshot represents a ZFS Snapshot of the zfsvolume
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: VolumeInfo defines ZFS volume parameters for all modes in
-              which ZFS volumes can be created like - ZFS volume with filesystem,
-              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
-              Some of the parameters can be only set during creation time (as specified
-              in the details of the parameter), and a few are editable. In case of
-              Cloned volumes, the parameters are assigned the same values as the source
-              volume.
-            properties:
-              capacity:
-                description: Capacity of the volume
-                minLength: 1
-                type: string
-              compression:
-                description: 'Compression specifies the block-level compression algorithm
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: VolumeInfo defines ZFS volume parameters for all modes in
+                which ZFS volumes can be created like - ZFS volume with filesystem,
+                ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+                Some of the parameters can be only set during creation time (as specified
+                in the details of the parameter), and a few are editable. In case of
+                Cloned volumes, the parameters are assigned the same values as the source
+                volume.
+              properties:
+                capacity:
+                  description: Capacity of the volume
+                  minLength: 1
+                  type: string
+                compression:
+                  description: 'Compression specifies the block-level compression algorithm
                   to be applied to the ZFS Volume. The value "on" indicates ZFS to
                   use the default compression algorithm. The default compression algorithm
                   used by ZFS will be either lzjb or, if the lz4_compress feature
@@ -1572,10 +1572,10 @@ spec:
                   data. For instance, if the Volume was created with "off" and the
                   next day the compression was modified to "on", the data written
                   prior to setting "on" will not be compressed. Default Value: off.'
-                pattern: ^(on|off|lzjb|zstd|zstd-[1-9]|zstd-1[0-9]|gzip|gzip-[1-9]|zle|lz4)$
-                type: string
-              dedup:
-                description: 'Deduplication is the process for removing redundant
+                  pattern: ^(on|off|lzjb|zstd|zstd-[1-9]|zstd-1[0-9]|gzip|gzip-[1-9]|zle|lz4)$
+                  type: string
+                dedup:
+                  description: 'Deduplication is the process for removing redundant
                   data at the block level, reducing the total amount of data stored.
                   If a file system has the dedup property enabled, duplicate data
                   blocks are removed synchronously. The result is that only unique
@@ -1588,12 +1588,12 @@ spec:
                   using compression=lz4, as a less resource-intensive alternative.
                   should be enabled on the zvol. Dedup property can be edited after
                   the volume has been created. Default Value: off.'
-                enum:
-                - "on"
-                - "off"
-                type: string
-              encryption:
-                description: 'Enabling the encryption feature allows for the creation
+                  enum:
+                    - "on"
+                    - "off"
+                  type: string
+                encryption:
+                  description: 'Enabling the encryption feature allows for the creation
                   of encrypted filesystems and volumes. ZFS will encrypt file and
                   zvol data, file attributes, ACLs, permission bits, directory listings,
                   FUID mappings, and userused / groupused data. ZFS will not encrypt
@@ -1601,64 +1601,64 @@ spec:
                   names, dataset hierarchy, properties, file size, file holes, and
                   deduplication tables (though the deduplicated data itself is encrypted).
                   Default Value: off.'
-                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
-                type: string
-              fsType:
-                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                  type: string
+                fsType:
+                  description: 'FsType specifies filesystem type for the zfs volume/dataset.
                   If FsType is provided as "zfs", then the driver will create a ZFS
                   dataset, formatting is not required as underlying filesystem is
                   ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
                   will create a ZVOL and format the volume accordingly. FsType can
                   not be modified once volume has been provisioned. Default Value:
                   ext4.'
-                type: string
-              keyformat:
-                description: KeyFormat specifies format of the encryption key The
-                  supported KeyFormats are passphrase, raw, hex.
-                enum:
-                - passphrase
-                - raw
-                - hex
-                type: string
-              keylocation:
-                description: KeyLocation is the location of key for the encryption
-                type: string
-              ownerNodeID:
-                description: OwnerNodeID is the Node ID where the ZPOOL is running
-                  which is where the volume has been provisioned. OwnerNodeID can
-                  not be edited after the volume has been provisioned.
-                minLength: 1
-                type: string
-              poolName:
-                description: poolName specifies the name of the pool where the volume
-                  has been created. PoolName can not be edited after the volume has
-                  been provisioned.
-                minLength: 1
-                type: string
-              recordsize:
-                description: 'Specifies a suggested block size for files in the file
+                  type: string
+                keyformat:
+                  description: KeyFormat specifies format of the encryption key The
+                    supported KeyFormats are passphrase, raw, hex.
+                  enum:
+                    - passphrase
+                    - raw
+                    - hex
+                  type: string
+                keylocation:
+                  description: KeyLocation is the location of key for the encryption
+                  type: string
+                ownerNodeID:
+                  description: OwnerNodeID is the Node ID where the ZPOOL is running
+                    which is where the volume has been provisioned. OwnerNodeID can
+                    not be edited after the volume has been provisioned.
+                  minLength: 1
+                  type: string
+                poolName:
+                  description: poolName specifies the name of the pool where the volume
+                    has been created. PoolName can not be edited after the volume has
+                    been provisioned.
+                  minLength: 1
+                  type: string
+                recordsize:
+                  description: 'Specifies a suggested block size for files in the file
                   system. The size specified must be a power of two greater than or
                   equal to 512 and less than or equal to 128 Kbytes. RecordSize property
                   can be edited after the volume has been created. Changing the file
                   system''s recordsize affects only files created afterward; existing
                   files are unaffected. Default Value: 128k.'
-                minLength: 1
-                type: string
-              shared:
-                description: Shared specifies whether the volume can be shared among
-                  multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
-                  will not allow the volumes to be mounted by more than one pods.
-                enum:
-                - "yes"
-                - "no"
-                type: string
-              snapname:
-                description: SnapName specifies the name of the snapshot where the
-                  volume has been cloned from. Snapname can not be edited after the
-                  volume has been provisioned.
-                type: string
-              thinProvision:
-                description: 'ThinProvision describes whether space reservation for
+                  minLength: 1
+                  type: string
+                shared:
+                  description: Shared specifies whether the volume can be shared among
+                    multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
+                    will not allow the volumes to be mounted by more than one pods.
+                  enum:
+                    - "yes"
+                    - "no"
+                  type: string
+                snapname:
+                  description: SnapName specifies the name of the snapshot where the
+                    volume has been cloned from. Snapname can not be edited after the
+                    volume has been provisioned.
+                  type: string
+                thinProvision:
+                  description: 'ThinProvision describes whether space reservation for
                   the source volume is required or not. The value "yes" indicates
                   that volume should be thin provisioned and "no" means thick provisioning
                   of the volume. If thinProvision is set to "yes" then volume can
@@ -1667,80 +1667,80 @@ spec:
                   if the ZPOOL has enough capacity and capacity required by volume
                   can be reserved. ThinProvision can not be modified once volume has
                   been provisioned. Default Value: no.'
-                enum:
-                - "yes"
-                - "no"
-                type: string
-              volblocksize:
-                description: 'VolBlockSize specifies the block size for the zvol.
+                  enum:
+                    - "yes"
+                    - "no"
+                  type: string
+                volblocksize:
+                  description: 'VolBlockSize specifies the block size for the zvol.
                   The volsize can only be set to a multiple of volblocksize, and cannot
                   be zero. VolBlockSize can not be edited after the volume has been
                   provisioned. Default Value: 8k.'
-                minLength: 1
-                type: string
-              volumeType:
-                description: volumeType determines whether the volume is of type "DATASET"
-                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
-                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
-                  is mentioned as fstype in the storageclass, then a volume of type
-                  zvol will be created, which will be further formatted as the fstype
-                  provided in the storageclass. VolumeType can not be modified once
-                  volume has been provisioned.
-                enum:
-                - ZVOL
-                - DATASET
-                type: string
-            required:
-            - capacity
-            - ownerNodeID
-            - poolName
-            - volumeType
-            type: object
-          status:
-            description: SnapStatus string that reflects if the snapshot was created
-              successfully
-            properties:
-              state:
-                type: string
-            type: object
-        required:
-        - spec
-        - status
-        type: object
-    served: true
-    storage: true
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: ZFSSnapshot represents a ZFS Snapshot of the zfsvolume
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
+                  minLength: 1
+                  type: string
+                volumeType:
+                  description: volumeType determines whether the volume is of type "DATASET"
+                    or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                    of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                    is mentioned as fstype in the storageclass, then a volume of type
+                    zvol will be created, which will be further formatted as the fstype
+                    provided in the storageclass. VolumeType can not be modified once
+                    volume has been provisioned.
+                  enum:
+                    - ZVOL
+                    - DATASET
+                  type: string
+              required:
+                - capacity
+                - ownerNodeID
+                - poolName
+                - volumeType
+              type: object
+            status:
+              description: SnapStatus string that reflects if the snapshot was created
+                successfully
+              properties:
+                state:
+                  type: string
+              type: object
+          required:
+            - spec
+            - status
+          type: object
+      served: true
+      storage: true
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ZFSSnapshot represents a ZFS Snapshot of the zfsvolume
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: VolumeInfo defines ZFS volume parameters for all modes in
-              which ZFS volumes can be created like - ZFS volume with filesystem,
-              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
-              Some of the parameters can be only set during creation time (as specified
-              in the details of the parameter), and a few are editable. In case of
-              Cloned volumes, the parameters are assigned the same values as the source
-              volume.
-            properties:
-              capacity:
-                description: Capacity of the volume
-                minLength: 1
-                type: string
-              compression:
-                description: 'Compression specifies the block-level compression algorithm
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: VolumeInfo defines ZFS volume parameters for all modes in
+                which ZFS volumes can be created like - ZFS volume with filesystem,
+                ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+                Some of the parameters can be only set during creation time (as specified
+                in the details of the parameter), and a few are editable. In case of
+                Cloned volumes, the parameters are assigned the same values as the source
+                volume.
+              properties:
+                capacity:
+                  description: Capacity of the volume
+                  minLength: 1
+                  type: string
+                compression:
+                  description: 'Compression specifies the block-level compression algorithm
                   to be applied to the ZFS Volume. The value "on" indicates ZFS to
                   use the default compression algorithm. The default compression algorithm
                   used by ZFS will be either lzjb or, if the lz4_compress feature
@@ -1749,10 +1749,10 @@ spec:
                   data. For instance, if the Volume was created with "off" and the
                   next day the compression was modified to "on", the data written
                   prior to setting "on" will not be compressed. Default Value: off.'
-                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
-                type: string
-              dedup:
-                description: 'Deduplication is the process for removing redundant
+                  pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                  type: string
+                dedup:
+                  description: 'Deduplication is the process for removing redundant
                   data at the block level, reducing the total amount of data stored.
                   If a file system has the dedup property enabled, duplicate data
                   blocks are removed synchronously. The result is that only unique
@@ -1765,12 +1765,12 @@ spec:
                   using compression=lz4, as a less resource-intensive alternative.
                   should be enabled on the zvol. Dedup property can be edited after
                   the volume has been created. Default Value: off.'
-                enum:
-                - "on"
-                - "off"
-                type: string
-              encryption:
-                description: 'Enabling the encryption feature allows for the creation
+                  enum:
+                    - "on"
+                    - "off"
+                  type: string
+                encryption:
+                  description: 'Enabling the encryption feature allows for the creation
                   of encrypted filesystems and volumes. ZFS will encrypt file and
                   zvol data, file attributes, ACLs, permission bits, directory listings,
                   FUID mappings, and userused / groupused data. ZFS will not encrypt
@@ -1778,56 +1778,56 @@ spec:
                   names, dataset hierarchy, properties, file size, file holes, and
                   deduplication tables (though the deduplicated data itself is encrypted).
                   Default Value: off.'
-                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
-                type: string
-              fsType:
-                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                  type: string
+                fsType:
+                  description: 'FsType specifies filesystem type for the zfs volume/dataset.
                   If FsType is provided as "zfs", then the driver will create a ZFS
                   dataset, formatting is not required as underlying filesystem is
                   ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
                   will create a ZVOL and format the volume accordingly. FsType can
                   not be modified once volume has been provisioned. Default Value:
                   ext4.'
-                type: string
-              keyformat:
-                description: KeyFormat specifies format of the encryption key The
-                  supported KeyFormats are passphrase, raw, hex.
-                enum:
-                - passphrase
-                - raw
-                - hex
-                type: string
-              keylocation:
-                description: KeyLocation is the location of key for the encryption
-                type: string
-              ownerNodeID:
-                description: OwnerNodeID is the Node ID where the ZPOOL is running
-                  which is where the volume has been provisioned. OwnerNodeID can
-                  not be edited after the volume has been provisioned.
-                minLength: 1
-                type: string
-              poolName:
-                description: poolName specifies the name of the pool where the volume
-                  has been created. PoolName can not be edited after the volume has
-                  been provisioned.
-                minLength: 1
-                type: string
-              recordsize:
-                description: 'Specifies a suggested block size for files in the file
+                  type: string
+                keyformat:
+                  description: KeyFormat specifies format of the encryption key The
+                    supported KeyFormats are passphrase, raw, hex.
+                  enum:
+                    - passphrase
+                    - raw
+                    - hex
+                  type: string
+                keylocation:
+                  description: KeyLocation is the location of key for the encryption
+                  type: string
+                ownerNodeID:
+                  description: OwnerNodeID is the Node ID where the ZPOOL is running
+                    which is where the volume has been provisioned. OwnerNodeID can
+                    not be edited after the volume has been provisioned.
+                  minLength: 1
+                  type: string
+                poolName:
+                  description: poolName specifies the name of the pool where the volume
+                    has been created. PoolName can not be edited after the volume has
+                    been provisioned.
+                  minLength: 1
+                  type: string
+                recordsize:
+                  description: 'Specifies a suggested block size for files in the file
                   system. The size specified must be a power of two greater than or
                   equal to 512 and less than or equal to 128 Kbytes. RecordSize property
                   can be edited after the volume has been created. Changing the file
                   system''s recordsize affects only files created afterward; existing
                   files are unaffected. Default Value: 128k.'
-                minLength: 1
-                type: string
-              snapname:
-                description: SnapName specifies the name of the snapshot where the
-                  volume has been cloned from. Snapname can not be edited after the
-                  volume has been provisioned.
-                type: string
-              thinProvision:
-                description: 'ThinProvision describes whether space reservation for
+                  minLength: 1
+                  type: string
+                snapname:
+                  description: SnapName specifies the name of the snapshot where the
+                    volume has been cloned from. Snapname can not be edited after the
+                    volume has been provisioned.
+                  type: string
+                thinProvision:
+                  description: 'ThinProvision describes whether space reservation for
                   the source volume is required or not. The value "yes" indicates
                   that volume should be thin provisioned and "no" means thick provisioning
                   of the volume. If thinProvision is set to "yes" then volume can
@@ -1836,48 +1836,48 @@ spec:
                   if the ZPOOL has enough capacity and capacity required by volume
                   can be reserved. ThinProvision can not be modified once volume has
                   been provisioned. Default Value: no.'
-                enum:
-                - "yes"
-                - "no"
-                type: string
-              volblocksize:
-                description: 'VolBlockSize specifies the block size for the zvol.
+                  enum:
+                    - "yes"
+                    - "no"
+                  type: string
+                volblocksize:
+                  description: 'VolBlockSize specifies the block size for the zvol.
                   The volsize can only be set to a multiple of volblocksize, and cannot
                   be zero. VolBlockSize can not be edited after the volume has been
                   provisioned. Default Value: 8k.'
-                minLength: 1
-                type: string
-              volumeType:
-                description: volumeType determines whether the volume is of type "DATASET"
-                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
-                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
-                  is mentioned as fstype in the storageclass, then a volume of type
-                  zvol will be created, which will be further formatted as the fstype
-                  provided in the storageclass. VolumeType can not be modified once
-                  volume has been provisioned.
-                enum:
-                - ZVOL
-                - DATASET
-                type: string
-            required:
-            - capacity
-            - ownerNodeID
-            - poolName
-            - volumeType
-            type: object
-          status:
-            description: SnapStatus string that reflects if the snapshot was created
-              successfully
-            properties:
-              state:
-                type: string
-            type: object
-        required:
-        - spec
-        - status
-        type: object
-    served: true
-    storage: false
+                  minLength: 1
+                  type: string
+                volumeType:
+                  description: volumeType determines whether the volume is of type "DATASET"
+                    or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                    of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                    is mentioned as fstype in the storageclass, then a volume of type
+                    zvol will be created, which will be further formatted as the fstype
+                    provided in the storageclass. VolumeType can not be modified once
+                    volume has been provisioned.
+                  enum:
+                    - ZVOL
+                    - DATASET
+                  type: string
+              required:
+                - capacity
+                - ownerNodeID
+                - poolName
+                - volumeType
+              type: object
+            status:
+              description: SnapStatus string that reflects if the snapshot was created
+                successfully
+              properties:
+                state:
+                  type: string
+              type: object
+          required:
+            - spec
+            - status
+          type: object
+      served: true
+      storage: false
 status:
   acceptedNames:
     kind: ""
@@ -1891,7 +1891,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
-    
+
   creationTimestamp: null
   name: zfsvolumes.zfs.openebs.io
 spec:
@@ -1901,68 +1901,68 @@ spec:
     listKind: ZFSVolumeList
     plural: zfsvolumes
     shortNames:
-    - zfsvol
-    - zv
+      - zfsvol
+      - zv
     singular: zfsvolume
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: ZFS Pool where the volume is created
-      jsonPath: .spec.poolName
-      name: ZPool
-      type: string
-    - description: Node where the volume is created
-      jsonPath: .spec.ownerNodeID
-      name: NodeID
-      type: string
-    - description: Size of the volume
-      jsonPath: .spec.capacity
-      name: Size
-      type: string
-    - description: Status of the volume
-      jsonPath: .status.state
-      name: Status
-      type: string
-    - description: filesystem created on the volume
-      jsonPath: .spec.fsType
-      name: Filesystem
-      type: string
-    - description: Age of the volume
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: ZFSVolume represents a ZFS based volume
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
+    - additionalPrinterColumns:
+        - description: ZFS Pool where the volume is created
+          jsonPath: .spec.poolName
+          name: ZPool
+          type: string
+        - description: Node where the volume is created
+          jsonPath: .spec.ownerNodeID
+          name: NodeID
+          type: string
+        - description: Size of the volume
+          jsonPath: .spec.capacity
+          name: Size
+          type: string
+        - description: Status of the volume
+          jsonPath: .status.state
+          name: Status
+          type: string
+        - description: filesystem created on the volume
+          jsonPath: .spec.fsType
+          name: Filesystem
+          type: string
+        - description: Age of the volume
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: ZFSVolume represents a ZFS based volume
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: VolumeInfo defines ZFS volume parameters for all modes in
-              which ZFS volumes can be created like - ZFS volume with filesystem,
-              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
-              Some of the parameters can be only set during creation time (as specified
-              in the details of the parameter), and a few are editable. In case of
-              Cloned volumes, the parameters are assigned the same values as the source
-              volume.
-            properties:
-              capacity:
-                description: Capacity of the volume
-                minLength: 1
-                type: string
-              compression:
-                description: 'Compression specifies the block-level compression algorithm
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: VolumeInfo defines ZFS volume parameters for all modes in
+                which ZFS volumes can be created like - ZFS volume with filesystem,
+                ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+                Some of the parameters can be only set during creation time (as specified
+                in the details of the parameter), and a few are editable. In case of
+                Cloned volumes, the parameters are assigned the same values as the source
+                volume.
+              properties:
+                capacity:
+                  description: Capacity of the volume
+                  minLength: 1
+                  type: string
+                compression:
+                  description: 'Compression specifies the block-level compression algorithm
                   to be applied to the ZFS Volume. The value "on" indicates ZFS to
                   use the default compression algorithm. The default compression algorithm
                   used by ZFS will be either lzjb or, if the lz4_compress feature
@@ -1971,10 +1971,10 @@ spec:
                   data. For instance, if the Volume was created with "off" and the
                   next day the compression was modified to "on", the data written
                   prior to setting "on" will not be compressed. Default Value: off.'
-                pattern: ^(on|off|lzjb|zstd|zstd-[1-9]|zstd-1[0-9]|gzip|gzip-[1-9]|zle|lz4)$
-                type: string
-              dedup:
-                description: 'Deduplication is the process for removing redundant
+                  pattern: ^(on|off|lzjb|zstd|zstd-[1-9]|zstd-1[0-9]|gzip|gzip-[1-9]|zle|lz4)$
+                  type: string
+                dedup:
+                  description: 'Deduplication is the process for removing redundant
                   data at the block level, reducing the total amount of data stored.
                   If a file system has the dedup property enabled, duplicate data
                   blocks are removed synchronously. The result is that only unique
@@ -1987,12 +1987,12 @@ spec:
                   using compression=lz4, as a less resource-intensive alternative.
                   should be enabled on the zvol. Dedup property can be edited after
                   the volume has been created. Default Value: off.'
-                enum:
-                - "on"
-                - "off"
-                type: string
-              encryption:
-                description: 'Enabling the encryption feature allows for the creation
+                  enum:
+                    - "on"
+                    - "off"
+                  type: string
+                encryption:
+                  description: 'Enabling the encryption feature allows for the creation
                   of encrypted filesystems and volumes. ZFS will encrypt file and
                   zvol data, file attributes, ACLs, permission bits, directory listings,
                   FUID mappings, and userused / groupused data. ZFS will not encrypt
@@ -2000,64 +2000,64 @@ spec:
                   names, dataset hierarchy, properties, file size, file holes, and
                   deduplication tables (though the deduplicated data itself is encrypted).
                   Default Value: off.'
-                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
-                type: string
-              fsType:
-                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                  type: string
+                fsType:
+                  description: 'FsType specifies filesystem type for the zfs volume/dataset.
                   If FsType is provided as "zfs", then the driver will create a ZFS
                   dataset, formatting is not required as underlying filesystem is
                   ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
                   will create a ZVOL and format the volume accordingly. FsType can
                   not be modified once volume has been provisioned. Default Value:
                   ext4.'
-                type: string
-              keyformat:
-                description: KeyFormat specifies format of the encryption key The
-                  supported KeyFormats are passphrase, raw, hex.
-                enum:
-                - passphrase
-                - raw
-                - hex
-                type: string
-              keylocation:
-                description: KeyLocation is the location of key for the encryption
-                type: string
-              ownerNodeID:
-                description: OwnerNodeID is the Node ID where the ZPOOL is running
-                  which is where the volume has been provisioned. OwnerNodeID can
-                  not be edited after the volume has been provisioned.
-                minLength: 1
-                type: string
-              poolName:
-                description: poolName specifies the name of the pool where the volume
-                  has been created. PoolName can not be edited after the volume has
-                  been provisioned.
-                minLength: 1
-                type: string
-              recordsize:
-                description: 'Specifies a suggested block size for files in the file
+                  type: string
+                keyformat:
+                  description: KeyFormat specifies format of the encryption key The
+                    supported KeyFormats are passphrase, raw, hex.
+                  enum:
+                    - passphrase
+                    - raw
+                    - hex
+                  type: string
+                keylocation:
+                  description: KeyLocation is the location of key for the encryption
+                  type: string
+                ownerNodeID:
+                  description: OwnerNodeID is the Node ID where the ZPOOL is running
+                    which is where the volume has been provisioned. OwnerNodeID can
+                    not be edited after the volume has been provisioned.
+                  minLength: 1
+                  type: string
+                poolName:
+                  description: poolName specifies the name of the pool where the volume
+                    has been created. PoolName can not be edited after the volume has
+                    been provisioned.
+                  minLength: 1
+                  type: string
+                recordsize:
+                  description: 'Specifies a suggested block size for files in the file
                   system. The size specified must be a power of two greater than or
                   equal to 512 and less than or equal to 128 Kbytes. RecordSize property
                   can be edited after the volume has been created. Changing the file
                   system''s recordsize affects only files created afterward; existing
                   files are unaffected. Default Value: 128k.'
-                minLength: 1
-                type: string
-              shared:
-                description: Shared specifies whether the volume can be shared among
-                  multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
-                  will not allow the volumes to be mounted by more than one pods.
-                enum:
-                - "yes"
-                - "no"
-                type: string
-              snapname:
-                description: SnapName specifies the name of the snapshot where the
-                  volume has been cloned from. Snapname can not be edited after the
-                  volume has been provisioned.
-                type: string
-              thinProvision:
-                description: 'ThinProvision describes whether space reservation for
+                  minLength: 1
+                  type: string
+                shared:
+                  description: Shared specifies whether the volume can be shared among
+                    multiple pods. If it is not set to "yes", then the ZFS-LocalPV Driver
+                    will not allow the volumes to be mounted by more than one pods.
+                  enum:
+                    - "yes"
+                    - "no"
+                  type: string
+                snapname:
+                  description: SnapName specifies the name of the snapshot where the
+                    volume has been cloned from. Snapname can not be edited after the
+                    volume has been provisioned.
+                  type: string
+                thinProvision:
+                  description: 'ThinProvision describes whether space reservation for
                   the source volume is required or not. The value "yes" indicates
                   that volume should be thin provisioned and "no" means thick provisioning
                   of the volume. If thinProvision is set to "yes" then volume can
@@ -2066,113 +2066,113 @@ spec:
                   if the ZPOOL has enough capacity and capacity required by volume
                   can be reserved. ThinProvision can not be modified once volume has
                   been provisioned. Default Value: no.'
-                enum:
-                - "yes"
-                - "no"
-                type: string
-              volblocksize:
-                description: 'VolBlockSize specifies the block size for the zvol.
+                  enum:
+                    - "yes"
+                    - "no"
+                  type: string
+                volblocksize:
+                  description: 'VolBlockSize specifies the block size for the zvol.
                   The volsize can only be set to a multiple of volblocksize, and cannot
                   be zero. VolBlockSize can not be edited after the volume has been
                   provisioned. Default Value: 8k.'
-                minLength: 1
-                type: string
-              volumeType:
-                description: volumeType determines whether the volume is of type "DATASET"
-                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
-                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
-                  is mentioned as fstype in the storageclass, then a volume of type
-                  zvol will be created, which will be further formatted as the fstype
-                  provided in the storageclass. VolumeType can not be modified once
-                  volume has been provisioned.
-                enum:
-                - ZVOL
-                - DATASET
-                type: string
-            required:
-            - capacity
-            - ownerNodeID
-            - poolName
-            - volumeType
-            type: object
-          status:
-            description: VolStatus string that specifies the current state of the
-              volume provisioning request.
-            properties:
-              state:
-                description: State specifies the current state of the volume provisioning
-                  request. The state "Pending" means that the volume creation request
-                  has not processed yet. The state "Ready" means that the volume has
-                  been created and it is ready for the use.
-                enum:
-                - Pending
-                - Ready
-                - Failed
-                type: string
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources: {}
-  - additionalPrinterColumns:
-    - description: ZFS Pool where the volume is created
-      jsonPath: .spec.poolName
-      name: ZPool
-      type: string
-    - description: Node where the volume is created
-      jsonPath: .spec.ownerNodeID
-      name: Node
-      type: string
-    - description: Size of the volume
-      jsonPath: .spec.capacity
-      name: Size
-      type: string
-    - description: Status of the volume
-      jsonPath: .status.state
-      name: Status
-      type: string
-    - description: filesystem created on the volume
-      jsonPath: .spec.fsType
-      name: Filesystem
-      type: string
-    - description: Age of the volume
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: ZFSVolume represents a ZFS based volume
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
+                  minLength: 1
+                  type: string
+                volumeType:
+                  description: volumeType determines whether the volume is of type "DATASET"
+                    or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                    of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                    is mentioned as fstype in the storageclass, then a volume of type
+                    zvol will be created, which will be further formatted as the fstype
+                    provided in the storageclass. VolumeType can not be modified once
+                    volume has been provisioned.
+                  enum:
+                    - ZVOL
+                    - DATASET
+                  type: string
+              required:
+                - capacity
+                - ownerNodeID
+                - poolName
+                - volumeType
+              type: object
+            status:
+              description: VolStatus string that specifies the current state of the
+                volume provisioning request.
+              properties:
+                state:
+                  description: State specifies the current state of the volume provisioning
+                    request. The state "Pending" means that the volume creation request
+                    has not processed yet. The state "Ready" means that the volume has
+                    been created and it is ready for the use.
+                  enum:
+                    - Pending
+                    - Ready
+                    - Failed
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources: {}
+    - additionalPrinterColumns:
+        - description: ZFS Pool where the volume is created
+          jsonPath: .spec.poolName
+          name: ZPool
+          type: string
+        - description: Node where the volume is created
+          jsonPath: .spec.ownerNodeID
+          name: Node
+          type: string
+        - description: Size of the volume
+          jsonPath: .spec.capacity
+          name: Size
+          type: string
+        - description: Status of the volume
+          jsonPath: .status.state
+          name: Status
+          type: string
+        - description: filesystem created on the volume
+          jsonPath: .spec.fsType
+          name: Filesystem
+          type: string
+        - description: Age of the volume
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ZFSVolume represents a ZFS based volume
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: VolumeInfo defines ZFS volume parameters for all modes in
-              which ZFS volumes can be created like - ZFS volume with filesystem,
-              ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
-              Some of the parameters can be only set during creation time (as specified
-              in the details of the parameter), and a few are editable. In case of
-              Cloned volumes, the parameters are assigned the same values as the source
-              volume.
-            properties:
-              capacity:
-                description: Capacity of the volume
-                minLength: 1
-                type: string
-              compression:
-                description: 'Compression specifies the block-level compression algorithm
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: VolumeInfo defines ZFS volume parameters for all modes in
+                which ZFS volumes can be created like - ZFS volume with filesystem,
+                ZFS Volume exposed as zfs or ZFS volume exposed as raw block device.
+                Some of the parameters can be only set during creation time (as specified
+                in the details of the parameter), and a few are editable. In case of
+                Cloned volumes, the parameters are assigned the same values as the source
+                volume.
+              properties:
+                capacity:
+                  description: Capacity of the volume
+                  minLength: 1
+                  type: string
+                compression:
+                  description: 'Compression specifies the block-level compression algorithm
                   to be applied to the ZFS Volume. The value "on" indicates ZFS to
                   use the default compression algorithm. The default compression algorithm
                   used by ZFS will be either lzjb or, if the lz4_compress feature
@@ -2181,10 +2181,10 @@ spec:
                   data. For instance, if the Volume was created with "off" and the
                   next day the compression was modified to "on", the data written
                   prior to setting "on" will not be compressed. Default Value: off.'
-                pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
-                type: string
-              dedup:
-                description: 'Deduplication is the process for removing redundant
+                  pattern: ^(on|off|lzjb|gzip|gzip-[1-9]|zle|lz4)$
+                  type: string
+                dedup:
+                  description: 'Deduplication is the process for removing redundant
                   data at the block level, reducing the total amount of data stored.
                   If a file system has the dedup property enabled, duplicate data
                   blocks are removed synchronously. The result is that only unique
@@ -2197,12 +2197,12 @@ spec:
                   using compression=lz4, as a less resource-intensive alternative.
                   should be enabled on the zvol. Dedup property can be edited after
                   the volume has been created. Default Value: off.'
-                enum:
-                - "on"
-                - "off"
-                type: string
-              encryption:
-                description: 'Enabling the encryption feature allows for the creation
+                  enum:
+                    - "on"
+                    - "off"
+                  type: string
+                encryption:
+                  description: 'Enabling the encryption feature allows for the creation
                   of encrypted filesystems and volumes. ZFS will encrypt file and
                   zvol data, file attributes, ACLs, permission bits, directory listings,
                   FUID mappings, and userused / groupused data. ZFS will not encrypt
@@ -2210,56 +2210,56 @@ spec:
                   names, dataset hierarchy, properties, file size, file holes, and
                   deduplication tables (though the deduplicated data itself is encrypted).
                   Default Value: off.'
-                pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
-                type: string
-              fsType:
-                description: 'FsType specifies filesystem type for the zfs volume/dataset.
+                  pattern: ^(on|off|aes-128-[c,g]cm|aes-192-[c,g]cm|aes-256-[c,g]cm)$
+                  type: string
+                fsType:
+                  description: 'FsType specifies filesystem type for the zfs volume/dataset.
                   If FsType is provided as "zfs", then the driver will create a ZFS
                   dataset, formatting is not required as underlying filesystem is
                   ZFS anyway. If FsType is ext2, ext3, ext4 or xfs, then the driver
                   will create a ZVOL and format the volume accordingly. FsType can
                   not be modified once volume has been provisioned. Default Value:
                   ext4.'
-                type: string
-              keyformat:
-                description: KeyFormat specifies format of the encryption key The
-                  supported KeyFormats are passphrase, raw, hex.
-                enum:
-                - passphrase
-                - raw
-                - hex
-                type: string
-              keylocation:
-                description: KeyLocation is the location of key for the encryption
-                type: string
-              ownerNodeID:
-                description: OwnerNodeID is the Node ID where the ZPOOL is running
-                  which is where the volume has been provisioned. OwnerNodeID can
-                  not be edited after the volume has been provisioned.
-                minLength: 1
-                type: string
-              poolName:
-                description: poolName specifies the name of the pool where the volume
-                  has been created. PoolName can not be edited after the volume has
-                  been provisioned.
-                minLength: 1
-                type: string
-              recordsize:
-                description: 'Specifies a suggested block size for files in the file
+                  type: string
+                keyformat:
+                  description: KeyFormat specifies format of the encryption key The
+                    supported KeyFormats are passphrase, raw, hex.
+                  enum:
+                    - passphrase
+                    - raw
+                    - hex
+                  type: string
+                keylocation:
+                  description: KeyLocation is the location of key for the encryption
+                  type: string
+                ownerNodeID:
+                  description: OwnerNodeID is the Node ID where the ZPOOL is running
+                    which is where the volume has been provisioned. OwnerNodeID can
+                    not be edited after the volume has been provisioned.
+                  minLength: 1
+                  type: string
+                poolName:
+                  description: poolName specifies the name of the pool where the volume
+                    has been created. PoolName can not be edited after the volume has
+                    been provisioned.
+                  minLength: 1
+                  type: string
+                recordsize:
+                  description: 'Specifies a suggested block size for files in the file
                   system. The size specified must be a power of two greater than or
                   equal to 512 and less than or equal to 128 Kbytes. RecordSize property
                   can be edited after the volume has been created. Changing the file
                   system''s recordsize affects only files created afterward; existing
                   files are unaffected. Default Value: 128k.'
-                minLength: 1
-                type: string
-              snapname:
-                description: SnapName specifies the name of the snapshot where the
-                  volume has been cloned from. Snapname can not be edited after the
-                  volume has been provisioned.
-                type: string
-              thinProvision:
-                description: 'ThinProvision describes whether space reservation for
+                  minLength: 1
+                  type: string
+                snapname:
+                  description: SnapName specifies the name of the snapshot where the
+                    volume has been cloned from. Snapname can not be edited after the
+                    volume has been provisioned.
+                  type: string
+                thinProvision:
+                  description: 'ThinProvision describes whether space reservation for
                   the source volume is required or not. The value "yes" indicates
                   that volume should be thin provisioned and "no" means thick provisioning
                   of the volume. If thinProvision is set to "yes" then volume can
@@ -2268,55 +2268,55 @@ spec:
                   if the ZPOOL has enough capacity and capacity required by volume
                   can be reserved. ThinProvision can not be modified once volume has
                   been provisioned. Default Value: no.'
-                enum:
-                - "yes"
-                - "no"
-                type: string
-              volblocksize:
-                description: 'VolBlockSize specifies the block size for the zvol.
+                  enum:
+                    - "yes"
+                    - "no"
+                  type: string
+                volblocksize:
+                  description: 'VolBlockSize specifies the block size for the zvol.
                   The volsize can only be set to a multiple of volblocksize, and cannot
                   be zero. VolBlockSize can not be edited after the volume has been
                   provisioned. Default Value: 8k.'
-                minLength: 1
-                type: string
-              volumeType:
-                description: volumeType determines whether the volume is of type "DATASET"
-                  or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
-                  of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
-                  is mentioned as fstype in the storageclass, then a volume of type
-                  zvol will be created, which will be further formatted as the fstype
-                  provided in the storageclass. VolumeType can not be modified once
-                  volume has been provisioned.
-                enum:
-                - ZVOL
-                - DATASET
-                type: string
-            required:
-            - capacity
-            - ownerNodeID
-            - poolName
-            - volumeType
-            type: object
-          status:
-            description: VolStatus string that specifies the current state of the
-              volume provisioning request.
-            properties:
-              state:
-                description: State specifies the current state of the volume provisioning
-                  request. The state "Pending" means that the volume creation request
-                  has not processed yet. The state "Ready" means that the volume has
-                  been created and it is ready for the use.
-                enum:
-                - Pending
-                - Ready
-                type: string
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: false
-    subresources: {}
+                  minLength: 1
+                  type: string
+                volumeType:
+                  description: volumeType determines whether the volume is of type "DATASET"
+                    or "ZVOL". If fstype provided in the storageclass is "zfs", a volume
+                    of type dataset will be created. If "ext4", "ext3", "ext2" or "xfs"
+                    is mentioned as fstype in the storageclass, then a volume of type
+                    zvol will be created, which will be further formatted as the fstype
+                    provided in the storageclass. VolumeType can not be modified once
+                    volume has been provisioned.
+                  enum:
+                    - ZVOL
+                    - DATASET
+                  type: string
+              required:
+                - capacity
+                - ownerNodeID
+                - poolName
+                - volumeType
+              type: object
+            status:
+              description: VolStatus string that specifies the current state of the
+                volume provisioning request.
+              properties:
+                state:
+                  description: State specifies the current state of the volume provisioning
+                    request. The state "Pending" means that the volume creation request
+                    has not processed yet. The state "Ready" means that the volume has
+                    been created and it is ready for the use.
+                  enum:
+                    - Pending
+                    - Ready
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources: {}
 status:
   acceptedNames:
     kind: ""
@@ -2660,7 +2660,7 @@ spec:
         app: "openebs-zfs-controller"
         component: "openebs-zfs-controller"
         openebs.io/component-name: "openebs-zfs-controller"
-        
+
         name: openebs-zfs-controller
     spec:
       priorityClassName: openebs-zfs-csi-controller-critical
@@ -2670,7 +2670,7 @@ spec:
           image: "registry.k8s.io/sig-storage/csi-resizer:v1.8.0"
           args:
             - "--v=5"
-            - "--csi-address=$(ADDRESS)"            
+            - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -2682,7 +2682,7 @@ spec:
           image: "registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2"
           imagePullPolicy: IfNotPresent
           args:
-            - "--csi-address=$(ADDRESS)"            
+            - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -2692,7 +2692,7 @@ spec:
         - name: snapshot-controller
           image: "registry.k8s.io/sig-storage/snapshot-controller:v6.2.2"
           args:
-            - "--v=5"            
+            - "--v=5"
           imagePullPolicy: IfNotPresent
         - name: csi-provisioner
           image: "registry.k8s.io/sig-storage/csi-provisioner:v3.5.0"
@@ -2704,7 +2704,7 @@ spec:
             - "--strict-topology"
             - "--enable-capacity=true"
             - "--extra-create-metadata=true"
-            - "--default-fstype=ext4"            
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/pkg/apis/openebs.io/zfs/v1/zfsvolume.go
+++ b/pkg/apis/openebs.io/zfs/v1/zfsvolume.go
@@ -163,6 +163,12 @@ type VolumeInfo struct {
 	// +kubebuilder:validation:Enum=ZVOL;DATASET
 	VolumeType string `json:"volumeType"`
 
+	// quotaType determines whether the dataset volume quota type is of type "quota" or "refquota".
+	// QuotaType can not be modified once volume has been provisioned.
+	// +kubebuilder:validation:Enum=quota;refquota
+	// Default Value: quota.
+	QuotaType string `json:"quotaType,omitempty"`
+
 	// FsType specifies filesystem type for the zfs volume/dataset.
 	// If FsType is provided as "zfs", then the driver will create a
 	// ZFS dataset, formatting is not required as underlying filesystem is ZFS anyway.

--- a/pkg/builder/volbuilder/build.go
+++ b/pkg/builder/volbuilder/build.go
@@ -172,6 +172,16 @@ func (b *Builder) WithFsType(fstype string) *Builder {
 	return b
 }
 
+// WithQuotaType sets quota type for dataset volume
+func (b *Builder) WithQuotaType(quotatype string) *Builder {
+	if quotatype != "" {
+		b.volume.Object.Spec.QuotaType = quotatype
+	} else {
+		b.volume.Object.Spec.QuotaType = "quota"
+	}
+	return b
+}
+
 // WithShared sets where filesystem is shared or not
 func (b *Builder) WithShared(shared string) *Builder {
 	b.volume.Object.Spec.Shared = shared

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -221,7 +221,7 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 	schld := parameters["scheduler"]
 	fstype := parameters["fstype"]
 	shared := parameters["shared"]
-	qoutatype := parameters["qoutatype"]
+	quotatype := parameters["quotatype"]
 
 	vtype := zfs.GetVolumeType(fstype)
 
@@ -280,7 +280,7 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 		WithVolumeType(vtype).
 		WithVolumeStatus(zfs.ZFSStatusPending).
 		WithFsType(fstype).
-		WithQuotaType(qoutatype).
+		WithQuotaType(quotatype).
 		WithShared(shared).
 		WithCompression(compression).Build()
 

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -221,6 +221,7 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 	schld := parameters["scheduler"]
 	fstype := parameters["fstype"]
 	shared := parameters["shared"]
+	qoutatype := parameters["qoutatype"]
 
 	vtype := zfs.GetVolumeType(fstype)
 
@@ -279,6 +280,7 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 		WithVolumeType(vtype).
 		WithVolumeStatus(zfs.ZFSStatusPending).
 		WithFsType(fstype).
+		WithQuotaType(qoutatype).
 		WithShared(shared).
 		WithCompression(compression).Build()
 

--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -153,10 +153,10 @@ func buildCloneCreateArgs(vol *apis.ZFSVolume) []string {
 		if vol.Spec.ThinProvision == "no" {
 			reservationProperty := ""
 			switch vol.Spec.QuotaType {
-			case "quota":
-				reservationProperty = "reservation=" + vol.Spec.Capacity
 			case "refquota":
 				reservationProperty = "refreservation=" + vol.Spec.Capacity
+			default:
+				reservationProperty = "reservation=" + vol.Spec.Capacity
 			}
 			ZFSVolArg = append(ZFSVolArg, "-o", reservationProperty)
 		}
@@ -232,10 +232,10 @@ func buildDatasetCreateArgs(vol *apis.ZFSVolume) []string {
 	if vol.Spec.ThinProvision == "no" {
 		reservationProperty := ""
 		switch vol.Spec.QuotaType {
-		case "quota":
-			reservationProperty = "reservation=" + vol.Spec.Capacity
 		case "refquota":
 			reservationProperty = "refreservation=" + vol.Spec.Capacity
+		default:
+			reservationProperty = "reservation=" + vol.Spec.Capacity
 		}
 		ZFSVolArg = append(ZFSVolArg, "-o", reservationProperty)
 	}

--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -143,7 +143,7 @@ func buildCloneCreateArgs(vol *apis.ZFSVolume) []string {
 
 	if vol.Spec.VolumeType == VolTypeDataset {
 		if len(vol.Spec.Capacity) != 0 {
-			quotaProperty := "quota=" + vol.Spec.Capacity
+			quotaProperty := vol.Spec.QuotaType + "=" + vol.Spec.Capacity
 			ZFSVolArg = append(ZFSVolArg, "-o", quotaProperty)
 		}
 		if len(vol.Spec.RecordSize) != 0 {
@@ -216,7 +216,7 @@ func buildDatasetCreateArgs(vol *apis.ZFSVolume) []string {
 	ZFSVolArg = append(ZFSVolArg, ZFSCreateArg)
 
 	if len(vol.Spec.Capacity) != 0 {
-		quotaProperty := "quota=" + vol.Spec.Capacity
+		quotaProperty := vol.Spec.QuotaType + "=" + vol.Spec.Capacity
 		ZFSVolArg = append(ZFSVolArg, "-o", quotaProperty)
 	}
 	if len(vol.Spec.RecordSize) != 0 {
@@ -292,7 +292,7 @@ func buildVolumeResizeArgs(vol *apis.ZFSVolume) []string {
 	ZFSVolArg = append(ZFSVolArg, ZFSSetArg)
 
 	if vol.Spec.VolumeType == VolTypeDataset {
-		quotaProperty := "quota=" + vol.Spec.Capacity
+		quotaProperty := vol.Spec.QuotaType + "=" + vol.Spec.Capacity
 		ZFSVolArg = append(ZFSVolArg, quotaProperty)
 	} else {
 		volsizeProperty := "volsize=" + vol.Spec.Capacity
@@ -350,7 +350,7 @@ func buildVolumeRestoreArgs(rstr *apis.ZFSRestore) ([]string, error) {
 
 	if rstr.VolSpec.VolumeType == VolTypeDataset {
 		if len(rstr.VolSpec.Capacity) != 0 {
-			ZFSRecvParam += " -o quota=" + rstr.VolSpec.Capacity
+			ZFSRecvParam += " -o " + rstr.VolSpec.QuotaType + "=" + rstr.VolSpec.Capacity
 		}
 		if len(rstr.VolSpec.RecordSize) != 0 {
 			ZFSRecvParam += " -o recordsize=" + rstr.VolSpec.RecordSize

--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -151,14 +151,7 @@ func buildCloneCreateArgs(vol *apis.ZFSVolume) []string {
 			ZFSVolArg = append(ZFSVolArg, "-o", recordsizeProperty)
 		}
 		if vol.Spec.ThinProvision == "no" {
-			reservationProperty := ""
-			switch vol.Spec.QuotaType {
-			case "refquota":
-				reservationProperty = "refreservation=" + vol.Spec.Capacity
-			default:
-				reservationProperty = "reservation=" + vol.Spec.Capacity
-			}
-			ZFSVolArg = append(ZFSVolArg, "-o", reservationProperty)
+			ZFSVolArg = append(ZFSVolArg, "-o", reservationProperty(vol.Spec.QuotaType, vol.Spec.Capacity))
 		}
 		ZFSVolArg = append(ZFSVolArg, "-o", "mountpoint=legacy")
 	}
@@ -230,14 +223,7 @@ func buildDatasetCreateArgs(vol *apis.ZFSVolume) []string {
 		ZFSVolArg = append(ZFSVolArg, "-o", recordsizeProperty)
 	}
 	if vol.Spec.ThinProvision == "no" {
-		reservationProperty := ""
-		switch vol.Spec.QuotaType {
-		case "refquota":
-			reservationProperty = "refreservation=" + vol.Spec.Capacity
-		default:
-			reservationProperty = "reservation=" + vol.Spec.Capacity
-		}
-		ZFSVolArg = append(ZFSVolArg, "-o", reservationProperty)
+		ZFSVolArg = append(ZFSVolArg, "-o", reservationProperty(vol.Spec.QuotaType, vol.Spec.Capacity))
 	}
 	if len(vol.Spec.Dedup) != 0 {
 		dedupProperty := "dedup=" + vol.Spec.Dedup
@@ -979,4 +965,13 @@ func decodeListOutput(raw []byte) ([]apis.Pool, error) {
 		}
 	}
 	return pools, nil
+}
+
+// get the reservation property based on the quota type
+func reservationProperty(quotaType string, capacity string) string {
+	var reservationProperties = map[string]string{
+		"quota":    "reservation=",
+		"refquota": "refreservation=",
+	}
+	return reservationProperties[quotaType] + capacity
 }

--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -151,7 +151,13 @@ func buildCloneCreateArgs(vol *apis.ZFSVolume) []string {
 			ZFSVolArg = append(ZFSVolArg, "-o", recordsizeProperty)
 		}
 		if vol.Spec.ThinProvision == "no" {
-			reservationProperty := "reservation=" + vol.Spec.Capacity
+			reservationProperty := ""
+			switch vol.Spec.QuotaType {
+			case "quota":
+				reservationProperty = "reservation=" + vol.Spec.Capacity
+			case "refquota":
+				reservationProperty = "refreservation=" + vol.Spec.Capacity
+			}
 			ZFSVolArg = append(ZFSVolArg, "-o", reservationProperty)
 		}
 		ZFSVolArg = append(ZFSVolArg, "-o", "mountpoint=legacy")
@@ -224,7 +230,13 @@ func buildDatasetCreateArgs(vol *apis.ZFSVolume) []string {
 		ZFSVolArg = append(ZFSVolArg, "-o", recordsizeProperty)
 	}
 	if vol.Spec.ThinProvision == "no" {
-		reservationProperty := "reservation=" + vol.Spec.Capacity
+		reservationProperty := ""
+		switch vol.Spec.QuotaType {
+		case "quota":
+			reservationProperty = "reservation=" + vol.Spec.Capacity
+		case "refquota":
+			reservationProperty = "refreservation=" + vol.Spec.Capacity
+		}
 		ZFSVolArg = append(ZFSVolArg, "-o", reservationProperty)
 	}
 	if len(vol.Spec.Dedup) != 0 {


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**: 
resolve this issue: [https://github.com/openebs/zfs-localpv/issues/423](https://github.com/openebs/zfs-localpv/issues/423)

**What this PR does?**: 
this PR adds an option for choosing between refquota or quota and uses this value as zfs command options


**Checklist:**
- [X] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: