### PR TITLE
feat: globaloverride for gaid and gakey

### DIFF
--- a/deploy/helm/charts/templates/zfs-controller.yaml
+++ b/deploy/helm/charts/templates/zfs-controller.yaml
@@ -140,11 +140,17 @@ spec:
               {{- else}}
               value: "{{ .Values.analytics.enabled }}"
               {{- end}}
-            {{- if .Values.analytics.gaId }}
+            {{- if .Values.global.analytics.gaId }}
+            - name: GA_ID
+              value: {{ .Values.global.analytics.gaId | quote }}
+            {{- else if .Values.analytics.gaId }}
             - name: GA_ID
               value: {{ .Values.analytics.gaId | quote }}
             {{- end }}
-            {{- if .Values.analytics.gaKey }}
+            {{- if .Values.global.analytics.gaKey }}
+            - name: GA_KEY
+              value: {{ .Values.global.analytics.gaKey | quote }}
+            {{- else if .Values.analytics.gaKey }}
             - name: GA_KEY
               value: {{ .Values.analytics.gaKey | quote }}
             {{- end }}


### PR DESCRIPTION
Why is this PR required? What issue does it fix?:
This PR implements Global Override behvaiour for gaid and gakey to be consistent with other local engine charts

What this PR does?:
This PR implements Global Override behvaiour for gaid and gakey to be consistent with other local engine charts

Does this PR require any upgrade changes?:
No

If the changes in this PR are manually verified, list down the scenarios covered::
did a helm template test on the chart manually

without anything set: no values are rendered
with global and local values set: global values win
with local values set: local is applied