### PR TITLE
feat(helm): initContainers values as list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ v2.9.0 / TBC
 - **Fixed Encrypted Volume Cloning**
   Removed encryption parameters (`-o encryption`, `-o keylocation`, `-o keyformat`) from the `zfs clone` command. These parameters are read-only and cannot be set on clones as they automatically inherit encryption from the parent snapshot.
   [#675](https://github.com/openebs/zfs-localpv/pull/675)
+- **Change helm chart value `initContainers` to list**
+  Changed the `initContainers` value in the Helm chart from a map to a list to
+  make ordering easier
+  [#679](https://github.com/openebs/zfs-localpv/pull/679)
 
 ---
 

--- a/deploy/helm/charts/templates/zfs-controller.yaml
+++ b/deploy/helm/charts/templates/zfs-controller.yaml
@@ -33,9 +33,13 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount.zfsController.name }}
 {{- if .Values.zfsController.initContainers }}
       initContainers:
+{{- if eq (kindOf .Values.zfsController.initContainers) "slice" }}
+{{ toYaml .Values.zfsController.initContainers | indent 10 }}
+{{- else }}
 {{- range $key, $value := .Values.zfsController.initContainers }}
         - name: {{ $key }}
 {{ toYaml $value | indent 10 }}
+{{- end }}
 {{- end }}
 {{- end }}
       containers:

--- a/deploy/helm/charts/templates/zfs-node.yaml
+++ b/deploy/helm/charts/templates/zfs-node.yaml
@@ -37,9 +37,13 @@ spec:
       hostNetwork: true
 {{- if .Values.zfsNode.initContainers }}
       initContainers:
+{{- if eq (kindOf .Values.zfsNode.initContainers) "slice" }}
+{{ toYaml .Values.zfsNode.initContainers | indent 10 }}
+{{- else }}
 {{- range $key, $value := .Values.zfsNode.initContainers }}
         - name: {{ $key }}
 {{ toYaml $value | indent 10 }}
+{{- end }}
 {{- end }}
 {{- end }}
       containers:

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -60,14 +60,14 @@ zfsNode:
   # For example:
   # allowedTopologyKeys: "kubernetes.io/hostname,openebs.io/rack"
   allowedTopologyKeys: "All"
-  initContainers: {}
+  initContainers: []
   additionalVolumes: {}
 
 # zfsController contains the configurables for
 # the zfs controller deployment
 zfsController:
   componentName: openebs-zfs-controller
-  initContainers: {}
+  initContainers: []
   additionalVolumes: {}
   replicas: 1
   resizer:


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
Fixes https://github.com/openebs/zfs-localpv/issues/676

**What this PR does**:
Treats the `*.initContainers` values as lists instead of maps.

**Does this PR require any upgrade changes?**:
Any use of `initContainers` values must be changed to a list.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/website is used to track them: