### PR TITLE
ci: fix the csi driver and chart releaser

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -86,7 +86,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: ./buildscripts/zfs-driver/zfs-driver.Dockerfile
+          file: ./buildscripts/zfs-driver/Dockerfile.buildx
           push: true
           platforms: linux/amd64, linux/arm64
           tags: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           charts_dir: ./deploy/helm
 
       - name: Publish chart via OCI
-        uses: appany/helm-oci-chart-releaser@v0.5
+        uses: appany/helm-oci-chart-releaser@v0.5.0
         with:
           name: zfs-localpv
           repository: ${{ github.repository_owner }}/charts

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -76,7 +76,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: ./buildscripts/zfs-driver/zfs-driver.Dockerfile
+          file: ./buildscripts/zfs-driver/Dockerfile.buildx
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.docker_meta.outputs.tags }}
@@ -114,7 +114,7 @@ jobs:
           echo "VERSION=${TAG#v}" >> $GITHUB_ENV
 
       - name: Push chart to staging repo
-        uses: appany/helm-oci-chart-releaser@v0.5
+        uses: appany/helm-oci-chart-releaser@v0.5.0
         with:
           name: zfs-localpv
           repository: ${{ env.IMAGE_ORG }}/helm


### PR DESCRIPTION
- The dockerfile points to a wrong location.
- The chart releaser version was wrong.