### PR TITLE
fix(controller): Fix race of csi controller calls on the same volume

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -65,23 +64,7 @@ type controller struct {
 	k8sNodeInformer cache.SharedIndexInformer
 	zfsNodeInformer cache.SharedIndexInformer
 
-	volMutexes sync.Map
-}
-
-func (cs *controller) LockVolume(volume string) func() {
-	value, _ := cs.volMutexes.LoadOrStore(volume, &sync.Mutex{})
-	mtx := value.(*sync.Mutex)
-	mtx.Lock()
-	return func() { mtx.Unlock() }
-}
-
-func (cs *controller) LockVolumeWithSnapshot(volume string, snapshot string) func() {
-	unlockVol := cs.LockVolume(volume)
-	unlockSnap := cs.LockVolume(snapshot)
-	return func() {
-		unlockVol()
-		unlockSnap()
-	}
+	volumeLock *volumeLock
 }
 
 // NewController returns a new instance
@@ -90,6 +73,7 @@ func NewController(d *CSIDriver) csi.ControllerServer {
 	ctrl := &controller{
 		driver:       d,
 		capabilities: newControllerCapabilities(),
+		volumeLock:   newVolumeLock(),
 	}
 	if err := ctrl.init(); err != nil {
 		klog.Fatalf("init controller: %v", err)
@@ -469,7 +453,7 @@ func (cs *controller) CreateVolume(
 	contentSource := req.GetVolumeContentSource()
 	pvcName := helpers.GetInsensitiveParameter(&parameters, "csi.storage.k8s.io/pvc/name")
 
-	unlock := cs.LockVolume(volName)
+	unlock := cs.volumeLock.LockVolume(volName)
 	defer unlock()
 
 	if contentSource != nil && contentSource.GetSnapshot() != nil {
@@ -515,7 +499,7 @@ func (cs *controller) DeleteVolume(
 	}
 
 	volumeID := strings.ToLower(req.GetVolumeId())
-	unlock := cs.LockVolume(volumeID)
+	unlock := cs.volumeLock.LockVolume(volumeID)
 	defer unlock()
 
 	// verify if the volume has already been deleted
@@ -635,7 +619,7 @@ func (cs *controller) ControllerExpandVolume(
 			"ControllerExpandVolume: no volumeID provided",
 		)
 	}
-	unlock := cs.LockVolume(volumeID)
+	unlock := cs.volumeLock.LockVolume(volumeID)
 	defer unlock()
 
 	/* round off the new size */
@@ -733,7 +717,7 @@ func (cs *controller) CreateSnapshot(
 	if err != nil {
 		return nil, err
 	}
-	unlock := cs.LockVolumeWithSnapshot(volumeID, snapName)
+	unlock := cs.volumeLock.LockVolumeWithSnapshot(volumeID, snapName)
 	defer unlock()
 
 	snapTimeStamp := time.Now().Unix()
@@ -831,7 +815,7 @@ func (cs *controller) DeleteSnapshot(
 		// should succeed when an invalid snapshot id is used
 		return &csi.DeleteSnapshotResponse{}, nil
 	}
-	unlock := cs.LockVolumeWithSnapshot(snapshotID[0], snapshotID[1])
+	unlock := cs.volumeLock.LockVolumeWithSnapshot(snapshotID[0], snapshotID[1])
 	defer unlock()
 	if err := zfs.DeleteSnapshot(snapshotID[1]); err != nil {
 		return nil, status.Errorf(

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -63,6 +64,15 @@ type controller struct {
 
 	k8sNodeInformer cache.SharedIndexInformer
 	zfsNodeInformer cache.SharedIndexInformer
+
+	volMutexes sync.Map
+}
+
+func (cs *controller) LockVolume(volume string) func() {
+	value, _ := cs.volMutexes.LoadOrStore(volume, &sync.Mutex{})
+	mtx := value.(*sync.Mutex)
+	mtx.Lock()
+	return func() { mtx.Unlock() }
 }
 
 // NewController returns a new instance
@@ -450,6 +460,9 @@ func (cs *controller) CreateVolume(
 	contentSource := req.GetVolumeContentSource()
 	pvcName := helpers.GetInsensitiveParameter(&parameters, "csi.storage.k8s.io/pvc/name")
 
+	unlock := cs.LockVolume(volName)
+	defer unlock()
+
 	if contentSource != nil && contentSource.GetSnapshot() != nil {
 		snapshotID := contentSource.GetSnapshot().GetSnapshotId()
 
@@ -493,6 +506,8 @@ func (cs *controller) DeleteVolume(
 	}
 
 	volumeID := strings.ToLower(req.GetVolumeId())
+	unlock := cs.LockVolume(volumeID)
+	defer unlock()
 
 	// verify if the volume has already been deleted
 	vol, err := zfs.GetVolume(volumeID)
@@ -611,6 +626,8 @@ func (cs *controller) ControllerExpandVolume(
 			"ControllerExpandVolume: no volumeID provided",
 		)
 	}
+	unlock := cs.LockVolume(volumeID)
+	defer unlock()
 
 	/* round off the new size */
 	updatedSize := getRoundedCapacity(req.GetCapacityRange().GetRequiredBytes())
@@ -707,6 +724,10 @@ func (cs *controller) CreateSnapshot(
 	if err != nil {
 		return nil, err
 	}
+	unlockVol := cs.LockVolume(volumeID)
+	defer unlockVol()
+	unlockSnap := cs.LockVolume(snapName)
+	defer unlockSnap()
 
 	snapTimeStamp := time.Now().Unix()
 	var state string
@@ -803,6 +824,10 @@ func (cs *controller) DeleteSnapshot(
 		// should succeed when an invalid snapshot id is used
 		return &csi.DeleteSnapshotResponse{}, nil
 	}
+	unlockVol := cs.LockVolume(snapshotID[0])
+	defer unlockVol()
+	unlockSnap := cs.LockVolume(snapshotID[1])
+	defer unlockSnap()
 	if err := zfs.DeleteSnapshot(snapshotID[1]); err != nil {
 		return nil, status.Errorf(
 			codes.Internal,

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -75,6 +75,15 @@ func (cs *controller) LockVolume(volume string) func() {
 	return func() { mtx.Unlock() }
 }
 
+func (cs *controller) LockVolumeWithSnapshot(volume string, snapshot string) func() {
+	unlockVol := cs.LockVolume(volume)
+	unlockSnap := cs.LockVolume(snapshot)
+	return func() {
+		unlockVol()
+		unlockSnap()
+	}
+}
+
 // NewController returns a new instance
 // of CSI controller
 func NewController(d *CSIDriver) csi.ControllerServer {
@@ -724,10 +733,8 @@ func (cs *controller) CreateSnapshot(
 	if err != nil {
 		return nil, err
 	}
-	unlockVol := cs.LockVolume(volumeID)
-	defer unlockVol()
-	unlockSnap := cs.LockVolume(snapName)
-	defer unlockSnap()
+	unlock := cs.LockVolumeWithSnapshot(volumeID, snapName)
+	defer unlock()
 
 	snapTimeStamp := time.Now().Unix()
 	var state string
@@ -824,10 +831,8 @@ func (cs *controller) DeleteSnapshot(
 		// should succeed when an invalid snapshot id is used
 		return &csi.DeleteSnapshotResponse{}, nil
 	}
-	unlockVol := cs.LockVolume(snapshotID[0])
-	defer unlockVol()
-	unlockSnap := cs.LockVolume(snapshotID[1])
-	defer unlockSnap()
+	unlock := cs.LockVolumeWithSnapshot(snapshotID[0], snapshotID[1])
+	defer unlock()
 	if err := zfs.DeleteSnapshot(snapshotID[1]); err != nil {
 		return nil, status.Errorf(
 			codes.Internal,

--- a/pkg/driver/volume_lock.go
+++ b/pkg/driver/volume_lock.go
@@ -1,0 +1,49 @@
+package driver
+
+import (
+	"sync"
+)
+
+type volumeLock struct {
+	cond   sync.Cond
+	locked map[string]struct{}
+}
+
+func newVolumeLock() *volumeLock {
+	return &volumeLock{
+		cond:   *sync.NewCond(&sync.Mutex{}),
+		locked: map[string]struct{}{},
+	}
+}
+
+func (l *volumeLock) LockVolume(volume string) func() {
+	l.cond.L.Lock()
+	defer l.cond.L.Unlock()
+
+	for {
+		if _, locked := l.locked[volume]; !locked {
+			break
+		}
+
+		l.cond.Wait()
+	}
+
+	l.locked[volume] = struct{}{}
+
+	return func() {
+		l.cond.L.Lock()
+		defer l.cond.L.Unlock()
+
+		delete(l.locked, volume)
+		l.cond.Broadcast()
+	}
+}
+
+func (l *volumeLock) LockVolumeWithSnapshot(volume string, snapshot string) func() {
+	unlockVol := l.LockVolume(volume)
+	unlockSnap := l.LockVolume(snapshot)
+	return func() {
+		unlockVol()
+		unlockSnap()
+	}
+}


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

When a CreateVolume requests takes longer then 10 seconds the request runs into a client-side timeout and gets retied by kubelet. While processing the new request, the old request is still being canceled on the server-side and the created ZFSVolume CR gets deleted.

1|2
-|-
CreateVolume call|
ZFSVolume CR created|
waiting for volume creation|
client timeout + context cancel|
| |CreateVolume call
| | ZFSVolume CR already exists
ZFSVolume CR deleted|
Return ERR|Return OK without creating a ZFSVolume

```
I0916 15:01:49.227721       1 grpc.go:72] GRPC call: /csi.v1.Controller/CreateVolume requests {"accessibility_requirements":{"preferred":[{"segments":{"beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/os":"linux","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"i04-1-b-node-i041b-0-0","kubernetes.io/os":"linux","m3.services/cluster":"i04-1-b","m3.services/worker-group":"i041b-0","node.systems.mittwald.cloud/placement-group":"i041b-0","openebs.io/nodeid":"i04-1-b-node-i041b-0-0","openebs.io/nodename":"i04-1-b-node-i041b-0-0"}}],"requisite":[{"segments":{"beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/os":"linux","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"i04-1-b-node-i041b-0-0","kubernetes.io/os":"linux","m3.services/cluster":"i04-1-b","m3.services/worker-group":"i041b-0","node.systems.mittwald.cloud/placement-group":"i041b-0","openebs.io/nodeid":"i04-1-b-node-i041b-0-0","openebs.io/nodename":"i04-1-b-node-i041b-0-0"}}]},"capacity_range":{"required_bytes":5368709120},"name":"pvc-eb11c446-f26c-4333-b3da-4ecb9c5b2457","parameters":{"compression":"off","csi.storage.k8s.io/pv/name":"pvc-eb11c446-f26c-4333-b3da-4ecb9c5b2457","csi.storage.k8s.io/pvc/name":"test-pvc0","csi.storage.k8s.io/pvc/namespace":"default","dedup":"off","fstype":"zfs","poolname":"kluster-pool/i04-1-b-128k","recordsize":"128k","shared":"yes","thinprovision":"yes"},"volume_capabilities":[{"AccessType":{"Mount":{"fs_type":"zfs"}},"access_mode":{"mode":1}}]}
I0916 15:01:58.853180       1 controller.go:289] zfs: trying volume creation kluster-pool/i04-1-b-128k/pvc-eb11c446-f26c-4333-b3da-4ecb9c5b2457 on node [i04-1-b-node-i041b-0-0]
I0916 15:01:59.104207       1 volume.go:139] zfs: waiting for volume kluster-pool/i04-1-b-128k/pvc-eb11c446-f26c-4333-b3da-4ecb9c5b2457 to be created on nodeid i04-1-b-node-i041b-0-0
I0916 15:02:00.105273       1 volume.go:170] zfs: volume kluster-pool/i04-1-b-128k/pvc-eb11c446-f26c-4333-b3da-4ecb9c5b2457 provisioning failed on nodeid i04-1-b-node-i041b-0-0 err: zfs: context deadline reached
I0916 15:02:00.235113       1 grpc.go:72] GRPC call: /csi.v1.Controller/CreateVolume requests {"accessibility_requirements":{"preferred":[{"segments":{"beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/os":"linux","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"i04-1-b-node-i041b-0-0","kubernetes.io/os":"linux","m3.services/cluster":"i04-1-b","m3.services/worker-group":"i041b-0","node.systems.mittwald.cloud/placement-group":"i041b-0","openebs.io/nodeid":"i04-1-b-node-i041b-0-0","openebs.io/nodename":"i04-1-b-node-i041b-0-0"}}],"requisite":[{"segments":{"beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/os":"linux","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"i04-1-b-node-i041b-0-0","kubernetes.io/os":"linux","m3.services/cluster":"i04-1-b","m3.services/worker-group":"i041b-0","node.systems.mittwald.cloud/placement-group":"i041b-0","openebs.io/nodeid":"i04-1-b-node-i041b-0-0","openebs.io/nodename":"i04-1-b-node-i041b-0-0"}}]},"capacity_range":{"required_bytes":5368709120},"name":"pvc-eb11c446-f26c-4333-b3da-4ecb9c5b2457","parameters":{"compression":"off","csi.storage.k8s.io/pv/name":"pvc-eb11c446-f26c-4333-b3da-4ecb9c5b2457","csi.storage.k8s.io/pvc/name":"test-pvc0","csi.storage.k8s.io/pvc/namespace":"default","dedup":"off","fstype":"zfs","poolname":"kluster-pool/i04-1-b-128k","recordsize":"128k","shared":"yes","thinprovision":"yes"},"volume_capabilities":[{"AccessType":{"Mount":{"fs_type":"zfs"}},"access_mode":{"mode":1}}]}
I0916 15:02:00.449153       1 volume.go:221] zfs: deleted the volume pvc-eb11c446-f26c-4333-b3da-4ecb9c5b2457
I0916 15:02:00.449299       1 controller.go:466] created the volume kluster-pool/i04-1-b-128k/pvc-eb11c446-f26c-4333-b3da-4ecb9c5b2457 on node i04-1-b-node-i041b-0-0
I0916 15:02:00.553778       1 grpc.go:81] GRPC response: {"volume":{"accessible_topology":[{"segments":{"openebs.io/nodeid":"i04-1-b-node-i041b-0-0"}}],"capacity_bytes":5368709120,"volume_context":{"openebs.io/cas-type":"localpv-zfs","openebs.io/poolname":"kluster-pool/i04-1-b-128k"},"volume_id":"pvc-eb11c446-f26c-4333-b3da-4ecb9c5b2457"}}
```

**What this PR does?**: Adds a per volume mutex to csi calls to prevent simultaneous requests

**Does this PR require any upgrade changes?**: No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/website is used to track them: