### PR TITLE
fix(controller): provision zfs volume if zfs volume already exists

### DIFF
--- a/pkg/zfs/volume_test.go
+++ b/pkg/zfs/volume_test.go
@@ -1,0 +1,40 @@
+package zfs
+
+import (
+	"testing"
+
+	apis "github.com/openebs/zfs-localpv/pkg/apis/openebs.io/zfs/v1"
+)
+
+func TestIsVolumeReady(t *testing.T) {
+	volGen := func(finalizer string, state string) *apis.ZFSVolume {
+		vol := &apis.ZFSVolume{}
+		if finalizer != "" {
+			vol.Finalizers = append(vol.Finalizers, finalizer)
+		}
+		if state != "" {
+			vol.Status.State = state
+		}
+		return vol
+	}
+	tests := []struct {
+		name         string
+		volFinalizer string
+		volState     string
+		want         bool
+	}{
+		{"Older volume is ready", ZFSFinalizer, "", true},
+		{"Older volume is not ready", "", "", false},
+		{"Newer volume is pending", "", ZFSStatusPending, false},
+		{"Newer volume is pending with finalizer", ZFSFinalizer, ZFSStatusPending, false},
+		{"Newer volume is ready with finalizer", ZFSFinalizer, ZFSStatusReady, true},
+		{"Newer volume is failed", "", ZFSStatusFailed, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsVolumeReady(volGen(tt.volFinalizer, tt.volState)); got != tt.want {
+				t.Errorf("IsVolumeReady() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
- When the ZFSVolume is actually ready but the PV has not been created due to timeout or controller crash, the status of ZFSVolume will remain in Pending, which prevents the PV from being created and keeps the PVC in Pending as well.

**What this PR does?**:
- Clear finalizers of ZFSVolume in zfs.ProvisionVolume()
- When volume.ZVController.syncZV() is called, it will update the status of the ready ZFSVolume to the actual status instead of keep calling zfs.SetVolumeProp()

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- This is an intermittent issue, and it is difficult to reproduce the scenarios manually

**Any additional information for your reviewer?** :
No

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/website is used to track them:
