### PR TITLE
fix(chart): move app=componentName label out of csi-node matchLabels

### DIFF
--- a/deploy/helm/charts/templates/_helpers.tpl
+++ b/deploy/helm/charts/templates/_helpers.tpl
@@ -98,7 +98,6 @@ Create labels for openebs zfs-localpv controller
 Create match labels for openebs zfs-localpv node daemon
 */}}
 {{- define "zfslocalpv.zfsNode.matchLabels" -}}
-app: {{ .Values.zfsNode.componentName | quote }}
 name: {{ .Values.zfsNode.componentName | quote }}{{ if or (not (hasKey .Values "enableHelmMetaLabels")) .Values.enableHelmMetaLabels }}
 release: {{ .Release.Name }}
 {{- end -}}
@@ -108,6 +107,7 @@ release: {{ .Release.Name }}
 Create component labels openebs zfs-localpv node daemon
 */}}
 {{- define "zfslocalpv.zfsNode.componentLabels" -}}
+app: {{ .Values.zfsNode.componentName | quote }}
 openebs.io/component-name: {{ .Values.zfsNode.componentName | quote }}
 {{- end -}}
 


### PR DESCRIPTION
The label `app: openebs-zfs-node` was missing on the csi-node components. However, adding it to the selector labels section breaks upgrade from previous versions.

This need not live in matchLabels, and could simply live in componentLabels

Fixes https://github.com/openebs/zfs-localpv/issues/593

