### PR TITLE
fix(ci): add ginkgo binary to nix shell

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/container-storage-interface/spec v1.8.0
 	github.com/kubernetes-csi/csi-lib-utils v0.9.0
+	// Update nix/sources.json nixpkgsGinkgo revision when this updated, to pull in the correct version of ginkgo.
 	github.com/onsi/ginkgo/v2 v2.19.1
 	github.com/onsi/gomega v1.34.1
 	github.com/openebs/google-analytics-4 v0.2.1

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -10,5 +10,17 @@
         "type": "tarball",
         "url": "https://github.com/NixOS/nixpkgs/archive/9a333eaa80901efe01df07eade2c16d183761fa3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "nixpkgsGinkgo": {
+        "branch": "master",
+        "description": "Nix Packages collection & NixOS",
+        "homepage": "",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "dbecfcef10b0e38fc02f7779b23dbeba731c4c13",
+        "sha256": "1vwyl8qprizyxxk9gv876ibbans5j4d394rsj9y9vl4dsfdzkj2w",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/dbecfcef10b0e38fc02f7779b23dbeba731c4c13.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,12 +1,15 @@
 let
   sources = import ./nix/sources.nix;
-  pkgs = import sources.nixpkgs {};
+  pkgs = import sources.nixpkgs { };
+  nixpkgsGinkgo = import sources.nixpkgsGinkgo { };
 in
 pkgs.mkShell {
   name = "scripts-shell";
   buildInputs = with pkgs; [
+    chart-testing
+    nixpkgs-fmt
+    nixpkgsGinkgo.ginkgo
     semver-tool
     yq-go
-    chart-testing
   ];
 }


### PR DESCRIPTION
CI runs for PRs 578, 580 are failing with
```
/home/runner/work/zfs-localpv/zfs-localpv/ci/ci-test.sh: line 79: ginkgo: command not found
```
This adds the ginkgo CLI to the nix-shell and pins it to version used in the go.mod using niv dependencies.