### PR TITLE
ci: enable mergify for merge/backport

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,20 @@
+queue_rules:
+  - name: default
+    update_method: rebase
+    branch_protection_injection_mode: merge
+    update_bot_account: openebs-ci
+merge_queue:
+  max_parallel_checks: 1
+pull_request_rules:
+  - name: auto-label and approve backport PRs
+    conditions:
+      - author=mergify[bot]
+      - title~=\(backport \#[0-9]+\)$
+    actions:
+      label:
+        add:
+          - kind/backport
+      review:
+        type: APPROVE
+        message: "Automatically approved backport PR"
+        bot_account: openebs-ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,3 +69,12 @@ jobs:
           files: ./tests/bdd_coverage.txt,./tests/bdd_coverage_custom-node-id.txt
           flags: bddtests
           fail_ci_if_error: true
+
+  results:
+    runs-on: ubuntu-latest
+    needs: [bdd-tests]
+    if: ${{ !cancelled() }}
+    steps:
+      - if: ${{ needs.bdd-tests.result != 'success' }}
+        run: exit 1
+      - run: exit 0


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

Enables mergify for merging PRs and also backporting.
Allows us to more easily merge PRs without having to manually rebase them and also allows
for easy backporting.

**What this PR does?**:

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :

We've already been enabling mergify on other repos.


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/website is used to track them:
