### PR TITLE
fix(deploy): indent for imagePullSecrets

### DIFF
--- a/deploy/helm/charts/charts/crds/templates/zfsrestore.yaml
+++ b/deploy/helm/charts/charts/crds/templates/zfsrestore.yaml
@@ -91,7 +91,7 @@ spec:
                   data. For instance, if the Volume was created with "off" and the
                   next day the compression was modified to "on", the data written
                   prior to setting "on" will not be compressed. Default Value: off.'
-                pattern: ^(on|off|lzjb|zstd|zstd-[1-9]|zstd-1[0-9]|gzip|gzip-[1-9]|zle|lz4)$
+                pattern: ^(on|off|lzjb|zstd(?:-fast|-[1-9]|-1[0-9])?|gzip(?:-[1-9])?|zle|lz4)$
                 type: string
               dedup:
                 description: 'Deduplication is the process for removing redundant

--- a/deploy/helm/charts/charts/crds/templates/zfssnapshot.yaml
+++ b/deploy/helm/charts/charts/crds/templates/zfssnapshot.yaml
@@ -60,7 +60,7 @@ spec:
                   data. For instance, if the Volume was created with "off" and the
                   next day the compression was modified to "on", the data written
                   prior to setting "on" will not be compressed. Default Value: off.'
-                pattern: ^(on|off|lzjb|zstd|zstd-[1-9]|zstd-1[0-9]|gzip|gzip-[1-9]|zle|lz4)$
+                pattern: ^(on|off|lzjb|zstd(?:-fast|-[1-9]|-1[0-9])?|gzip(?:-[1-9])?|zle|lz4)$
                 type: string
               dedup:
                 description: 'Deduplication is the process for removing redundant

--- a/deploy/helm/charts/charts/crds/templates/zfsvolume.yaml
+++ b/deploy/helm/charts/charts/crds/templates/zfsvolume.yaml
@@ -86,7 +86,7 @@ spec:
                   data. For instance, if the Volume was created with "off" and the
                   next day the compression was modified to "on", the data written
                   prior to setting "on" will not be compressed. Default Value: off.'
-                pattern: ^(on|off|lzjb|zstd|zstd-[1-9]|zstd-1[0-9]|gzip|gzip-[1-9]|zle|lz4)$
+                pattern: ^(on|off|lzjb|zstd(?:-fast|-[1-9]|-1[0-9])?|gzip(?:-[1-9])?|zle|lz4)$
                 type: string
               dedup:
                 description: 'Deduplication is the process for removing redundant

--- a/deploy/helm/charts/templates/zfs-controller.yaml
+++ b/deploy/helm/charts/templates/zfs-controller.yaml
@@ -146,7 +146,7 @@ spec:
 {{- end }}
 {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 2 }}
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
 {{- end }}
 {{- if .Values.zfsController.nodeSelector }}
       nodeSelector:

--- a/deploy/helm/charts/templates/zfs-node.yaml
+++ b/deploy/helm/charts/templates/zfs-node.yaml
@@ -148,7 +148,7 @@ spec:
 {{- end }}
 {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 2 }}
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
 {{- end }}
 {{- if .Values.zfsNode.nodeSelector }}
       nodeSelector:

--- a/deploy/yamls/zfsrestore-crd.yaml
+++ b/deploy/yamls/zfsrestore-crd.yaml
@@ -89,7 +89,7 @@ spec:
                   data. For instance, if the Volume was created with "off" and the
                   next day the compression was modified to "on", the data written
                   prior to setting "on" will not be compressed. Default Value: off.'
-                pattern: ^(on|off|lzjb|zstd|zstd-[1-9]|zstd-1[0-9]|gzip|gzip-[1-9]|zle|lz4)$
+                pattern: ^(on|off|lzjb|zstd(?:-fast|-[1-9]|-1[0-9])?|gzip(?:-[1-9])?|zle|lz4)$
                 type: string
               dedup:
                 description: 'Deduplication is the process for removing redundant

--- a/deploy/yamls/zfssnapshot-crd.yaml
+++ b/deploy/yamls/zfssnapshot-crd.yaml
@@ -58,7 +58,7 @@ spec:
                   data. For instance, if the Volume was created with "off" and the
                   next day the compression was modified to "on", the data written
                   prior to setting "on" will not be compressed. Default Value: off.'
-                pattern: ^(on|off|lzjb|zstd|zstd-[1-9]|zstd-1[0-9]|gzip|gzip-[1-9]|zle|lz4)$
+                pattern: ^(on|off|lzjb|zstd(?:-fast|-[1-9]|-1[0-9])?|gzip(?:-[1-9])?|zle|lz4)$
                 type: string
               dedup:
                 description: 'Deduplication is the process for removing redundant

--- a/deploy/yamls/zfsvolume-crd.yaml
+++ b/deploy/yamls/zfsvolume-crd.yaml
@@ -84,7 +84,7 @@ spec:
                   data. For instance, if the Volume was created with "off" and the
                   next day the compression was modified to "on", the data written
                   prior to setting "on" will not be compressed. Default Value: off.'
-                pattern: ^(on|off|lzjb|zstd|zstd-[1-9]|zstd-1[0-9]|gzip|gzip-[1-9]|zle|lz4)$
+                pattern: ^(on|off|lzjb|zstd(?:-fast|-[1-9]|-1[0-9])?|gzip(?:-[1-9])?|zle|lz4)$
                 type: string
               dedup:
                 description: 'Deduplication is the process for removing redundant

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -1377,7 +1377,7 @@ spec:
                   data. For instance, if the Volume was created with "off" and the
                   next day the compression was modified to "on", the data written
                   prior to setting "on" will not be compressed. Default Value: off.'
-                pattern: ^(on|off|lzjb|zstd|zstd-[1-9]|zstd-1[0-9]|gzip|gzip-[1-9]|zle|lz4)$
+                pattern: ^(on|off|lzjb|zstd(?:-fast|-[1-9]|-1[0-9])?|gzip(?:-[1-9])?|zle|lz4)$
                 type: string
               dedup:
                 description: 'Deduplication is the process for removing redundant
@@ -1582,7 +1582,7 @@ spec:
                   data. For instance, if the Volume was created with "off" and the
                   next day the compression was modified to "on", the data written
                   prior to setting "on" will not be compressed. Default Value: off.'
-                pattern: ^(on|off|lzjb|zstd|zstd-[1-9]|zstd-1[0-9]|gzip|gzip-[1-9]|zle|lz4)$
+                pattern: ^(on|off|lzjb|zstd(?:-fast|-[1-9]|-1[0-9])?|gzip(?:-[1-9])?|zle|lz4)$
                 type: string
               dedup:
                 description: 'Deduplication is the process for removing redundant
@@ -1989,7 +1989,7 @@ spec:
                   data. For instance, if the Volume was created with "off" and the
                   next day the compression was modified to "on", the data written
                   prior to setting "on" will not be compressed. Default Value: off.'
-                pattern: ^(on|off|lzjb|zstd|zstd-[1-9]|zstd-1[0-9]|gzip|gzip-[1-9]|zle|lz4)$
+                pattern: ^(on|off|lzjb|zstd(?:-fast|-[1-9]|-1[0-9])?|gzip(?:-[1-9])?|zle|lz4)$
                 type: string
               dedup:
                 description: 'Deduplication is the process for removing redundant

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -37,13 +37,13 @@ aws_secret_access_key = minio123
 We can install Velero by using below command
 
 ```
-velero install --provider aws --bucket velero --secret-file /home/pawan/velero/credentials-minio --plugins velero/velero-plugin-for-aws:v1.0.0-beta.1 --backup-location-config region=minio,s3ForcePathStyle="true",s3Url=http://minio.velero.svc:9000 --use-volume-snapshots=true --use-node-agent --uploader-type restic
+velero install --provider aws --bucket velero --secret-file /home/pawan/velero/credentials-minio --plugins velero/velero-plugin-for-aws:v1.10.1 --backup-location-config region=minio,s3ForcePathStyle="true",s3Url=http://minio.velero.svc:9000 --use-volume-snapshots=true --use-node-agent
 ```
 
 If you would like to use cloud storage like AWS-S3 buckets for storing backups, you could use a command like the following: 
 
 ```
-velero install --provider aws --bucket <bucket_name> --secret-file <./aws-iam-creds> --plugins velero/velero-plugin-for-aws:v1.0.0-beta.1 --backup-location-config region=<bucket_region>,s3ForcePathStyle="true" --use-volume-snapshots=true --use-node-agent --uploader-type restic
+velero install --provider aws --bucket <bucket_name> --secret-file <./aws-iam-creds> --plugins velero/velero-plugin-for-aws:v1.10.1 --backup-location-config region=<bucket_region>,s3ForcePathStyle="true" --use-volume-snapshots=true --use-node-agent
 ```
 
 We have to install the velero 1.5 or later version for LocalPV-ZFS.
@@ -65,9 +65,7 @@ $ kubectl get po -n velero
 NAME                      READY   STATUS      RESTARTS   AGE
 minio-d787f4bf7-xqmq5     1/1     Running     0          8s
 minio-setup-prln8         0/1     Completed   0          8s
-restic-4kx8l              1/1     Running     0          69s
-restic-g5zq9              1/1     Running     0          69s
-restic-k7k4s              1/1     Running     0          69s
+node-agent-lltf2          1/1     Running     0          69s
 velero-7d9c448bc5-j424s   1/1     Running     3          69s
 ```
 

--- a/pkg/apis/openebs.io/zfs/v1/zfsvolume.go
+++ b/pkg/apis/openebs.io/zfs/v1/zfsvolume.go
@@ -106,7 +106,7 @@ type VolumeInfo struct {
 	// the next day the compression was modified to "on", the data written prior to setting "on" will
 	// not be compressed.
 	// Default Value: off.
-	// +kubebuilder:validation:Pattern="^(on|off|lzjb|zstd|zstd-[1-9]|zstd-1[0-9]|gzip|gzip-[1-9]|zle|lz4)$"
+	// +kubebuilder:validation:Pattern="^(on|off|lzjb|zstd(?:-fast|-[1-9]|-1[0-9])?|gzip(?:-[1-9])?|zle|lz4)$"
 	Compression string `json:"compression,omitempty"`
 
 	// Deduplication is the process for removing redundant data at the block level,

--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -297,6 +297,10 @@ func buildVolumeResizeArgs(vol *apis.ZFSVolume) []string {
 		ZFSVolArg = append(ZFSVolArg, volsizeProperty)
 	}
 
+	if vol.Spec.ThinProvision == "no" {
+		ZFSVolArg = append(ZFSVolArg, "-o", reservationProperty(vol.Spec.QuotaType, vol.Spec.Capacity))
+	}
+
 	ZFSVolArg = append(ZFSVolArg, volume)
 
 	return ZFSVolArg

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -639,7 +639,7 @@ func getStoragClassParams() []map[string]string {
 		},
 		{
 			"fstype":        "zfs",
-			"compression":   "zstd-6",
+			"compression":   "zstd-fast",
 			"dedup":         "on",
 			"thinprovision": "yes",
 		},
@@ -676,6 +676,10 @@ func getStoragClassParams() []map[string]string {
 			"fstype":      "btrfs",
 			"compression": "zstd-6",
 			"dedup":       "on",
+		},
+		{
+			"fstype":      "xfs",
+			"compression": "zstd-fast",
 		},
 	}
 }


### PR DESCRIPTION
Why is this PR required? What issue does it fix?:
When we were pulling the image from a private repo, we noticed that the synax is wrong for zfs-node and zfs-controller. The indent must be 8 and not 2.
What this PR does?:
change indent
Does this PR require any upgrade changes?:
No
If the changes in this PR are manually verified, list down the scenarios covered::
N/A
Any additional information for your reviewer? :
N/A
Checklist:

 Fixes
 PR Title follows the convention of <type>(<scope>): <subject>
 Has the change log section been updated?
 Commit has unit tests
 Commit has integration tests
 (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
 (Optional) If documentation changes are required, which issue on https://github.com/openebs/website is used to track