### PR TITLE
refactor(zfs): replace error classification with verbatim stderr propagation

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -197,7 +197,7 @@ func waitForVolDestroy(volname string) error {
 	}
 }
 
-func waitForReadySnapshot(snapname string) error {
+func waitForReadySnapshot(ctx context.Context, snapname string) error {
 	for {
 		snap, err := zfs.GetZFSSnapshot(snapname)
 		if err != nil {
@@ -208,8 +208,17 @@ func waitForReadySnapshot(snapname string) error {
 		switch snap.Status.State {
 		case zfs.ZFSStatusReady:
 			return nil
+		case zfs.ZFSStatusFailed:
+			return status.Errorf(codes.Internal,
+				"snapshot %s creation failed on node %s", snapname, snap.Spec.OwnerNodeID)
 		}
-		time.Sleep(time.Second)
+
+		select {
+		case <-ctx.Done():
+			return status.Errorf(codes.DeadlineExceeded,
+				"snapshot %s creation: context deadline reached", snapname)
+		case <-time.After(time.Second):
+		}
 	}
 }
 
@@ -809,7 +818,7 @@ func (cs *controller) CreateSnapshot(
 	originalParams := req.GetParameters()
 	parameters := helpers.GetCaseInsensitiveMap(&originalParams)
 	if _, ok := parameters["wait"]; ok {
-		if err := waitForReadySnapshot(snapName); err != nil {
+		if err := waitForReadySnapshot(ctx, snapName); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/mgmt/backup/backup.go
+++ b/pkg/mgmt/backup/backup.go
@@ -81,6 +81,8 @@ func (c *BkpController) syncBkp(bkp *apis.ZFSBackup) error {
 		err = zfs.DestoryBackup(bkp)
 		if err == nil {
 			err = zfs.RemoveBkpFinalizer(bkp)
+		} else {
+			zfs.EmitFailureEvent(c.recorder, bkp, zfs.ReasonDestroyFailed, err)
 		}
 	} else {
 		// if status is init then it means we are creating the zfs backup.
@@ -88,9 +90,11 @@ func (c *BkpController) syncBkp(bkp *apis.ZFSBackup) error {
 			err = zfs.CreateBackup(bkp)
 			if err == nil {
 				klog.Infof("backup %s done %s@%s prevsnap [%s]", bkp.Name, bkp.Spec.VolumeName, bkp.Spec.SnapName, bkp.Spec.PrevSnapName)
+				zfs.EmitSuccessEvent(c.recorder, bkp, zfs.ReasonBackupCompleted, "backup completed")
 				err = zfs.UpdateBkpInfo(bkp, apis.BKPZFSStatusDone)
 			} else {
 				klog.Errorf("backup %s failed %s@%s err %v", bkp.Name, bkp.Spec.VolumeName, bkp.Spec.SnapName, err)
+				zfs.EmitFailureEvent(c.recorder, bkp, zfs.ReasonBackupFailed, err)
 				err = zfs.UpdateBkpInfo(bkp, apis.BKPZFSStatusFailed)
 			}
 		}

--- a/pkg/mgmt/restore/restore.go
+++ b/pkg/mgmt/restore/restore.go
@@ -83,9 +83,11 @@ func (c *RstrController) syncRestore(rstr *apis.ZFSRestore) error {
 			err = zfs.CreateRestore(rstr)
 			if err == nil {
 				klog.Infof("restore %s done %s", rstr.Name, rstr.Spec.VolumeName)
+				zfs.EmitSuccessEvent(c.recorder, rstr, zfs.ReasonRestoreCompleted, "restore completed")
 				err = zfs.UpdateRestoreInfo(rstr, apis.RSTZFSStatusDone)
 			} else {
 				klog.Errorf("restore %s failed %s err %v", rstr.Name, rstr.Spec.VolumeName, err)
+				zfs.EmitFailureEvent(c.recorder, rstr, zfs.ReasonRestoreFailed, err)
 				err = zfs.UpdateRestoreInfo(rstr, apis.RSTZFSStatusFailed)
 			}
 		}

--- a/pkg/mgmt/snapshot/snapshot.go
+++ b/pkg/mgmt/snapshot/snapshot.go
@@ -82,7 +82,10 @@ func (c *SnapController) syncSnap(snap *apis.ZFSSnapshot) error {
 			// destroy only if other finalizers have been removed
 			err = zfs.DestroySnapshot(snap)
 			if err == nil {
+				zfs.EmitSuccessEvent(c.recorder, snap, zfs.ReasonSnapDestroyed, "snapshot destroyed")
 				err = zfs.RemoveSnapFinalizer(snap)
+			} else {
+				zfs.EmitFailureEvent(c.recorder, snap, zfs.ReasonSnapDestroyFailed, err)
 			}
 		} else {
 			return fmt.Errorf("snapshot: can not destroy, waiting for finalizers to be removed %v", userFin)
@@ -93,7 +96,10 @@ func (c *SnapController) syncSnap(snap *apis.ZFSSnapshot) error {
 		if snap.Status.State != zfs.ZFSStatusReady {
 			err = zfs.CreateSnapshot(snap)
 			if err == nil {
+				zfs.EmitSuccessEvent(c.recorder, snap, zfs.ReasonSnapshotted, "snapshot created")
 				err = zfs.UpdateSnapInfo(snap)
+			} else {
+				zfs.EmitFailureEvent(c.recorder, snap, zfs.ReasonSnapshotFailed, err)
 			}
 		}
 	}

--- a/pkg/mgmt/volume/volume.go
+++ b/pkg/mgmt/volume/volume.go
@@ -83,7 +83,10 @@ func (c *ZVController) syncZV(zv *apis.ZFSVolume) error {
 			// destroy only if other finalizers have been removed
 			err = zfs.DestroyVolume(zv)
 			if err == nil {
+				zfs.EmitSuccessEvent(c.recorder, zv, zfs.ReasonDestroyed, "volume destroyed")
 				err = zfs.RemoveVolumeFinalizer(zv)
+			} else {
+				zfs.EmitFailureEvent(c.recorder, zv, zfs.ReasonDestroyFailed, err)
 			}
 		} else {
 			return fmt.Errorf("volume: can not destroy, waiting for finalizers to be removed %v", userFin)
@@ -92,16 +95,26 @@ func (c *ZVController) syncZV(zv *apis.ZFSVolume) error {
 		// if volume has already been created and its state is Ready
 		// then this event is for property change only.
 		if zfs.IsVolumeReady(zv) {
-			err = zfs.SetVolumeProp(zv)
+			if err = zfs.SetVolumeProp(zv); err != nil {
+				zfs.EmitFailureEvent(c.recorder, zv, zfs.ReasonSetPropertyFailed, err)
+			}
 		} else {
+			opReason := zfs.ReasonProvisionFailed
+			successReason := zfs.ReasonProvisioned
+			successMsg := "volume provisioned"
 			if len(zv.Spec.SnapName) > 0 {
 				err = zfs.CreateClone(zv)
+				opReason = zfs.ReasonCloneFailed
+				successReason = zfs.ReasonCloned
+				successMsg = "clone created from " + zv.Spec.SnapName
 			} else {
 				err = zfs.CreateVolume(zv)
 			}
 			if err == nil {
+				zfs.EmitSuccessEvent(c.recorder, zv, successReason, successMsg)
 				err = zfs.UpdateZvolInfo(zv, zfs.ZFSStatusReady)
 			} else {
+				zfs.EmitFailureEvent(c.recorder, zv, opReason, err)
 				err = zfs.UpdateZvolInfo(zv, zfs.ZFSStatusFailed)
 			}
 		}

--- a/pkg/zfs/errors.go
+++ b/pkg/zfs/errors.go
@@ -1,0 +1,83 @@
+package zfs
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Event reason constants for Kubernetes Warning/Normal events on ZFS CRs.
+// These are operation-level identifiers used as the reason field in
+// recorder.Event calls — they name what failed, not why.
+const (
+	ReasonProvisionFailed   = "ProvisionFailed"
+	ReasonCloneFailed       = "CloneFailed"
+	ReasonDestroyFailed     = "DestroyFailed"
+	ReasonSetPropertyFailed = "SetPropertyFailed"
+	ReasonResizeFailed      = "ResizeFailed"
+	ReasonSnapshotFailed    = "SnapshotFailed"
+	ReasonSnapDestroyFailed = "SnapshotDestroyFailed"
+	ReasonBackupFailed      = "BackupFailed"
+	ReasonRestoreFailed     = "RestoreFailed"
+
+	ReasonProvisioned      = "Provisioned"
+	ReasonCloned           = "Cloned"
+	ReasonDestroyed        = "Destroyed"
+	ReasonPropertySet      = "PropertySet"
+	ReasonResized          = "Resized"
+	ReasonSnapshotted      = "Snapshotted"
+	ReasonSnapDestroyed    = "SnapshotDestroyed"
+	ReasonBackupCompleted  = "BackupCompleted"
+	ReasonRestoreCompleted = "RestoreCompleted"
+)
+
+// Error is the typed error returned by every zfs/zpool shell-out.
+// It preserves the raw stderr from the binary verbatim — no pattern
+// matching or state probing — so the actual ZFS message always reaches
+// logs and Kubernetes events unchanged.
+type Error struct {
+	Op      string // e.g. "zfs create", "zfs destroy"
+	Dataset string // target dataset (may be empty)
+	Stderr  string // trimmed combined output from the binary
+	Err     error  // original error (exec.ExitError, etc.)
+}
+
+// Error implements the error interface and is safe to emit verbatim as
+// a Kubernetes Event message.
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Dataset != "" && e.Stderr != "" {
+		return fmt.Sprintf("%s on %q: %s", e.Op, e.Dataset, e.Stderr)
+	}
+	if e.Stderr != "" {
+		return fmt.Sprintf("%s: %s", e.Op, e.Stderr)
+	}
+	if e.Dataset != "" {
+		return fmt.Sprintf("%s on %q: %v", e.Op, e.Dataset, e.Err)
+	}
+	return fmt.Sprintf("%s: %v", e.Op, e.Err)
+}
+
+// Unwrap exposes the underlying exec error so errors.As/errors.Is
+// work for callers that need to inspect the original exec.ExitError.
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// NewZFSError wraps a failed zfs/zpool exec result. Returns nil when
+// err is nil so callers can use it unconditionally as a return value.
+func NewZFSError(op, dataset string, err error, stderr []byte) error {
+	if err == nil {
+		return nil
+	}
+	return &Error{
+		Op:      op,
+		Dataset: dataset,
+		Stderr:  strings.TrimSpace(string(stderr)),
+		Err:     err,
+	}
+}

--- a/pkg/zfs/errors_test.go
+++ b/pkg/zfs/errors_test.go
@@ -1,0 +1,66 @@
+package zfs
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestNewZFSError_NilErr(t *testing.T) {
+	if err := NewZFSError("zfs create", "tank/foo", nil, []byte("irrelevant")); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestNewZFSError_PreservesFields(t *testing.T) {
+	base := fmt.Errorf("exit status 1")
+	stderr := []byte("  cannot create 'tank/foo': dataset already exists\n")
+	err := NewZFSError("zfs create", "tank/foo", base, stderr)
+
+	var zerr *Error
+	if !errors.As(err, &zerr) {
+		t.Fatalf("errors.As *ZFSError failed")
+	}
+	if zerr.Op != "zfs create" {
+		t.Errorf("Op = %q, want %q", zerr.Op, "zfs create")
+	}
+	if zerr.Dataset != "tank/foo" {
+		t.Errorf("Dataset = %q, want %q", zerr.Dataset, "tank/foo")
+	}
+	wantStderr := strings.TrimSpace(string(stderr))
+	if zerr.Stderr != wantStderr {
+		t.Errorf("Stderr = %q, want %q", zerr.Stderr, wantStderr)
+	}
+}
+
+func TestZFSError_ErrorContainsStderr(t *testing.T) {
+	base := fmt.Errorf("exit status 1")
+	stderr := "cannot create 'tank/foo': out of space"
+	err := NewZFSError("zfs create", "tank/foo", base, []byte(stderr))
+
+	msg := err.Error()
+	if !strings.Contains(msg, stderr) {
+		t.Errorf("error message %q does not contain stderr %q", msg, stderr)
+	}
+	if !strings.Contains(msg, "tank/foo") {
+		t.Errorf("error message %q does not contain dataset", msg)
+	}
+}
+
+func TestZFSError_Unwrap(t *testing.T) {
+	base := fmt.Errorf("exit status 1")
+	err := NewZFSError("zfs destroy", "tank/foo", base, []byte("dataset is busy"))
+	if !errors.Is(err, base) {
+		t.Errorf("errors.Is(err, base) = false, Unwrap should expose original error")
+	}
+}
+
+func TestZFSError_EmptyStderrFallsBackToErr(t *testing.T) {
+	base := fmt.Errorf("exit status 1")
+	err := NewZFSError("zfs create", "tank/foo", base, nil)
+	msg := err.Error()
+	if !strings.Contains(msg, "exit status 1") {
+		t.Errorf("expected fallback to Err in message, got %q", msg)
+	}
+}

--- a/pkg/zfs/events.go
+++ b/pkg/zfs/events.go
@@ -1,0 +1,37 @@
+package zfs
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+)
+
+// maxEventMessageLen is the Kubernetes API server hard limit for Event.Message.
+// Messages longer than this are rejected with a validation error.
+const maxEventMessageLen = 1024
+
+func truncateEventMessage(msg string) string {
+	if len(msg) <= maxEventMessageLen {
+		return msg
+	}
+	return msg[:maxEventMessageLen-3] + "..."
+}
+
+// EmitFailureEvent records a Warning event on obj. The event message is
+// err.Error(), which for *ZFSError includes the verbatim ZFS stderr so
+// the real failure cause is visible in kubectl describe output.
+func EmitFailureEvent(recorder record.EventRecorder, obj runtime.Object, reason string, err error) {
+	if recorder == nil || err == nil || obj == nil {
+		return
+	}
+	recorder.Event(obj, corev1.EventTypeWarning, reason, truncateEventMessage(err.Error()))
+}
+
+// EmitSuccessEvent records a Normal event on obj for terminal
+// user-visible transitions (provisioned, destroyed, etc.).
+func EmitSuccessEvent(recorder record.EventRecorder, obj runtime.Object, reason, message string) {
+	if recorder == nil || obj == nil {
+		return
+	}
+	recorder.Event(obj, corev1.EventTypeNormal, reason, truncateEventMessage(message))
+}

--- a/pkg/zfs/volume.go
+++ b/pkg/zfs/volume.go
@@ -139,20 +139,24 @@ func checkVolCreation(ctx context.Context, volname string) (bool, error) {
 	for {
 		select {
 		case <-ctx.Done():
-			return true, fmt.Errorf("zfs: context deadline reached")
+			return true, status.Errorf(codes.DeadlineExceeded,
+				"volume %s creation: context deadline reached", volname)
 		case <-timeout.C:
-			return true, fmt.Errorf("zfs: vol creation timeout reached")
+			return true, status.Errorf(codes.DeadlineExceeded,
+				"volume %s creation timed out", volname)
 		default:
 			vol, err := GetZFSVolume(volname)
 			if err != nil {
-				return false, fmt.Errorf("zfs: wait failed, not able to get the volume %s %s", volname, err.Error())
+				return false, status.Errorf(codes.Internal,
+					"volume creation wait failed, not able to get the volume %s: %s", volname, err.Error())
 			}
 
 			switch vol.Status.State {
 			case ZFSStatusReady:
 				return false, nil
 			case ZFSStatusFailed:
-				return false, fmt.Errorf("zfs: volume creation failed")
+				return false, status.Errorf(codes.Internal,
+					"volume %s creation failed on node %s", volname, vol.Spec.OwnerNodeID)
 			}
 
 			klog.Infof("zfs: waiting for volume %s/%s to be created on nodeid %s",

--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -62,6 +62,18 @@ const (
 	VolTypeZVol    = "ZVOL"
 )
 
+// runCmd executes cmd, logs the invocation at V(4) and full output at V(5),
+// and returns combined stdout+stderr. Use this instead of cmd.CombinedOutput()
+// throughout this package so verbosity can be tuned with --v.
+func runCmd(cmd *exec.Cmd, dataset string) ([]byte, error) {
+	klog.V(4).Infof("zfs: executing %v on %q", cmd.Args, dataset)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		klog.V(5).Infof("zfs: command %v on %q output: %s", cmd.Args, dataset, strings.TrimSpace(string(out)))
+	}
+	return out, err
+}
+
 // PropertyChanged return whether volume property is changed
 func PropertyChanged(oldVol *apis.ZFSVolume, newVol *apis.ZFSVolume) bool {
 	if oldVol.Spec.VolumeType == VolTypeDataset &&
@@ -395,8 +407,8 @@ func getVolume(volume string) error {
 	ZFSVolArg = append(ZFSVolArg, ZFSListArg, volume)
 
 	cmd := exec.Command(ZFSVolCmd, ZFSVolArg...)
-	_, err := cmd.CombinedOutput()
-	return err
+	out, err := runCmd(cmd, volume)
+	return NewZFSError("zfs list", volume, err, out)
 }
 
 // CreateVolume creates the zvol/dataset as per
@@ -412,16 +424,15 @@ func CreateVolume(vol *apis.ZFSVolume) error {
 			args = buildZvolCreateArgs(vol)
 		}
 		cmd := exec.Command(ZFSVolCmd, args...)
-		out, err := cmd.CombinedOutput()
+		out, err := runCmd(cmd, volume)
 
 		if err != nil {
-			klog.Errorf(
-				"zfs: could not create volume %v cmd %v error: %s", volume, args, string(out),
-			)
-			return err
+			zerr := NewZFSError("zfs create", volume, err, out)
+			klog.Errorf("zfs: could not create volume %v cmd %v error: %s", volume, args, zerr)
+			return zerr
 		}
 		klog.Infof("created volume %s", volume)
-	} else if err == nil {
+	} else {
 		klog.Infof("using existing volume %v", volume)
 	}
 
@@ -456,16 +467,15 @@ func CreateClone(vol *apis.ZFSVolume) error {
 	if err := getVolume(volume); err != nil {
 		args := buildCloneCreateArgs(vol)
 		cmd := exec.Command(ZFSVolCmd, args...)
-		out, err := cmd.CombinedOutput()
+		out, err := runCmd(cmd, volume)
 
 		if err != nil {
-			klog.Errorf(
-				"zfs: could not clone volume %v cmd %v error: %s", volume, args, string(out),
-			)
-			return err
+			zerr := NewZFSError("zfs clone", volume, err, out)
+			klog.Errorf("zfs: could not clone volume %v cmd %v error: %s", volume, args, zerr)
+			return zerr
 		}
 		klog.Infof("created clone %s", volume)
-	} else if err == nil {
+	} else {
 		klog.Infof("using existing clone volume %v", volume)
 	}
 
@@ -488,11 +498,12 @@ func SetDatasetMountProp(volume string, mountpath string) error {
 	ZFSVolArg = append(ZFSVolArg, ZFSSetArg, mountProperty, volume)
 
 	cmd := exec.Command(ZFSVolCmd, ZFSVolArg...)
-	out, err := cmd.CombinedOutput()
+	out, err := runCmd(cmd, volume)
 	if err != nil {
+		zerr := NewZFSError("zfs set mountpoint", volume, err, out)
 		klog.Errorf("zfs: could not set mountpoint on dataset %v cmd %v error: %s",
-			volume, ZFSVolArg, string(out))
-		return fmt.Errorf("could not set the mountpoint, %s", string(out))
+			volume, ZFSVolArg, zerr)
+		return zerr
 	}
 	return nil
 }
@@ -522,11 +533,12 @@ func MountZFSDataset(vol *apis.ZFSVolume, mountpath string) error {
 		var MountVolArg []string
 		MountVolArg = append(MountVolArg, "mount", volume)
 		cmd := exec.Command(ZFSVolCmd, MountVolArg...)
-		out, err := cmd.CombinedOutput()
+		out, err := runCmd(cmd, volume)
 		if err != nil {
+			zerr := NewZFSError("zfs mount", volume, err, out)
 			klog.Errorf("zfs: could not mount the dataset %v cmd %v error: %s",
-				volume, MountVolArg, string(out))
-			return fmt.Errorf("not able to mount, %s", string(out))
+				volume, MountVolArg, zerr)
+			return zerr
 		}
 	}
 
@@ -561,11 +573,12 @@ func GetVolumeProperty(vol *apis.ZFSVolume, prop string) (string, error) {
 	ZFSVolArg = append(ZFSVolArg, ZFSGetArg, "-pH", "-o", "value", prop, volume)
 
 	cmd := exec.Command(ZFSVolCmd, ZFSVolArg...)
-	out, err := cmd.CombinedOutput()
+	out, err := runCmd(cmd, volume)
 	if err != nil {
+		zerr := NewZFSError(fmt.Sprintf("zfs get %s", prop), volume, err, out)
 		klog.Errorf("zfs: could not get %s on dataset %v cmd %v error: %s",
-			prop, volume, ZFSVolArg, string(out))
-		return "", fmt.Errorf("zfs get %s failed, %s", prop, string(out))
+			prop, volume, ZFSVolArg, zerr)
+		return "", zerr
 	}
 	val := out[:len(out)-1]
 	return string(val), nil
@@ -599,17 +612,16 @@ func SetVolumeProp(vol *apis.ZFSVolume) error {
 
 	args := buildVolumeSetArgs(vol)
 	cmd := exec.Command(ZFSVolCmd, args...)
-	out, err := cmd.CombinedOutput()
+	out, err := runCmd(cmd, volume)
 
 	if err != nil {
-		klog.Errorf(
-			"zfs: could not set property on volume %v cmd %v error: %s", volume, args, string(out),
-		)
-		return err
+		zerr := NewZFSError("zfs set", volume, err, out)
+		klog.Errorf("zfs: could not set property on volume %v cmd %v error: %s", volume, args, zerr)
+		return zerr
 	}
 	klog.Infof("property set on volume %s", volume)
 
-	return err
+	return nil
 }
 
 // DestroyVolume deletes the zfs volume
@@ -634,13 +646,12 @@ func DestroyVolume(vol *apis.ZFSVolume) error {
 
 	args := buildVolumeDestroyArgs(vol)
 	cmd := exec.Command(ZFSVolCmd, args...)
-	out, err := cmd.CombinedOutput()
+	out, err := runCmd(cmd, volume)
 
 	if err != nil {
-		klog.Errorf(
-			"zfs: could not destroy volume %v cmd %v error: %s", volume, args, string(out),
-		)
-		return err
+		zerr := NewZFSError("zfs destroy", volume, err, out)
+		klog.Errorf("zfs: could not destroy volume %v cmd %v error: %s", volume, args, zerr)
+		return zerr
 	}
 
 	if srcVol, ok := vol.Labels[ZFSSrcVolKey]; ok {
@@ -682,13 +693,12 @@ func CreateSnapshot(snap *apis.ZFSSnapshot) error {
 
 	args := buildZFSSnapCreateArgs(snap)
 	cmd := exec.Command(ZFSVolCmd, args...)
-	out, err := cmd.CombinedOutput()
+	out, err := runCmd(cmd, snapDataset)
 
 	if err != nil {
-		klog.Errorf(
-			"zfs: could not create snapshot %v@%v cmd %v error: %s", volume, snap.Name, args, string(out),
-		)
-		return err
+		zerr := NewZFSError("zfs snapshot", snapDataset, err, out)
+		klog.Errorf("zfs: could not create snapshot %v@%v cmd %v error: %s", volume, snap.Name, args, zerr)
+		return zerr
 	}
 	klog.Infof("created snapshot %s@%s", volume, snap.Name)
 	return nil
@@ -720,13 +730,12 @@ func DestroySnapshot(snap *apis.ZFSSnapshot) error {
 
 	args := buildZFSSnapDestroyArgs(snap)
 	cmd := exec.Command(ZFSVolCmd, args...)
-	out, err := cmd.CombinedOutput()
+	out, err := runCmd(cmd, snapDataset)
 
 	if err != nil {
-		klog.Errorf(
-			"zfs: could not destroy snapshot %v@%v cmd %v error: %s", volume, snap.Name, args, string(out),
-		)
-		return err
+		zerr := NewZFSError("zfs destroy snapshot", snapDataset, err, out)
+		klog.Errorf("zfs: could not destroy snapshot %v@%v cmd %v error: %s", volume, snap.Name, args, zerr)
+		return zerr
 	}
 	klog.Infof("deleted snapshot %s@%s", volume, snap.Name)
 	return nil
@@ -761,22 +770,22 @@ func ResizeZFSVolume(vol *apis.ZFSVolume, mountpath string, resizefs bool) error
 	args := buildVolumeResizeArgs(vol)
 	cmd := exec.Command(ZFSVolCmd, args...)
 
-	out, err := cmd.CombinedOutput()
+	out, err := runCmd(cmd, volume)
 	if err != nil {
-		klog.Errorf("zfs: could not resize the volume %v cmd %v error: %s", volume, args, string(out))
+		zerr := NewZFSError("zfs set quota", volume, err, out)
+		klog.Errorf("zfs: could not resize the volume %v cmd %v error: %s", volume, args, zerr)
 		klog.Infof("zfs: reverting the volume quota to %s", oldReservation)
 
 		revertedVol := vol.DeepCopy()
 		revertedVol.Spec.Capacity = oldReservation
 		args := buildVolumeResizeArgs(revertedVol)
 		cmd := exec.Command(ZFSVolCmd, args...)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			klog.Errorf(
-				"zfs: could not revert the volume %v quota cmd %v error: %s", volume, args, string(out),
-			)
+		if out, rerr := runCmd(cmd, volume); rerr != nil {
+			rzerr := NewZFSError("zfs set quota (revert)", volume, rerr, out)
+			klog.Errorf("zfs: could not revert the volume %v quota cmd %v error: %s", volume, args, rzerr)
 		}
 
-		return err
+		return zerr
 	}
 
 	if resizefs {
@@ -816,15 +825,15 @@ func CreateBackup(bkp *apis.ZFSBackup) error {
 		return err
 	}
 	cmd := exec.Command("bash", args...)
-	out, err := cmd.CombinedOutput()
+	out, err := runCmd(cmd, volume)
 
 	if err != nil {
-		klog.Errorf(
-			"zfs: could not backup the volume %v cmd %v error: %s", volume, args, string(out),
-		)
+		zerr := NewZFSError("zfs send (backup)", volume, err, out)
+		klog.Errorf("zfs: could not backup the volume %v cmd %v error: %s", volume, args, zerr)
+		return zerr
 	}
 
-	return err
+	return nil
 }
 
 // DestoryBackup deletes the snapshot created
@@ -894,13 +903,12 @@ func CreateRestore(rstr *apis.ZFSRestore) error {
 	volume := rstr.VolSpec.PoolName + "/" + rstr.Spec.VolumeName
 
 	cmd := exec.Command("bash", args...)
-	out, err := cmd.CombinedOutput()
+	out, err := runCmd(cmd, volume)
 
 	if err != nil {
-		klog.Errorf(
-			"zfs: could not restore the volume %v cmd %v error: %s", volume, args, string(out),
-		)
-		return err
+		zerr := NewZFSError("zfs recv (restore)", volume, err, out)
+		klog.Errorf("zfs: could not restore the volume %v cmd %v error: %s", volume, args, zerr)
+		return zerr
 	}
 
 	/*
@@ -934,10 +942,11 @@ func ListZFSPool() ([]apis.Pool, error) {
 		"-H", "-p",
 	}
 	cmd := exec.Command(ZFSVolCmd, args...)
-	output, err := cmd.CombinedOutput()
+	output, err := runCmd(cmd, "")
 	if err != nil {
-		klog.Errorf("zfs: could not list zpool cmd %v: %v", args, err)
-		return nil, err
+		zerr := NewZFSError("zfs list (pools)", "", err, output)
+		klog.Errorf("zfs: could not list zpool cmd %v: %s", args, zerr)
+		return nil, zerr
 	}
 	return decodeListOutput(output)
 }


### PR DESCRIPTION
  - ZFS operation failures now surface the exact CLI error via Warning events on the CR — visible with `kubectl describe zfsvolume/zfssnapshot`
  - All `zfs`/`zpool` exec failures are wrapped with operation and dataset context so logs are never vague
  - Exec verbosity controllable via `--v=4` (commands) and `--v=5` (output on failure)
