### PR TITLE
feat: add helm global values

### DIFF
--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -67,6 +67,11 @@ The following table lists the configurable parameters of the OpenEBS ZFS Localpv
 
 | Key                                                                 | Type   | Default Value               | Description                                                                                           |
 |----------------------------------------------------------------------|--------|-----------------------------|-------------------------------------------------------------------------------------------------------|
+| `global.imageRegistry`                                                | string | `""`                        | Global override for container image registry                                                           |
+| `global.imagePullPolicy`                                              | string | `""`                        | Global override for  image pull policy.                                                            |
+| `global.imagePullSecrets`                                             | list   | `[]`                        | Global image pull secrets (merged with local imagePullSecrets and not overridden).                                                                       |
+| `global.analytics.enabled`                                            | bool   | `null`                      | Global override for analytics.                                                                         |
+| `global.kubeletDir`                                                   | string |  `""`                       | Global override for kubelet directory                                                                  |
 | `analytics.enabled`                                                  | bool   | `true`                      | Enables or disables analytics reporting for the chart.                                                 |
 | `analytics.installerType`                                             | string | `"zfs-localpv-helm"`        | Specifies the installer type for analytics.                                                           |
 | `backupGC.enabled`                                                    | bool   | `false`                     | Enables or disables garbage collection for backups.                                                   |

--- a/deploy/helm/charts/templates/_helpers.tpl
+++ b/deploy/helm/charts/templates/_helpers.tpl
@@ -158,5 +158,54 @@ Enable zfsController containers leader election if replicas > 1
 Ensure that the path to kubelet ends with a slash
 */}}
 {{- define "zfslocalpv.zfsNode.kubeletDir" -}}
-{{- printf "%s/" (.Values.zfsNode.kubeletDir | trimSuffix "/") -}}
+{{- printf "%s/" (default .Values.zfsNode.kubeletDir .Values.global.kubeletDir | trimSuffix "/") -}}
 {{- end }}
+
+{{/*
+Creates the image URL ie registry/repository:tag
+*/}}
+{{- define "zfslocalpv.common.image" -}}
+{{- $registryName := default .imageRoot.registry ((.global).imageRegistry) | trimSuffix "/" -}}
+{{- $repositoryName := .imageRoot.repository -}}
+{{- $termination := .imageRoot.tag | toString -}}
+{{- if $registryName }}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $termination -}}
+{{- else -}}
+    {{- printf "%s:%s"  $repositoryName $termination -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Concatenates imagepullsecrets and handles different formats (example - secret or - name: secret)
+*/}}
+{{- define "zfslocalpv.common.pullSecrets" -}}
+{{- $names := list -}}
+{{- with .Values.global.imagePullSecrets -}}
+  {{- range . -}}
+    {{- if kindIs "map" . }}
+      {{- if and (hasKey . "name") (not (empty .name)) -}}
+        {{ $names = append $names .name }}
+      {{- end -}}
+    {{- else if not (empty .) -}}
+      {{ $names = append $names . -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
+{{- with .Values.imagePullSecrets -}}
+  {{- range . }}
+    {{- if kindIs "map" . -}}
+      {{- if and (hasKey . "name") (not (empty .name)) -}}
+        {{- $names = append $names .name }}
+      {{- end -}}
+    {{- else if not (empty .) -}}
+      {{- $names = append $names . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $names = uniq $names -}}
+{{- if $names -}}
+{{- range $names }}
+- name: {{ . }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/charts/templates/zfs-controller.yaml
+++ b/deploy/helm/charts/templates/zfs-controller.yaml
@@ -44,7 +44,7 @@ spec:
 {{- end }}
       containers:
         - name: {{ .Values.zfsController.resizer.name }}
-          image: "{{ .Values.zfsController.resizer.image.registry }}{{ .Values.zfsController.resizer.image.repository }}:{{ .Values.zfsController.resizer.image.tag }}"
+          image: {{ include "zfslocalpv.common.image" (dict "imageRoot" .Values.zfsController.resizer.image "global" .Values.global) }}
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -55,15 +55,15 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          imagePullPolicy: {{ .Values.zfsController.resizer.image.pullPolicy }}
+          imagePullPolicy: {{ default .Values.zfsController.resizer.image.pullPolicy .Values.global.imagePullPolicy }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
           resources:
             {{- toYaml .Values.zfsController.resources | nindent 12 }}
         - name: {{ .Values.zfsController.snapshotter.name }}
-          image: "{{ .Values.zfsController.snapshotter.image.registry }}{{ .Values.zfsController.snapshotter.image.repository }}:{{ .Values.zfsController.snapshotter.image.tag }}"
-          imagePullPolicy: {{ .Values.zfsController.snapshotter.image.pullPolicy }}
+          image: {{ include "zfslocalpv.common.image" (dict "imageRoot" .Values.zfsController.snapshotter.image "global" .Values.global) }}
+          imagePullPolicy: {{ default .Values.zfsController.snapshotter.image.pullPolicy .Values.global.imagePullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
             {{- include "zfslocalpv.zfsController.leaderElection" . | indent 12 }}
@@ -79,19 +79,19 @@ spec:
           resources:
             {{- toYaml .Values.zfsController.resources | nindent 12 }}
         - name: {{ .Values.zfsController.snapshotController.name }}
-          image: "{{ .Values.zfsController.snapshotController.image.registry }}{{ .Values.zfsController.snapshotController.image.repository }}:{{ .Values.zfsController.snapshotController.image.tag }}"
+          image: {{ include "zfslocalpv.common.image" (dict "imageRoot" .Values.zfsController.snapshotController.image "global" .Values.global) }}
           args:
             - "--v=5"
             {{- include "zfslocalpv.zfsController.leaderElection" . | indent 12 }}
           {{- range .Values.zfsController.snapshotController.extraArgs }}
             - {{ tpl . $ | quote }}
           {{- end }}
-          imagePullPolicy: {{ .Values.zfsController.snapshotController.image.pullPolicy }}
+          imagePullPolicy: {{ default .Values.zfsController.snapshotController.image.pullPolicy .Values.global.imagePullPolicy }}
           resources:
             {{- toYaml .Values.zfsController.resources | nindent 12 }}
         - name: {{ .Values.zfsController.provisioner.name }}
-          image: "{{ .Values.zfsController.provisioner.image.registry }}{{ .Values.zfsController.provisioner.image.repository }}:{{ .Values.zfsController.provisioner.image.tag }}"
-          imagePullPolicy: {{ .Values.zfsController.provisioner.image.pullPolicy }}
+          image: {{ include "zfslocalpv.common.image" (dict "imageRoot" .Values.zfsController.provisioner.image "global" .Values.global) }}
+          imagePullPolicy: {{ default .Values.zfsController.provisioner.image.pullPolicy .Values.global.imagePullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -121,8 +121,8 @@ spec:
           resources:
             {{- toYaml .Values.zfsController.resources | nindent 12 }}
         - name: {{ .Values.zfsPlugin.name }}
-          image: "{{ .Values.zfsPlugin.image.registry }}{{ .Values.zfsPlugin.image.repository }}:{{ .Values.zfsPlugin.image.tag }}"
-          imagePullPolicy: {{ .Values.zfsPlugin.image.pullPolicy }}
+          image: {{ include "zfslocalpv.common.image" (dict "imageRoot" .Values.zfsPlugin.image "global" .Values.global) }}
+          imagePullPolicy: {{ default .Values.zfsPlugin.image.pullPolicy .Values.global.imagePullPolicy }}
           env:
             - name: OPENEBS_CONTROLLER_DRIVER
               value: controller
@@ -135,7 +135,11 @@ spec:
             - name: OPENEBS_IO_INSTALLER_TYPE
               value: "{{ if (not (hasKey .Values.analytics "installerType")) }}zfs-localpv-helm{{ else }}{{ .Values.analytics.installerType }}{{ end }}"
             - name: OPENEBS_IO_ENABLE_ANALYTICS
+              {{- if kindIs "bool" .Values.global.analytics.enabled }}
+              value: "{{ .Values.global.analytics.enabled }}"
+              {{- else}}
               value: "{{ .Values.analytics.enabled }}"
+              {{- end}}
             {{- if .Values.analytics.gaId }}
             - name: GA_ID
               value: {{ .Values.analytics.gaId | quote }}
@@ -163,10 +167,10 @@ spec:
 {{- tpl (toYaml $config) $ | nindent 10 }}
 {{- end }}
 {{- end }}
-{{- if .Values.imagePullSecrets }}
+      {{- if or .Values.global.imagePullSecrets .Values.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 8 }}
-{{- end }}
+      {{- include "zfslocalpv.common.pullSecrets" . | indent 6 }}
+      {{- end }}
 {{- if .Values.zfsController.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.zfsController.nodeSelector | indent 8 }}

--- a/deploy/helm/charts/templates/zfs-node.yaml
+++ b/deploy/helm/charts/templates/zfs-node.yaml
@@ -48,8 +48,8 @@ spec:
 {{- end }}
       containers:
         - name: {{ .Values.zfsNode.driverRegistrar.name }}
-          image: "{{ .Values.zfsNode.driverRegistrar.image.registry }}{{ .Values.zfsNode.driverRegistrar.image.repository }}:{{ .Values.zfsNode.driverRegistrar.image.tag }}"
-          imagePullPolicy: {{ .Values.zfsNode.driverRegistrar.image.pullPolicy }}
+          image: {{ include "zfslocalpv.common.image" (dict "imageRoot" .Values.zfsNode.driverRegistrar.image "global" .Values.global) }}
+          imagePullPolicy: {{ default .Values.zfsNode.driverRegistrar.image.pullPolicy .Values.global.imagePullPolicy }}
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -80,8 +80,8 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: "{{ .Values.zfsPlugin.image.registry }}{{ .Values.zfsPlugin.image.repository }}:{{ .Values.zfsPlugin.image.tag }}"
-          imagePullPolicy: {{ .Values.zfsPlugin.image.pullPolicy }}
+          image: {{ include "zfslocalpv.common.image" (dict "imageRoot" .Values.zfsPlugin.image "global" .Values.global) }}
+          imagePullPolicy: {{ default .Values.zfsPlugin.image.pullPolicy .Values.global.imagePullPolicy }}
           args:
             - "--nodename=$(OPENEBS_NODE_NAME)"
             - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
@@ -157,10 +157,10 @@ spec:
 {{- tpl (toYaml $config) $ | nindent 10 }}
 {{- end }}
 {{- end }}
-{{- if .Values.imagePullSecrets }}
+      {{- if or .Values.global.imagePullSecrets .Values.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 8 }}
-{{- end }}
+      {{- include "zfslocalpv.common.pullSecrets" . | indent 6 }}
+      {{- end }}
 {{- if .Values.zfsNode.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.zfsNode.nodeSelector | indent 8 }}

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -1,8 +1,24 @@
 # Default values for openebs-zfslocalpv.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+global:
+  # Global override for container image registry.
+  imageRegistry: ""
+  # - secret
+  imagePullSecrets: []
+  # Global override for image pull policy
+  imagePullPolicy: ""
+  analytics:
+    # Global override for analytics
+    enabled:
+  # Global override for kubelet directory
+  # This can be configured to run on various different k8s distributions like
+  # microk8s where kubelet dir is different
+  kubeletDir: ""
+
+# - secret
 imagePullSecrets:
-# - name: "image-pull-secret"
 
 feature:
   # enable storage capacity tracking feature

--- a/tests/backup_gc_test.go
+++ b/tests/backup_gc_test.go
@@ -141,5 +141,5 @@ func waitForBackupDeletion(name string) {
 	By("waiting for backup " + name + " to be deleted")
 	Eventually(func() bool {
 		return !backupExists(name)
-	}, 2*time.Second, 1*time.Second).Should(BeTrue(), fmt.Sprintf("Backup %s should be deleted", name))
+	}, 60*time.Second, 1*time.Second).Should(BeTrue(), fmt.Sprintf("Backup %s should be deleted", name))
 }


### PR DESCRIPTION
## Why is this PR required? What issue does it fix?

Currently, the Helm charts do not provide global variables for configuring common parameters such as the image registry, image pull secrets, image pull policy, and analytics settings.

When deploying the OpenEBS Helm charts, users often need to override these values across multiple subcharts and components. This makes it difficult to locate and configure all the required fields consistently. Providing global variables simplifies configuration and improves the user experience.

## What does this PR do?

This PR introduces the following global configuration variables:
```yaml
global:
  imageRegistry: ""
  # set the global image registry
  imagePullSecrets: []
  # - secret
  # or 
  # -name: secret
  imagePullPolicy: ""
  # set global image pull policy
  analytics:
    enabled: true
  # disable analytics
```

These variables allow users to configure common settings in a single place, which will then be applied across the chart components.

## Does this PR require any upgrade changes?

No.
This change is backward compatible and does not require any upgrade steps.

## Verification

The changes were verified using the following scenarios:

Rendered the templates using helm template to confirm correct value substitution.

Deployed the chart on a Kubernetes cluster with 3 worker nodes (kubeadm-based setup).

Verified that the global values are rendered and applied correctly across the components.