### PR TITLE
chore(cmd): flag --plugin allows only "controller" and "agent" and not "node"

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -71,7 +71,7 @@ func main() {
 	)
 
 	cmd.PersistentFlags().StringVar(
-		&config.PluginType, "plugin", "csi-plugin", "Type of this driver i.e. controller or node",
+		&config.PluginType, "plugin", "csi-plugin", "Type of this driver i.e. controller or agent",
 	)
 
 	err := cmd.Execute()


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
Prevent misconfiguration due to wrong CLI documentation.

**What this PR does?**:
Replaces `node` with `agent` in the description of flag `--plugin`.

**Does this PR require any upgrade changes?**:
No

**Any additional information for your reviewer?** :
According to https://github.com/openebs/zfs-localpv/blob/develop/pkg/driver/driver.go#L65-L76 it seems only "controller" or "agent" are functional values. This is further confirmed by the current helm charts:
- the daemonset is running "agent": https://github.com/openebs/zfs-localpv/blob/develop/deploy/helm/charts/templates/zfs-node.yaml#L87
- the deployment is running "controller": https://github.com/openebs/zfs-localpv/blob/develop/deploy/helm/charts/templates/zfs-controller.yaml#L112

Shouldn't we also fail if no valid value is set? Since https://github.com/openebs/zfs-localpv/blob/develop/pkg/driver/driver.go#L83 is just continuing...

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/website is used to track them:
