### PR TITLE
fix(grpc): stop server on SIGTERM and SIGINT

### DIFF
--- a/pkg/driver/agent.go
+++ b/pkg/driver/agent.go
@@ -53,6 +53,8 @@ func NewNode(d *CSIDriver) csi.NodeServer {
 	var ControllerMutex = sync.RWMutex{}
 
 	// set up signals so we handle the first shutdown signal gracefully
+	// TODO: (tech-debt) Setup signal handler more above, several files want to use stopCh and this function is only allowed to be used once (see #647)
+	// Affected files: pkg/driver/agent.go pkg/driver/controller.go pkg/driver/grpc.go
 	stopCh := signals.SetupSignalHandler()
 
 	// start the zfsnode resource watcher

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -103,6 +103,8 @@ func (cs *controller) init() error {
 		0, informers.WithNamespace(zfs.OpenEBSNamespace))
 
 	// set up signals so we handle the first shutdown signal gracefully
+	// TODO: (tech-debt) Setup signal handler more above, several files want to use stopCh and this function is only allowed to be used once (see #647)
+	// Affected files: pkg/driver/agent.go pkg/driver/controller.go pkg/driver/grpc.go
 	stopCh := signals.SetupSignalHandler()
 
 	cs.k8sNodeInformer = kubeInformerFactory.Core().V1().Nodes().Informer()

--- a/pkg/driver/grpc.go
+++ b/pkg/driver/grpc.go
@@ -21,8 +21,10 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/signal"
 	"strings"
 	"sync"
+	"syscall"
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -122,8 +124,17 @@ type nonBlockingGRPCServer struct {
 
 // Start grpc server for serving CSI endpoints
 func (s *nonBlockingGRPCServer) Start() {
-
+	// Also stop the grpc server if SIGINT or SIGTERM is received
+	// This is only a temporary solution, better pass a cancellable context around for the lifetime of the application
+	// See: https://stackoverflow.com/a/74895157 and https://gist.github.com/embano1/e0bf49d24f1cdd07cffad93097c04f0a
+	stopCh := make(chan os.Signal, 1)
+	signal.Notify(stopCh, syscall.SIGINT, syscall.SIGTERM)
 	s.wg.Add(1)
+	go func() {
+		<-stopCh    // wait for the stop signal
+		s.Stop()    // noone actually stops the grpc server, so have to do here
+		s.wg.Done() // to mark above wg.Add as done
+	}()
 
 	go s.serve(s.endpoint, s.idntyServer, s.ctrlServer, s.agentServer)
 }
@@ -135,11 +146,13 @@ func (s *nonBlockingGRPCServer) Wait() {
 
 // Stop the service forcefully
 func (s *nonBlockingGRPCServer) Stop() {
+	klog.Info("Shutting down gRPC server gracefully")
 	s.server.GracefulStop()
 }
 
 // ForceStop the service
 func (s *nonBlockingGRPCServer) ForceStop() {
+	klog.Info("Shutting down gRPC server forcefully")
 	s.server.Stop()
 }
 

--- a/pkg/driver/grpc.go
+++ b/pkg/driver/grpc.go
@@ -125,8 +125,8 @@ type nonBlockingGRPCServer struct {
 // Start grpc server for serving CSI endpoints
 func (s *nonBlockingGRPCServer) Start() {
 	// Also stop the grpc server if SIGINT or SIGTERM is received
-	// This is only a temporary solution, better pass a cancellable context around for the lifetime of the application
-	// See: https://stackoverflow.com/a/74895157 and https://gist.github.com/embano1/e0bf49d24f1cdd07cffad93097c04f0a
+	// TODO: (tech-debt) Setup signal handler more above, several files want to use stopCh and the appropriate function is only allowed to be used once.
+	// Affected files: pkg/driver/agent.go pkg/driver/controller.go pkg/driver/grpc.go
 	stopCh := make(chan os.Signal, 1)
 	signal.Notify(stopCh, syscall.SIGINT, syscall.SIGTERM)
 	s.wg.Add(1)


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**: Stopping the binary doesn't exit the process because the grpc server goroutine is still running and doesn't get cancelled in any form.

**What this PR does?**: Listens (additionally, see below) to system signals SIGTERM and SIGINT to handle grpc server stopping.

**Does this PR require any upgrade changes?**: no

**If the changes in this PR are manually verified, list down the scenarios covered:**: Stopping the binary in agent mode will now stop the process (since all goroutines have naturally stopped).

**Any additional information for your reviewer?** :
This is only a quick solution but small and concise. Better approach would be a refactoring and passing around of the stop-channel from the top. Even better would be to introduce a clean context instead for the whole lifetime of the application process. Even the used function which register those signals has been updated to return a context many years ago: https://github.com/kubernetes-sigs/controller-runtime/blob/main/pkg/manager/signals/signal.go. See also: https://stackoverflow.com/a/74895157 and https://gist.github.com/embano1/e0bf49d24f1cdd07cffad93097c04f0a

**Checklist:**
- [x] Fixes #646
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/website is used to track them:
