### PR TITLE
fix(FAQ): Update import-existing-volume.md to include correct working steps

### DIFF
--- a/docs/import-existing-volume.md
+++ b/docs/import-existing-volume.md
@@ -151,8 +151,8 @@ spec:
   ownerNodeID: pawan-3 # should be the nodename where ZPOOL is running
   poolName: zfspv-pool # poolname where the volume is present
   volumeType: DATASET # whether it is a DATASET or ZVOL
-Status:
-  State: Ready # state should be Ready as volume is already present
+status:
+  state: Ready # state should be Ready as volume is already present
 ```
 
 Modify the parameters :-

--- a/docs/import-existing-volume.md
+++ b/docs/import-existing-volume.md
@@ -138,7 +138,7 @@ If the volume is a zfs dataset, then create LocalPV-ZFS resource with volumeType
 
 ```
 $ cat zfspvcr.yaml
-apiVersion: zfs.openebs.io/v1alpha1
+apiVersion: zfs.openebs.io/v1
 kind: ZFSVolume
 metadata:
   finalizers:
@@ -151,6 +151,7 @@ spec:
   ownerNodeID: pawan-3 # should be the nodename where ZPOOL is running
   poolName: zfspv-pool # poolname where the volume is present
   volumeType: DATASET # whether it is a DATASET or ZVOL
+  shared: "yes" # whether or not the volume can be shared across pods
 status:
   state: Ready # state should be Ready as volume is already present
 ```


### PR DESCRIPTION
Correct the manifest for importing an existing volume

## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**:
If you follow the "Import an existing volume" steps in the FAQ, they fail due to some typos. 

**What this PR does?**:
Fix the typos mentioned above, so that you can perform the recovery correctly. 

**Does this PR require any upgrade changes?**:
No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Following steps:
```
(base) ➜ kubectl apply -f storage/zfs-provisioner/recovery/zfsvolume.yaml
Error from server (BadRequest): error when creating "storage/zfs-provisioner/recovery/zfsvolume.yaml": ZFSVolume in version "v1alpha1" cannot be handled as a ZFSVolume: strict decoding error: unknown field "Status"
```

Following fixed steps:
No error. Volume shows up as expected, with status Ready:
```
(base) ➜  kubectl get ZFSVolume -A                                   
NAMESPACE   NAME                                       ZPOOL        NODEID         SIZE            STATUS   FILESYSTEM   AGE
openebs     pvc-e3184afc-ea72-4b3a-886f-209c3ca26d44   zfspv-pool   node0  5368709120      Ready    zfs          11m
openebs     pvc-ed6ecc31-c5cc-4bb6-95b7-6fb83dd92133   zfspv-pool   node0   5497558138880   Ready    zfs          66s
```


**Any additional information for your reviewer?** :
N/A.

**Checklist:**
- [x] Fixes #252, possibly others.
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests