### PR TITLE
feat(helm): Add configurable resources for zfs-node and zfs-controller containers…

### DIFF
--- a/deploy/helm/charts/templates/zfs-controller.yaml
+++ b/deploy/helm/charts/templates/zfs-controller.yaml
@@ -55,6 +55,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          resources:
+            {{- toYaml .Values.zfsController.resources | nindent 12 }}
         - name: {{ .Values.zfsController.snapshotter.name }}
           image: "{{ .Values.zfsController.snapshotter.image.registry }}{{ .Values.zfsController.snapshotter.image.repository }}:{{ .Values.zfsController.snapshotter.image.tag }}"
           imagePullPolicy: {{ .Values.zfsController.snapshotter.image.pullPolicy }}
@@ -70,6 +72,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          resources:
+            {{- toYaml .Values.zfsController.resources | nindent 12 }}
         - name: {{ .Values.zfsController.snapshotController.name }}
           image: "{{ .Values.zfsController.snapshotController.image.registry }}{{ .Values.zfsController.snapshotController.image.repository }}:{{ .Values.zfsController.snapshotController.image.tag }}"
           args:
@@ -79,6 +83,8 @@ spec:
             - {{ tpl . $ | quote }}
           {{- end }}
           imagePullPolicy: {{ .Values.zfsController.snapshotController.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.zfsController.resources | nindent 12 }}
         - name: {{ .Values.zfsController.provisioner.name }}
           image: "{{ .Values.zfsController.provisioner.image.registry }}{{ .Values.zfsController.provisioner.image.repository }}:{{ .Values.zfsController.provisioner.image.tag }}"
           imagePullPolicy: {{ .Values.zfsController.provisioner.image.pullPolicy }}
@@ -108,6 +114,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          resources:
+            {{- toYaml .Values.zfsController.resources | nindent 12 }}
         - name: {{ .Values.zfsPlugin.name }}
           image: "{{ .Values.zfsPlugin.image.registry }}{{ .Values.zfsPlugin.image.repository }}:{{ .Values.zfsPlugin.image.tag }}"
           imagePullPolicy: {{ .Values.zfsPlugin.image.pullPolicy }}
@@ -140,6 +148,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          resources:
+            {{- toYaml .Values.zfsController.resources | nindent 12 }}
       volumes:
         - name: socket-dir
           emptyDir: {}

--- a/deploy/helm/charts/templates/zfs-node.yaml
+++ b/deploy/helm/charts/templates/zfs-node.yaml
@@ -70,6 +70,8 @@ spec:
               mountPath: /plugin
             - name: registration-dir
               mountPath: /registration
+          resources:
+            {{- toYaml .Values.zfsNode.resources | nindent 12 }}
         - name: {{ .Values.zfsPlugin.name }}
           securityContext:
             privileged: true
@@ -114,6 +116,8 @@ spec:
               # needed so that any mounts setup inside this container are
               # propagated back to the host machine.
               mountPropagation: "Bidirectional"
+          resources:
+            {{- toYaml .Values.zfsNode.resources | nindent 12 }}
       volumes:
         - name: device-dir
           hostPath:


### PR DESCRIPTION
… via values.yaml

## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**:
Allows users to configure CPU and memory requests/limits for all zfs-node and zfs-controller containers via values.yaml, improving resource management and deployment flexibility.

**What this PR does?**:

- Adds support for specifying resources for all containers in the zfs-node DaemonSet and zfs-controller Deployment using the resources field from values.yaml.
- No default resource values are set; users can define requests/limits as needed.

**Does this PR require any upgrade changes?**:
No upgrade changes required. Existing deployments will not be affected unless users set resource values in values.yaml.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

- Verified that resources are injected into all relevant containers when set in values.yaml.
- Confirmed that leaving resources empty does not affect current behavior.


**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #673 
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/website is used to track them: