### PR TITLE
fix(clone): remove encryption parameters from clone command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+v2.9.0 / TBC
+========================
+
+## Bug Fixes and Improvements
+
+- **Fixed Encrypted Volume Cloning**
+  Removed encryption parameters (`-o encryption`, `-o keylocation`, `-o keyformat`) from the `zfs clone` command. These parameters are read-only and cannot be set on clones as they automatically inherit encryption from the parent snapshot.
+  [#675](https://github.com/openebs/zfs-localpv/pull/675)
+
+---
+
 v2.8.0 / 2025-06-03
 ========================
 

--- a/ci/ci-test.sh
+++ b/ci/ci-test.sh
@@ -175,6 +175,12 @@ helm_install() {
   truncate -s 100G /tmp/disk.img
   sudo zpool create zfspv-pool "$(sudo losetup -f /tmp/disk.img --show)"
 
+  # Setup encryption key for testing encrypted volumes
+  echo "Setting up encryption key for encrypted volume tests"
+  sudo mkdir -p /etc/zfs/keys
+  sudo dd if=/dev/urandom of=/etc/zfs/keys/zfspool0.key bs=32 count=1
+  sudo chmod 600 /etc/zfs/keys/zfspool0.key
+
   helm install zfs-localpv ./deploy/helm/charts -n "$OPENEBS_NAMESPACE" --create-namespace --set zfsPlugin.image.pullPolicy=Never --set analytics.enabled=false --set backupGC.enabled=true
   kubectl apply -f "$SNAP_CLASS"
 

--- a/pkg/zfs/volume_test.go
+++ b/pkg/zfs/volume_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	apis "github.com/openebs/zfs-localpv/pkg/apis/openebs.io/zfs/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestIsVolumeReady(t *testing.T) {
@@ -81,6 +82,76 @@ func TestQuotaProperty(t *testing.T) {
 			if result != tt.expected {
 				t.Errorf("For quotaType %q, expected %q but got %q",
 					tt.quotaType, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestBuildCloneCreateArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		vol      *apis.ZFSVolume
+		expected []string
+	}{
+		{
+			name: "Clone without encryption",
+			vol: &apis.ZFSVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-vol",
+				},
+				Spec: apis.VolumeInfo{
+					PoolName:      "testpool",
+					SnapName:      "testsnap",
+					VolumeType:    "DATASET",
+					Capacity:      "10G",
+					RecordSize:    "128k",
+					Compression:   "on",
+					Dedup:         "off",
+					ThinProvision: "yes",
+				},
+			},
+			expected: []string{"clone", "-o", "quota=10G", "-o", "recordsize=128k", "-o", "mountpoint=legacy", "-o", "dedup=off", "-o", "compression=on", "testpool/testsnap", "testpool/test-vol"},
+		},
+		{
+			name: "Clone with encryption parameters (should be omitted)",
+			vol: &apis.ZFSVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-encrypted-vol",
+				},
+				Spec: apis.VolumeInfo{
+					PoolName:      "testpool",
+					SnapName:      "testsnap",
+					VolumeType:    "DATASET",
+					Capacity:      "10G",
+					Compression:   "on",
+					Encryption:    "aes-256-gcm",
+					KeyLocation:   "file:///etc/zfs/keys/testpool.key",
+					KeyFormat:     "raw",
+					ThinProvision: "yes",
+				},
+			},
+			expected: []string{"clone", "-o", "quota=10G", "-o", "mountpoint=legacy", "-o", "compression=on", "testpool/testsnap", "testpool/test-encrypted-vol"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildCloneCreateArgs(tt.vol)
+			if len(result) != len(tt.expected) {
+				t.Errorf("Expected %d arguments, got %d\nExpected: %v\nGot: %v",
+					len(tt.expected), len(result), tt.expected, result)
+				return
+			}
+			for i, arg := range result {
+				if arg != tt.expected[i] {
+					t.Errorf("Argument %d: expected %q, got %q", i, tt.expected[i], arg)
+				}
+			}
+			// Verify encryption parameters are NOT included
+			for _, arg := range result {
+				if arg == "encryption=aes-256-gcm" || arg == "keylocation=file:///etc/zfs/keys/testpool.key" || arg == "keyformat=raw" {
+					t.Errorf("Clone command should NOT include encryption parameter: %q", arg)
+				}
 			}
 		})
 	}

--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -164,18 +164,10 @@ func buildCloneCreateArgs(vol *apis.ZFSVolume) []string {
 		compressionProperty := "compression=" + vol.Spec.Compression
 		ZFSVolArg = append(ZFSVolArg, "-o", compressionProperty)
 	}
-	if len(vol.Spec.Encryption) != 0 {
-		encryptionProperty := "encryption=" + vol.Spec.Encryption
-		ZFSVolArg = append(ZFSVolArg, "-o", encryptionProperty)
-	}
-	if len(vol.Spec.KeyLocation) != 0 {
-		keyLocation := "keylocation=" + vol.Spec.KeyLocation
-		ZFSVolArg = append(ZFSVolArg, "-o", keyLocation)
-	}
-	if len(vol.Spec.KeyFormat) != 0 {
-		keyFormat := "keyformat=" + vol.Spec.KeyFormat
-		ZFSVolArg = append(ZFSVolArg, "-o", keyFormat)
-	}
+	// Note: Encryption parameters (encryption, keylocation, keyformat) are NOT set when cloning.
+	// ZFS clones automatically inherit encryption settings from the parent snapshot.
+	// The encryption property is read-only on clones and attempting to set it will fail with
+	// "encryption is readonly" error. This is expected ZFS behavior.
 	ZFSVolArg = append(ZFSVolArg, snapshot, volume)
 	return ZFSVolArg
 }

--- a/tests/provision_test.go
+++ b/tests/provision_test.go
@@ -24,6 +24,7 @@ var _ = Describe("[zfspv] TEST VOLUME PROVISIONING", func() {
 	Context("App is deployed with zfs driver", func() {
 		It("Running zfs volume Creation Test", volumeCreationTest)
 		It("Running zfs volume Creation Test with custom node id", Label("custom-node-id"), volumeCreationTest)
+		It("Running encrypted volume creation test", encryptedVolCreationTest)
 	})
 })
 
@@ -181,6 +182,5 @@ func volumeCreationTest() {
 	By("Running volume creation test", fsVolCreationTest)
 	By("Running block volume creation test", blockVolCreationTest)
 	By("Running block volume creation test with retain reclaim policy", blockVolCreationWithReclaimRetainTest)
-	By("Running encrypted volume creation test", encryptedVolCreationTest)
 
 }

--- a/tests/provision_test.go
+++ b/tests/provision_test.go
@@ -148,9 +148,39 @@ func blockVolCreationWithReclaimRetainTest() {
 
 }
 
+func encryptedVolCreationTest() {
+	By("Creating encrypted storage class", createEncryptedStorageClass)
+	By("creating and verifying PVC bound status", func() { createAndVerifyPVC(pvcNameFS) })
+
+	By("Creating and deploying app pod", func() { createDeployVerifyApp(appNameFS, pvcNameFS) })
+	By("verifying ZFSVolume object", VerifyZFSVolume)
+
+	createSnapshot(pvcNameFS, snapNameFS)
+	verifySnapshotCreated(snapNameFS)
+
+	createClone(clonePvcNameFS, snapNameFS, scObj.Name, "Filesystem")
+	By("Creating and deploying clone app pod", func() { createDeployVerifyCloneApp(cloneAppNameFS, clonePvcNameFS) })
+
+	By("Deleting clone application deployment")
+	deleteAppDeployment(cloneAppNameFS)
+	By("Deleting clone pvc")
+	deletePVC(clonePvcNameFS)
+
+	By("Deleting snapshot")
+	deleteSnapshot(pvcNameFS, snapNameFS)
+
+	By("Deleting main application deployment")
+	deleteAppDeployment(appNameFS)
+	By("Deleting main pvc")
+	deletePVC(pvcNameFS)
+
+	By("Deleting storage class", deleteStorageClass)
+}
+
 func volumeCreationTest() {
 	By("Running volume creation test", fsVolCreationTest)
 	By("Running block volume creation test", blockVolCreationTest)
 	By("Running block volume creation test with retain reclaim policy", blockVolCreationWithReclaimRetainTest)
+	By("Running encrypted volume creation test", encryptedVolCreationTest)
 
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -279,6 +279,33 @@ func createStorageClass() {
 	gomega.Expect(err).To(gomega.BeNil(), "while creating a default storageclass {%s}", scName)
 }
 
+func createEncryptedStorageClass() {
+	var (
+		err error
+	)
+
+	parameters := map[string]string{
+		"poolname":    POOLNAME,
+		"encryption":  "aes-256-gcm",
+		"keyformat":   "raw",
+		"keylocation": "file:///etc/zfs/keys/zfspool0.key",
+		"fstype":      "zfs",
+		"compression": "lz4",
+	}
+
+	ginkgo.By("building an encrypted storage class")
+	scObj, err = sc.NewBuilder().
+		WithGenerateName(scName).
+		WithVolumeExpansion(true).
+		WithParametersNew(parameters).
+		WithProvisioner(ZFSProvisioner).Build()
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred(),
+		"while building encrypted storageclass obj with prefix {%s}", scName)
+
+	scObj, err = SCClient.Create(scObj)
+	gomega.Expect(err).To(gomega.BeNil(), "while creating an encrypted storageclass {%s}", scName)
+}
+
 // VerifyZFSVolume verify the properties of a zfs-volume
 func VerifyZFSVolume() {
 	ginkgo.By("fetching zfs volume")
@@ -771,6 +798,13 @@ func getStoragClassParams() []map[string]string {
 			"fstype":        "zfs",
 			"thinprovision": "no",
 			"quotatype":     "refquota",
+		},
+		{
+			"fstype":      "zfs",
+			"encryption":  "aes-256-gcm",
+			"keyformat":   "raw",
+			"keylocation": "file:///etc/zfs/keys/zfspool0.key",
+			"compression": "lz4",
 		},
 	}
 }


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

When using OpenEBS ZFS LocalPV with encryption enabled, cloning volumes fails with the error: `cannot create 'zfspool0/pvc-xxx': 'encryption' is readonly`. This occurs when tools like Velero with `snapshotMoveData: true` attempt to clone CSI snapshots for data movement.

This seems to be because `buildCloneCreateArgs()` in `pkg/zfs/zfs_util.go` (lines 167-178) unconditionally adds encryption parameters (`-o encryption`, `-o keylocation`, `-o keyformat`) to the `zfs clone` command. However, according to ZFS behavior, clones automatically inherit encryption from the parent snapshot, and the `encryption` property is read-only after filesystem creation. Attempting to set it causes an error.

This seems to have been [added some time ago](https://github.com/openebs/zfs-localpv/blame/develop/pkg/zfs/zfs_util.go#L168) as part of #57 - `fix(clone): setting properties on the clone volume`.

**What this PR does?**:

Removes encryption parameter handling from `buildCloneCreateArgs()` since clones automatically inherit encryption from the parent snapshot and the property cannot be set (it's read-only).

**Changes:**
- `pkg/zfs/zfs_util.go`: Removed lines that add `-o encryption`, `-o keylocation`, and `-o keyformat` to clone commands. Added explanatory comment.
- `pkg/zfs/volume_test.go`: Added `TestBuildCloneCreateArgs()` with test cases verifying encryption parameters are correctly omitted from clone commands.

**Does this PR require any upgrade changes?**:

I think not. This is a bug fix that should make the driver work correctly with encrypted volumes. Existing encrypted volumes and new clones will function properly after this fix.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

1. Created StorageClass with encryption enabled (aes-256-gcm with keyformat=raw, keylocation=file:///etc/zfs/keys/zfspool0.key)
2. Created PVC with encrypted volume
3. Created VolumeSnapshot from the encrypted PVC
4. Created new PVC from VolumeSnapshot (clone operation) - succeeded after fix
5. Verified cloned volume is properly encrypted (inherited from parent)
6. Tested Velero backup with `snapshotMoveData: true` - succeeded after fix
7. Ran unit tests: `go test ./pkg/zfs/...` - all pass

**Any additional information for your reviewer?**:

This aligns with ZFS design principles. According to [ZFS documentation](https://docs.oracle.com/cd/E36784_01/html/E36835/gkkih.html), encryption is inherited automatically by clones. Related: https://github.com/openzfs/zfs/issues/14184

This fix enables Velero CSI snapshot data movement and any other tools that need to clone encrypted ZFS volumes via the CSI driver.

**Checklist:**

- [ ] Fixes # – I just created the PR, I hope that's ok.
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [x] Has the change log section been updated?
- [x] Commit has unit tests
- [x] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: N/A - no upgrade changes needed
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/website is used to track them: N/A
- [x] @adam-lithus to deploy this into his environment ([builds are here](https://github.com/golithus/zfs-localpv/pkgs/container/zfs-localpv)) - Done. It works!
