### PR TITLE
fix(agent): use openebs' lib-csi k8s client to load kubeconfig

### DIFF
--- a/pkg/mgmt/backup/start.go
+++ b/pkg/mgmt/backup/start.go
@@ -20,28 +20,21 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
-	"k8s.io/klog/v2"
 
 	"time"
 
+	k8sapi "github.com/openebs/lib-csi/pkg/client/k8s"
 	clientset "github.com/openebs/zfs-localpv/pkg/generated/clientset/internalclientset"
 	informers "github.com/openebs/zfs-localpv/pkg/generated/informer/externalversions"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-)
-
-var (
-	masterURL  string
-	kubeconfig string
 )
 
 // Start starts the zfsbackup controller.
 func Start(controllerMtx *sync.RWMutex, stopCh <-chan struct{}) error {
 
 	// Get in cluster config
-	cfg, err := getClusterConfig(kubeconfig)
+	cfg, err := k8sapi.Config().Get()
 	if err != nil {
 		return errors.Wrap(err, "error building kubeconfig")
 	}
@@ -88,20 +81,4 @@ func Start(controllerMtx *sync.RWMutex, stopCh <-chan struct{}) error {
 
 	// Threadiness defines the number of workers to be launched in Run function
 	return controller.Run(2, stopCh)
-}
-
-// GetClusterConfig return the config for k8s.
-func getClusterConfig(kubeconfig string) (*rest.Config, error) {
-	cfg, err := rest.InClusterConfig()
-	if err != nil {
-		klog.Errorf("Failed to get k8s Incluster config. %+v", err)
-		if kubeconfig == "" {
-			return nil, errors.Wrap(err, "kubeconfig is empty")
-		}
-		cfg, err = clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
-		if err != nil {
-			return nil, errors.Wrap(err, "error building kubeconfig")
-		}
-	}
-	return cfg, err
 }

--- a/pkg/mgmt/restore/start.go
+++ b/pkg/mgmt/restore/start.go
@@ -20,28 +20,21 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
-	"k8s.io/klog/v2"
 
 	"time"
 
+	k8sapi "github.com/openebs/lib-csi/pkg/client/k8s"
 	clientset "github.com/openebs/zfs-localpv/pkg/generated/clientset/internalclientset"
 	informers "github.com/openebs/zfs-localpv/pkg/generated/informer/externalversions"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-)
-
-var (
-	masterURL  string
-	kubeconfig string
 )
 
 // Start starts the zfsrestore controller.
 func Start(controllerMtx *sync.RWMutex, stopCh <-chan struct{}) error {
 
 	// Get in cluster config
-	cfg, err := getClusterConfig(kubeconfig)
+	cfg, err := k8sapi.Config().Get()
 	if err != nil {
 		return errors.Wrap(err, "error building kubeconfig")
 	}
@@ -88,20 +81,4 @@ func Start(controllerMtx *sync.RWMutex, stopCh <-chan struct{}) error {
 
 	// Threadiness defines the number of workers to be launched in Run function
 	return controller.Run(2, stopCh)
-}
-
-// GetClusterConfig return the config for k8s.
-func getClusterConfig(kubeconfig string) (*rest.Config, error) {
-	cfg, err := rest.InClusterConfig()
-	if err != nil {
-		klog.Errorf("Failed to get k8s Incluster config. %+v", err)
-		if kubeconfig == "" {
-			return nil, errors.Wrap(err, "kubeconfig is empty")
-		}
-		cfg, err = clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
-		if err != nil {
-			return nil, errors.Wrap(err, "error building kubeconfig")
-		}
-	}
-	return cfg, err
 }

--- a/pkg/mgmt/snapshot/start.go
+++ b/pkg/mgmt/snapshot/start.go
@@ -23,25 +23,18 @@ import (
 
 	"time"
 
+	k8sapi "github.com/openebs/lib-csi/pkg/client/k8s"
 	clientset "github.com/openebs/zfs-localpv/pkg/generated/clientset/internalclientset"
 	informers "github.com/openebs/zfs-localpv/pkg/generated/informer/externalversions"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/klog/v2"
-)
-
-var (
-	masterURL  string
-	kubeconfig string
 )
 
 // Start starts the zfssnapshot controller.
 func Start(controllerMtx *sync.RWMutex, stopCh <-chan struct{}) error {
 
 	// Get in cluster config
-	cfg, err := getClusterConfig(kubeconfig)
+	cfg, err := k8sapi.Config().Get()
 	if err != nil {
 		return errors.Wrap(err, "error building kubeconfig")
 	}
@@ -88,20 +81,4 @@ func Start(controllerMtx *sync.RWMutex, stopCh <-chan struct{}) error {
 
 	// Threadiness defines the number of workers to be launched in Run function
 	return controller.Run(2, stopCh)
-}
-
-// GetClusterConfig return the config for k8s.
-func getClusterConfig(kubeconfig string) (*rest.Config, error) {
-	cfg, err := rest.InClusterConfig()
-	if err != nil {
-		klog.Errorf("Failed to get k8s Incluster config. %+v", err)
-		if kubeconfig == "" {
-			return nil, errors.Wrap(err, "kubeconfig is empty")
-		}
-		cfg, err = clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
-		if err != nil {
-			return nil, errors.Wrap(err, "error building kubeconfig")
-		}
-	}
-	return cfg, err
 }

--- a/pkg/mgmt/volume/start.go
+++ b/pkg/mgmt/volume/start.go
@@ -23,24 +23,18 @@ import (
 
 	"time"
 
+	k8sapi "github.com/openebs/lib-csi/pkg/client/k8s"
 	clientset "github.com/openebs/zfs-localpv/pkg/generated/clientset/internalclientset"
 	informers "github.com/openebs/zfs-localpv/pkg/generated/informer/externalversions"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/klog/v2"
-)
-
-var (
-	masterURL  string
-	kubeconfig string
 )
 
 // Start starts the zfsvolume controller.
 func Start(controllerMtx *sync.RWMutex, stopCh <-chan struct{}) error {
+
 	// Get in cluster config
-	cfg, err := getClusterConfig(kubeconfig)
+	cfg, err := k8sapi.Config().Get()
 	if err != nil {
 		return errors.Wrap(err, "error building kubeconfig")
 	}
@@ -87,20 +81,4 @@ func Start(controllerMtx *sync.RWMutex, stopCh <-chan struct{}) error {
 
 	// Threadiness defines the number of workers to be launched in Run function
 	return controller.Run(2, stopCh)
-}
-
-// GetClusterConfig return the config for k8s.
-func getClusterConfig(kubeconfig string) (*rest.Config, error) {
-	cfg, err := rest.InClusterConfig()
-	if err != nil {
-		klog.Errorf("Failed to get k8s Incluster config. %+v", err)
-		if kubeconfig == "" {
-			return nil, errors.Wrap(err, "kubeconfig is empty")
-		}
-		cfg, err = clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
-		if err != nil {
-			return nil, errors.Wrap(err, "error building kubeconfig")
-		}
-	}
-	return cfg, err
 }


### PR DESCRIPTION
## Pull Request template

**Why is this PR required? What issue does it fix?**: The binary crashes if you want to use it with a kubeconfig stating it can't find the kubeconfig. The package variables `kubeconfig` and `masterurl` were never holding a value.

**What this PR does?**: Uses existing implementation to find kubeconfig. This is already in use in package `zfsnode`.

**Does this PR require any upgrade changes?**: no

**If the changes in this PR are manually verified, list down the scenarios covered:**: starts up binary successfully with env `OPENEBS_IO_KUBE_CONFIG` set and in `agent` plugin mode.

**Any additional information for your reviewer?** : no (see linked issue)


**Checklist:**
- [x] Fixes #414
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/website is used to track them: