### PR TITLE
feat: support atime and logbias StorageClass parameters

### DIFF
--- a/deploy/helm/charts/charts/crds/templates/zfsrestore.yaml
+++ b/deploy/helm/charts/charts/crds/templates/zfsrestore.yaml
@@ -81,6 +81,18 @@ spec:
               In case of Cloned volumes, the parameters are assigned the same values
               as the source volume.
             properties:
+              atime:
+                description: |-
+                  ATime controls whether the access time for files is updated when they are read.
+                  Turning this property off ("off") avoids producing write traffic when reading files,
+                  which can result in significant performance gains for read-heavy workloads.
+                  This is a filesystem (dataset) only property and is ignored for zvols.
+                  ATime property can be edited after the volume has been created.
+                  Default Value: on.
+                enum:
+                - "on"
+                - "off"
+                type: string
               capacity:
                 description: Capacity of the volume
                 minLength: 1
@@ -147,6 +159,18 @@ spec:
                 type: string
               keylocation:
                 description: KeyLocation is the location of key for the encryption
+                type: string
+              logbias:
+                description: |-
+                  LogBias provides a hint to ZFS about how to handle synchronous requests for this volume.
+                  If set to "latency" (the default), ZFS uses the pool's separate log devices, if any, to handle
+                  the requests at low latency. If set to "throughput", ZFS does not use the separate log devices,
+                  instead it optimizes synchronous operations for global pool throughput and efficient use of resources.
+                  LogBias property can be edited after the volume has been created.
+                  Default Value: latency.
+                enum:
+                - latency
+                - throughput
                 type: string
               ownerNodeID:
                 description: |-

--- a/deploy/helm/charts/charts/crds/templates/zfssnapshot.yaml
+++ b/deploy/helm/charts/charts/crds/templates/zfssnapshot.yaml
@@ -50,6 +50,18 @@ spec:
               In case of Cloned volumes, the parameters are assigned the same values
               as the source volume.
             properties:
+              atime:
+                description: |-
+                  ATime controls whether the access time for files is updated when they are read.
+                  Turning this property off ("off") avoids producing write traffic when reading files,
+                  which can result in significant performance gains for read-heavy workloads.
+                  This is a filesystem (dataset) only property and is ignored for zvols.
+                  ATime property can be edited after the volume has been created.
+                  Default Value: on.
+                enum:
+                - "on"
+                - "off"
+                type: string
               capacity:
                 description: Capacity of the volume
                 minLength: 1
@@ -116,6 +128,18 @@ spec:
                 type: string
               keylocation:
                 description: KeyLocation is the location of key for the encryption
+                type: string
+              logbias:
+                description: |-
+                  LogBias provides a hint to ZFS about how to handle synchronous requests for this volume.
+                  If set to "latency" (the default), ZFS uses the pool's separate log devices, if any, to handle
+                  the requests at low latency. If set to "throughput", ZFS does not use the separate log devices,
+                  instead it optimizes synchronous operations for global pool throughput and efficient use of resources.
+                  LogBias property can be edited after the volume has been created.
+                  Default Value: latency.
+                enum:
+                - latency
+                - throughput
                 type: string
               ownerNodeID:
                 description: |-

--- a/deploy/helm/charts/charts/crds/templates/zfsvolume.yaml
+++ b/deploy/helm/charts/charts/crds/templates/zfsvolume.yaml
@@ -76,6 +76,18 @@ spec:
               In case of Cloned volumes, the parameters are assigned the same values
               as the source volume.
             properties:
+              atime:
+                description: |-
+                  ATime controls whether the access time for files is updated when they are read.
+                  Turning this property off ("off") avoids producing write traffic when reading files,
+                  which can result in significant performance gains for read-heavy workloads.
+                  This is a filesystem (dataset) only property and is ignored for zvols.
+                  ATime property can be edited after the volume has been created.
+                  Default Value: on.
+                enum:
+                - "on"
+                - "off"
+                type: string
               capacity:
                 description: Capacity of the volume
                 minLength: 1
@@ -142,6 +154,18 @@ spec:
                 type: string
               keylocation:
                 description: KeyLocation is the location of key for the encryption
+                type: string
+              logbias:
+                description: |-
+                  LogBias provides a hint to ZFS about how to handle synchronous requests for this volume.
+                  If set to "latency" (the default), ZFS uses the pool's separate log devices, if any, to handle
+                  the requests at low latency. If set to "throughput", ZFS does not use the separate log devices,
+                  instead it optimizes synchronous operations for global pool throughput and efficient use of resources.
+                  LogBias property can be edited after the volume has been created.
+                  Default Value: latency.
+                enum:
+                - latency
+                - throughput
                 type: string
               ownerNodeID:
                 description: |-

--- a/deploy/yamls/zfsrestore-crd.yaml
+++ b/deploy/yamls/zfsrestore-crd.yaml
@@ -79,6 +79,18 @@ spec:
               In case of Cloned volumes, the parameters are assigned the same values
               as the source volume.
             properties:
+              atime:
+                description: |-
+                  ATime controls whether the access time for files is updated when they are read.
+                  Turning this property off ("off") avoids producing write traffic when reading files,
+                  which can result in significant performance gains for read-heavy workloads.
+                  This is a filesystem (dataset) only property and is ignored for zvols.
+                  ATime property can be edited after the volume has been created.
+                  Default Value: on.
+                enum:
+                - "on"
+                - "off"
+                type: string
               capacity:
                 description: Capacity of the volume
                 minLength: 1
@@ -145,6 +157,18 @@ spec:
                 type: string
               keylocation:
                 description: KeyLocation is the location of key for the encryption
+                type: string
+              logbias:
+                description: |-
+                  LogBias provides a hint to ZFS about how to handle synchronous requests for this volume.
+                  If set to "latency" (the default), ZFS uses the pool's separate log devices, if any, to handle
+                  the requests at low latency. If set to "throughput", ZFS does not use the separate log devices,
+                  instead it optimizes synchronous operations for global pool throughput and efficient use of resources.
+                  LogBias property can be edited after the volume has been created.
+                  Default Value: latency.
+                enum:
+                - latency
+                - throughput
                 type: string
               ownerNodeID:
                 description: |-

--- a/deploy/yamls/zfssnapshot-crd.yaml
+++ b/deploy/yamls/zfssnapshot-crd.yaml
@@ -48,6 +48,18 @@ spec:
               In case of Cloned volumes, the parameters are assigned the same values
               as the source volume.
             properties:
+              atime:
+                description: |-
+                  ATime controls whether the access time for files is updated when they are read.
+                  Turning this property off ("off") avoids producing write traffic when reading files,
+                  which can result in significant performance gains for read-heavy workloads.
+                  This is a filesystem (dataset) only property and is ignored for zvols.
+                  ATime property can be edited after the volume has been created.
+                  Default Value: on.
+                enum:
+                - "on"
+                - "off"
+                type: string
               capacity:
                 description: Capacity of the volume
                 minLength: 1
@@ -114,6 +126,18 @@ spec:
                 type: string
               keylocation:
                 description: KeyLocation is the location of key for the encryption
+                type: string
+              logbias:
+                description: |-
+                  LogBias provides a hint to ZFS about how to handle synchronous requests for this volume.
+                  If set to "latency" (the default), ZFS uses the pool's separate log devices, if any, to handle
+                  the requests at low latency. If set to "throughput", ZFS does not use the separate log devices,
+                  instead it optimizes synchronous operations for global pool throughput and efficient use of resources.
+                  LogBias property can be edited after the volume has been created.
+                  Default Value: latency.
+                enum:
+                - latency
+                - throughput
                 type: string
               ownerNodeID:
                 description: |-

--- a/deploy/yamls/zfsvolume-crd.yaml
+++ b/deploy/yamls/zfsvolume-crd.yaml
@@ -74,6 +74,18 @@ spec:
               In case of Cloned volumes, the parameters are assigned the same values
               as the source volume.
             properties:
+              atime:
+                description: |-
+                  ATime controls whether the access time for files is updated when they are read.
+                  Turning this property off ("off") avoids producing write traffic when reading files,
+                  which can result in significant performance gains for read-heavy workloads.
+                  This is a filesystem (dataset) only property and is ignored for zvols.
+                  ATime property can be edited after the volume has been created.
+                  Default Value: on.
+                enum:
+                - "on"
+                - "off"
+                type: string
               capacity:
                 description: Capacity of the volume
                 minLength: 1
@@ -140,6 +152,18 @@ spec:
                 type: string
               keylocation:
                 description: KeyLocation is the location of key for the encryption
+                type: string
+              logbias:
+                description: |-
+                  LogBias provides a hint to ZFS about how to handle synchronous requests for this volume.
+                  If set to "latency" (the default), ZFS uses the pool's separate log devices, if any, to handle
+                  the requests at low latency. If set to "throughput", ZFS does not use the separate log devices,
+                  instead it optimizes synchronous operations for global pool throughput and efficient use of resources.
+                  LogBias property can be edited after the volume has been created.
+                  Default Value: latency.
+                enum:
+                - latency
+                - throughput
                 type: string
               ownerNodeID:
                 description: |-

--- a/deploy/zfs-operator.yaml
+++ b/deploy/zfs-operator.yaml
@@ -16,6 +16,7 @@ metadata:
 value: 900001000
 globalDefault: false
 description: "This priority class should be used for the CStor CSI driver node deployment only."
+
 ---
 # Source: zfs-localpv/templates/rbac.yaml
 kind: ServiceAccount
@@ -65,6 +66,7 @@ data:
     else
       chroot /host "zfs" "$@"
     fi
+
 ---
 # Source: zfs-localpv/charts/crds/templates/csi-volume-snapshot-class.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -1391,6 +1393,18 @@ spec:
               In case of Cloned volumes, the parameters are assigned the same values
               as the source volume.
             properties:
+              atime:
+                description: |-
+                  ATime controls whether the access time for files is updated when they are read.
+                  Turning this property off ("off") avoids producing write traffic when reading files,
+                  which can result in significant performance gains for read-heavy workloads.
+                  This is a filesystem (dataset) only property and is ignored for zvols.
+                  ATime property can be edited after the volume has been created.
+                  Default Value: on.
+                enum:
+                - "on"
+                - "off"
+                type: string
               capacity:
                 description: Capacity of the volume
                 minLength: 1
@@ -1457,6 +1471,18 @@ spec:
                 type: string
               keylocation:
                 description: KeyLocation is the location of key for the encryption
+                type: string
+              logbias:
+                description: |-
+                  LogBias provides a hint to ZFS about how to handle synchronous requests for this volume.
+                  If set to "latency" (the default), ZFS uses the pool's separate log devices, if any, to handle
+                  the requests at low latency. If set to "throughput", ZFS does not use the separate log devices,
+                  instead it optimizes synchronous operations for global pool throughput and efficient use of resources.
+                  LogBias property can be edited after the volume has been created.
+                  Default Value: latency.
+                enum:
+                - latency
+                - throughput
                 type: string
               ownerNodeID:
                 description: |-
@@ -1601,6 +1627,18 @@ spec:
               In case of Cloned volumes, the parameters are assigned the same values
               as the source volume.
             properties:
+              atime:
+                description: |-
+                  ATime controls whether the access time for files is updated when they are read.
+                  Turning this property off ("off") avoids producing write traffic when reading files,
+                  which can result in significant performance gains for read-heavy workloads.
+                  This is a filesystem (dataset) only property and is ignored for zvols.
+                  ATime property can be edited after the volume has been created.
+                  Default Value: on.
+                enum:
+                - "on"
+                - "off"
+                type: string
               capacity:
                 description: Capacity of the volume
                 minLength: 1
@@ -1667,6 +1705,18 @@ spec:
                 type: string
               keylocation:
                 description: KeyLocation is the location of key for the encryption
+                type: string
+              logbias:
+                description: |-
+                  LogBias provides a hint to ZFS about how to handle synchronous requests for this volume.
+                  If set to "latency" (the default), ZFS uses the pool's separate log devices, if any, to handle
+                  the requests at low latency. If set to "throughput", ZFS does not use the separate log devices,
+                  instead it optimizes synchronous operations for global pool throughput and efficient use of resources.
+                  LogBias property can be edited after the volume has been created.
+                  Default Value: latency.
+                enum:
+                - latency
+                - throughput
                 type: string
               ownerNodeID:
                 description: |-
@@ -2023,6 +2073,18 @@ spec:
               In case of Cloned volumes, the parameters are assigned the same values
               as the source volume.
             properties:
+              atime:
+                description: |-
+                  ATime controls whether the access time for files is updated when they are read.
+                  Turning this property off ("off") avoids producing write traffic when reading files,
+                  which can result in significant performance gains for read-heavy workloads.
+                  This is a filesystem (dataset) only property and is ignored for zvols.
+                  ATime property can be edited after the volume has been created.
+                  Default Value: on.
+                enum:
+                - "on"
+                - "off"
+                type: string
               capacity:
                 description: Capacity of the volume
                 minLength: 1
@@ -2089,6 +2151,18 @@ spec:
                 type: string
               keylocation:
                 description: KeyLocation is the location of key for the encryption
+                type: string
+              logbias:
+                description: |-
+                  LogBias provides a hint to ZFS about how to handle synchronous requests for this volume.
+                  If set to "latency" (the default), ZFS uses the pool's separate log devices, if any, to handle
+                  the requests at low latency. If set to "throughput", ZFS does not use the separate log devices,
+                  instead it optimizes synchronous operations for global pool throughput and efficient use of resources.
+                  LogBias property can be edited after the volume has been created.
+                  Default Value: latency.
+                enum:
+                - latency
+                - throughput
                 type: string
               ownerNodeID:
                 description: |-
@@ -2589,6 +2663,7 @@ roleRef:
   kind: ClusterRole
   name: openebs-zfs-driver-registrar-role
   apiGroup: rbac.authorization.k8s.io
+
 ---
 # Source: zfs-localpv/templates/zfs-node.yaml
 kind: DaemonSet
@@ -2729,6 +2804,7 @@ spec:
           hostPath:
             path: "/var/lib/kubelet/"
             type: Directory
+
 ---
 # Source: zfs-localpv/templates/zfs-controller.yaml
 apiVersion: apps/v1
@@ -2854,6 +2930,7 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir: {}
+
 ---
 # Source: zfs-localpv/templates/csidriver.yaml
 # Create the CSI Driver object

--- a/docs/storageclasses.md
+++ b/docs/storageclasses.md
@@ -41,6 +41,18 @@ Deduplication is the process for removing redundant data at the block level, red
 
 allowed values: "on", "off"
 
+### atime (*optional* parameter)
+
+ATime controls whether the access time for files is updated when they are read. Setting it to "off" avoids producing write traffic when reading files, which can give a significant performance gain for read-heavy workloads. This is a filesystem (dataset) only property and is ignored for volumes (zvols).
+
+allowed values: "on", "off"
+
+### logbias (*optional* parameter)
+
+LogBias provides a hint to ZFS about how to handle synchronous requests for this volume. With "latency" (the default) ZFS uses the pool's separate log devices (SLOG), if any, to handle the requests at low latency. With "throughput" ZFS does not use the separate log devices and instead optimizes synchronous operations for global pool throughput; on pools without a SLOG this also avoids the in-pool ZIL double-write, which benefits write-heavy workloads such as databases.
+
+allowed values: "latency", "throughput"
+
 ### thinprovision (*optional* parameter)
 
 ThinProvision describes whether space reservation for the source volume is required or not. The value "yes" indicates that volume should be thin provisioned and "no" means thick provisioning of the volume. If thinProvision is set to "yes" then volume can be provisioned even if the ZPOOL does not have the enough capacity. If thinProvision is set to "no" then volume can be provisioned only if the ZPOOL has enough capacity and capacity required by volume can be reserved.
@@ -76,6 +88,9 @@ metadata:
 allowVolumeExpansion: true
 parameters:
  recordsize: "128k"
+ compression: "lz4"
+ atime: "off"
+ logbias: "throughput"
  thinprovision: "no"
  fstype: "zfs"
  poolname: "zfspv-pool"

--- a/pkg/apis/openebs.io/zfs/v1/zfsvolume.go
+++ b/pkg/apis/openebs.io/zfs/v1/zfsvolume.go
@@ -123,6 +123,24 @@ type VolumeInfo struct {
 	// +kubebuilder:validation:Enum=on;off
 	Dedup string `json:"dedup,omitempty"`
 
+	// ATime controls whether the access time for files is updated when they are read.
+	// Turning this property off ("off") avoids producing write traffic when reading files,
+	// which can result in significant performance gains for read-heavy workloads.
+	// This is a filesystem (dataset) only property and is ignored for zvols.
+	// ATime property can be edited after the volume has been created.
+	// Default Value: on.
+	// +kubebuilder:validation:Enum=on;off
+	ATime string `json:"atime,omitempty"`
+
+	// LogBias provides a hint to ZFS about how to handle synchronous requests for this volume.
+	// If set to "latency" (the default), ZFS uses the pool's separate log devices, if any, to handle
+	// the requests at low latency. If set to "throughput", ZFS does not use the separate log devices,
+	// instead it optimizes synchronous operations for global pool throughput and efficient use of resources.
+	// LogBias property can be edited after the volume has been created.
+	// Default Value: latency.
+	// +kubebuilder:validation:Enum=latency;throughput
+	LogBias string `json:"logbias,omitempty"`
+
 	// Enabling the encryption feature allows for the creation of
 	// encrypted filesystems and volumes. ZFS will encrypt file and zvol data,
 	// file attributes, ACLs, permission bits, directory listings, FUID mappings,

--- a/pkg/builder/volbuilder/build.go
+++ b/pkg/builder/volbuilder/build.go
@@ -133,6 +133,18 @@ func (b *Builder) WithDedup(dedup string) *Builder {
 	return b
 }
 
+// WithATime sets the atime property of ZFSVolume
+func (b *Builder) WithATime(atime string) *Builder {
+	b.volume.Object.Spec.ATime = atime
+	return b
+}
+
+// WithLogBias sets the logbias property of ZFSVolume
+func (b *Builder) WithLogBias(logbias string) *Builder {
+	b.volume.Object.Spec.LogBias = logbias
+	return b
+}
+
 // WithThinProv sets if ZFSVolume needs to be thin provisioned
 func (b *Builder) WithThinProv(thinprov string) *Builder {
 	b.volume.Object.Spec.ThinProvision = thinprov

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -238,6 +238,8 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 	bs := parameters["volblocksize"]
 	compression := parameters["compression"]
 	dedup := parameters["dedup"]
+	atime := parameters["atime"]
+	logbias := parameters["logbias"]
 	encr := parameters["encryption"]
 	kf := parameters["keyformat"]
 	kl := parameters["keylocation"]
@@ -307,6 +309,8 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 		WithFsType(fstype).
 		WithQuotaType(quotatype).
 		WithShared(shared).
+		WithATime(atime).
+		WithLogBias(logbias).
 		WithCompression(compression).Build()
 
 	if err != nil {

--- a/pkg/zfs/volume_test.go
+++ b/pkg/zfs/volume_test.go
@@ -1,6 +1,7 @@
 package zfs
 
 import (
+	"strings"
 	"testing"
 
 	apis "github.com/openebs/zfs-localpv/pkg/apis/openebs.io/zfs/v1"
@@ -153,6 +154,148 @@ func TestBuildCloneCreateArgs(t *testing.T) {
 					t.Errorf("Clone command should NOT include encryption parameter: %q", arg)
 				}
 			}
+		})
+	}
+}
+
+func assertArgs(t *testing.T, got, expected []string) {
+	t.Helper()
+	if len(got) != len(expected) {
+		t.Fatalf("Expected %d arguments, got %d\nExpected: %v\nGot: %v",
+			len(expected), len(got), expected, got)
+	}
+	for i, arg := range got {
+		if arg != expected[i] {
+			t.Errorf("Argument %d: expected %q, got %q", i, expected[i], arg)
+		}
+	}
+}
+
+func TestBuildDatasetCreateArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		vol      *apis.ZFSVolume
+		expected []string
+	}{
+		{
+			name: "atime and logbias are set on dataset creation",
+			vol: &apis.ZFSVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-vol"},
+				Spec: apis.VolumeInfo{
+					PoolName:      "testpool",
+					VolumeType:    "DATASET",
+					Capacity:      "10G",
+					RecordSize:    "16k",
+					ATime:         "off",
+					Compression:   "lz4",
+					LogBias:       "throughput",
+					ThinProvision: "yes",
+				},
+			},
+			expected: []string{"create", "-o", "quota=10G", "-o", "recordsize=16k", "-o", "atime=off", "-o", "compression=lz4", "-o", "logbias=throughput", "-o", "mountpoint=legacy", "testpool/test-vol"},
+		},
+		{
+			name: "atime and logbias omitted when unset",
+			vol: &apis.ZFSVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: "plain-vol"},
+				Spec: apis.VolumeInfo{
+					PoolName:      "testpool",
+					VolumeType:    "DATASET",
+					Capacity:      "10G",
+					ThinProvision: "yes",
+				},
+			},
+			expected: []string{"create", "-o", "quota=10G", "-o", "mountpoint=legacy", "testpool/plain-vol"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertArgs(t, buildDatasetCreateArgs(tt.vol), tt.expected)
+		})
+	}
+}
+
+func TestBuildZvolCreateArgs(t *testing.T) {
+	vol := &apis.ZFSVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-zvol"},
+		Spec: apis.VolumeInfo{
+			PoolName:      "testpool",
+			VolumeType:    "ZVOL",
+			Capacity:      "10G",
+			VolBlockSize:  "8k",
+			Compression:   "lz4",
+			ATime:         "off", // must be ignored for zvols
+			LogBias:       "throughput",
+			ThinProvision: "yes",
+		},
+	}
+	expected := []string{"create", "-s", "-V", "10G", "-b", "8k", "-o", "compression=lz4", "-o", "logbias=throughput", "testpool/test-zvol"}
+	assertArgs(t, buildZvolCreateArgs(vol), expected)
+}
+
+func TestBuildVolumeRestoreArgs(t *testing.T) {
+	rstr := &apis.ZFSRestore{
+		Spec: apis.ZFSRestoreSpec{RestoreSrc: "10.0.0.1:9000", VolumeName: "test-vol"},
+		VolSpec: apis.VolumeInfo{
+			PoolName:    "testpool",
+			VolumeType:  "DATASET",
+			Capacity:    "10G",
+			RecordSize:  "16k",
+			ATime:       "off",
+			Compression: "lz4",
+			LogBias:     "throughput",
+		},
+	}
+	args, err := buildVolumeRestoreArgs(rstr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cmd := strings.Join(args, " ")
+	for _, want := range []string{"-o atime=off", "-o logbias=throughput"} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("restore command missing %q\ngot: %s", want, cmd)
+		}
+	}
+}
+
+func TestBuildVolumeSetArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		vol      *apis.ZFSVolume
+		expected []string
+	}{
+		{
+			name: "atime (dataset) and logbias are emitted on set",
+			vol: &apis.ZFSVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-vol"},
+				Spec: apis.VolumeInfo{
+					PoolName:    "testpool",
+					VolumeType:  "DATASET",
+					RecordSize:  "16k",
+					ATime:       "off",
+					Compression: "lz4",
+					LogBias:     "throughput",
+				},
+			},
+			expected: []string{"set", "recordsize=16k", "atime=off", "compression=lz4", "logbias=throughput", "testpool/test-vol"},
+		},
+		{
+			name: "atime is skipped for zvol, logbias still applies",
+			vol: &apis.ZFSVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: "zvol-vol"},
+				Spec: apis.VolumeInfo{
+					PoolName:   "testpool",
+					VolumeType: "ZVOL",
+					ATime:      "off",
+					LogBias:    "throughput",
+				},
+			},
+			expected: []string{"set", "logbias=throughput", "testpool/zvol-vol"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertArgs(t, buildVolumeSetArgs(tt.vol), tt.expected)
 		})
 	}
 }

--- a/pkg/zfs/zfs_util.go
+++ b/pkg/zfs/zfs_util.go
@@ -78,12 +78,14 @@ func runCmd(cmd *exec.Cmd, dataset string) ([]byte, error) {
 func PropertyChanged(oldVol *apis.ZFSVolume, newVol *apis.ZFSVolume) bool {
 	if oldVol.Spec.VolumeType == VolTypeDataset &&
 		newVol.Spec.VolumeType == VolTypeDataset &&
-		oldVol.Spec.RecordSize != newVol.Spec.RecordSize {
+		(oldVol.Spec.RecordSize != newVol.Spec.RecordSize ||
+			oldVol.Spec.ATime != newVol.Spec.ATime) {
 		return true
 	}
 
 	return oldVol.Spec.Compression != newVol.Spec.Compression ||
-		oldVol.Spec.Dedup != newVol.Spec.Dedup
+		oldVol.Spec.Dedup != newVol.Spec.Dedup ||
+		oldVol.Spec.LogBias != newVol.Spec.LogBias
 }
 
 // GetVolumeType returns the volume type
@@ -126,6 +128,10 @@ func buildZvolCreateArgs(vol *apis.ZFSVolume) []string {
 		compressionProperty := "compression=" + vol.Spec.Compression
 		ZFSVolArg = append(ZFSVolArg, "-o", compressionProperty)
 	}
+	if len(vol.Spec.LogBias) != 0 {
+		logbiasProperty := "logbias=" + vol.Spec.LogBias
+		ZFSVolArg = append(ZFSVolArg, "-o", logbiasProperty)
+	}
 	if len(vol.Spec.Encryption) != 0 {
 		encryptionProperty := "encryption=" + vol.Spec.Encryption
 		ZFSVolArg = append(ZFSVolArg, "-o", encryptionProperty)
@@ -162,6 +168,10 @@ func buildCloneCreateArgs(vol *apis.ZFSVolume) []string {
 			recordsizeProperty := "recordsize=" + vol.Spec.RecordSize
 			ZFSVolArg = append(ZFSVolArg, "-o", recordsizeProperty)
 		}
+		if len(vol.Spec.ATime) != 0 {
+			atimeProperty := "atime=" + vol.Spec.ATime
+			ZFSVolArg = append(ZFSVolArg, "-o", atimeProperty)
+		}
 		if vol.Spec.ThinProvision == "no" {
 			ZFSVolArg = append(ZFSVolArg, "-o", reservationProperty(vol.Spec.QuotaType, vol.Spec.Capacity))
 		}
@@ -175,6 +185,10 @@ func buildCloneCreateArgs(vol *apis.ZFSVolume) []string {
 	if len(vol.Spec.Compression) != 0 {
 		compressionProperty := "compression=" + vol.Spec.Compression
 		ZFSVolArg = append(ZFSVolArg, "-o", compressionProperty)
+	}
+	if len(vol.Spec.LogBias) != 0 {
+		logbiasProperty := "logbias=" + vol.Spec.LogBias
+		ZFSVolArg = append(ZFSVolArg, "-o", logbiasProperty)
 	}
 	// Note: Encryption parameters (encryption, keylocation, keyformat) are NOT set when cloning.
 	// ZFS clones automatically inherit encryption settings from the parent snapshot.
@@ -226,6 +240,10 @@ func buildDatasetCreateArgs(vol *apis.ZFSVolume) []string {
 		recordsizeProperty := "recordsize=" + vol.Spec.RecordSize
 		ZFSVolArg = append(ZFSVolArg, "-o", recordsizeProperty)
 	}
+	if len(vol.Spec.ATime) != 0 {
+		atimeProperty := "atime=" + vol.Spec.ATime
+		ZFSVolArg = append(ZFSVolArg, "-o", atimeProperty)
+	}
 	if vol.Spec.ThinProvision == "no" {
 		ZFSVolArg = append(ZFSVolArg, "-o", reservationProperty(vol.Spec.QuotaType, vol.Spec.Capacity))
 	}
@@ -236,6 +254,10 @@ func buildDatasetCreateArgs(vol *apis.ZFSVolume) []string {
 	if len(vol.Spec.Compression) != 0 {
 		compressionProperty := "compression=" + vol.Spec.Compression
 		ZFSVolArg = append(ZFSVolArg, "-o", compressionProperty)
+	}
+	if len(vol.Spec.LogBias) != 0 {
+		logbiasProperty := "logbias=" + vol.Spec.LogBias
+		ZFSVolArg = append(ZFSVolArg, "-o", logbiasProperty)
 	}
 	if len(vol.Spec.Encryption) != 0 {
 		encryptionProperty := "encryption=" + vol.Spec.Encryption
@@ -271,6 +293,12 @@ func buildVolumeSetArgs(vol *apis.ZFSVolume) []string {
 		ZFSVolArg = append(ZFSVolArg, recordsizeProperty)
 	}
 
+	if vol.Spec.VolumeType == VolTypeDataset &&
+		len(vol.Spec.ATime) != 0 {
+		atimeProperty := "atime=" + vol.Spec.ATime
+		ZFSVolArg = append(ZFSVolArg, atimeProperty)
+	}
+
 	if len(vol.Spec.Dedup) != 0 {
 		dedupProperty := "dedup=" + vol.Spec.Dedup
 		ZFSVolArg = append(ZFSVolArg, dedupProperty)
@@ -278,6 +306,10 @@ func buildVolumeSetArgs(vol *apis.ZFSVolume) []string {
 	if len(vol.Spec.Compression) != 0 {
 		compressionProperty := "compression=" + vol.Spec.Compression
 		ZFSVolArg = append(ZFSVolArg, compressionProperty)
+	}
+	if len(vol.Spec.LogBias) != 0 {
+		logbiasProperty := "logbias=" + vol.Spec.LogBias
+		ZFSVolArg = append(ZFSVolArg, logbiasProperty)
 	}
 
 	ZFSVolArg = append(ZFSVolArg, volume)
@@ -361,6 +393,9 @@ func buildVolumeRestoreArgs(rstr *apis.ZFSRestore) ([]string, error) {
 		if len(rstr.VolSpec.RecordSize) != 0 {
 			ZFSRecvParam += " -o recordsize=" + rstr.VolSpec.RecordSize
 		}
+		if len(rstr.VolSpec.ATime) != 0 {
+			ZFSRecvParam += " -o atime=" + rstr.VolSpec.ATime
+		}
 		if rstr.VolSpec.ThinProvision == "no" {
 			ZFSRecvParam += " -o reservation=" + rstr.VolSpec.Capacity
 		}
@@ -372,6 +407,9 @@ func buildVolumeRestoreArgs(rstr *apis.ZFSRestore) ([]string, error) {
 	}
 	if len(rstr.VolSpec.Compression) != 0 {
 		ZFSRecvParam += " -o compression=" + rstr.VolSpec.Compression
+	}
+	if len(rstr.VolSpec.LogBias) != 0 {
+		ZFSRecvParam += " -o logbias=" + rstr.VolSpec.LogBias
 	}
 	if len(rstr.VolSpec.Encryption) != 0 {
 		ZFSRecvParam += " -o encryption=" + rstr.VolSpec.Encryption
@@ -591,8 +629,10 @@ func SetVolumeProp(vol *apis.ZFSVolume) error {
 
 	if len(vol.Spec.Compression) == 0 &&
 		len(vol.Spec.Dedup) == 0 &&
+		len(vol.Spec.LogBias) == 0 &&
 		(vol.Spec.VolumeType != VolTypeDataset ||
-			len(vol.Spec.RecordSize) == 0) {
+			(len(vol.Spec.RecordSize) == 0 &&
+				len(vol.Spec.ATime) == 0)) {
 		//nothing to set, just return
 		return nil
 	}


### PR DESCRIPTION
## Why

`atime` and `logbias` can be set in StorageClass `parameters` but are silently dropped — volumes always get the ZFS defaults (`atime=on`, `logbias=latency`). `logbias=throughput` in particular matters for write-heavy workloads on pools without a SLOG.

## What

Wire both through the same path as `compression`/`dedup`/`recordsize`: API field, volbuilder, controller param parsing, and the create/clone/set/recv arg builders.

- `atime` is filesystem-only → gated to `DATASET` (skipped for zvols).
- `logbias` applies to both datasets and zvols.
- Both editable post-creation (`PropertyChanged` + set args).
- CRDs regenerated, docs updated, unit tests added.

Possible follow-up (not in this PR): the per-property arg blocks could be collapsed into a helper.