### PR TITLE
chore: fix doc repo URL in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@ _Mention if this PR is part of any design or a continuation of previous PRs_
 - [ ] Commit has unit tests
 - [ ] Commit has integration tests
 - [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
-- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
+- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/website is used to track them:
 
 
 **PLEASE REMOVE BELOW INFORMATION BEFORE SUBMITTING**


### PR DESCRIPTION
## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**:
Incorrect doc repo URL in the PR template

**What this PR does?**:
Fixes the URL

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes #544 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
- `subject` is a single line brief description of the changes made in the pull request.
