### PR TITLE
feat(scheduler): pool pattern aware scheduler helpers

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -274,7 +274,14 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 		}
 	}
 
-	nmap, err := getNodeMap(schld, pool)
+	// the pool parameters are matched as a single regular expression, an exact
+	// name being an anchored, quoted one
+	pattern, err := compilePoolPattern(pool, "")
+	if err != nil {
+		return "", status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	nmap, err := getNodeMap(schld, pattern)
 	if err != nil {
 		return "", status.Errorf(codes.Internal, "get node map failed : %s", err.Error())
 	}

--- a/pkg/driver/schd_helper.go
+++ b/pkg/driver/schd_helper.go
@@ -40,12 +40,17 @@ const (
 	CapacityWeighted = "CapacityWeighted"
 )
 
-// The node keys used by all the helpers below are the node IDs (the value of
-// the openebs.io/nodeid topology label), which is what ZFSVolume records in
-// Spec.OwnerNodeID and what the ZFSNode CR is named after. Note that lib-csi's
-// scheduler works with kubernetes node *names*, so the caller has to map a node
-// name to its node ID (zfs.GetNodeID) before looking it up in the suitable set
-// or asking resolvePool for the concrete pool.
+// Returns the name of the kubernetes node this ZFSNode belongs to,
+// read from the owner reference the node agent maintains and falling back to the
+// CR name.
+func k8sNodeName(node apis.ZFSNode) string {
+	for _, ref := range node.OwnerReferences {
+		if ref.Kind == "Node" {
+			return ref.Name
+		}
+	}
+	return node.Name
+}
 
 // Returns the pool part of a "poolname" parameter, which may name a
 // pool ("zpool") or a dataset below it ("zpool/k8s/localpv").
@@ -101,13 +106,8 @@ func listZFSNodes() ([]apis.ZFSNode, error) {
 	return nodelist.Items, nil
 }
 
-// getVolumeWeightedMap goes through all the volumes provisioned into a pool
-// matching the pattern and creates the node mapping of the volume count.
-// It returns a map which has nodes as key and volumes present
-// on the nodes as corresponding value.
-//
-// This is an ordering input for the scheduler only, it does not decide whether
-// a node can hold the volume, see getSuitableNodes for that.
+// Returns the node name to volume count mapping for the
+// volumes provisioned into a pool matching the pattern.
 func getVolumeWeightedMap(pattern *regexp.Regexp) (map[string]int64, error) {
 	zvlist, err := volbuilder.NewKubeclient().
 		WithNamespace(zfs.OpenEBSNamespace).
@@ -117,33 +117,46 @@ func getVolumeWeightedMap(pattern *regexp.Regexp) (map[string]int64, error) {
 		return map[string]int64{}, err
 	}
 
-	return volumeWeightedMap(zvlist.Items, pattern), nil
+	// a volume records the node id of its node, the ZFSNode CRs are what maps
+	// that back to the node name the scheduler works with
+	nodelist, err := listZFSNodes()
+	if err != nil {
+		return map[string]int64{}, err
+	}
+
+	return volumeWeightedMap(zvlist.Items, nodelist, pattern), nil
 }
 
-func volumeWeightedMap(zvlist []apis.ZFSVolume, pattern *regexp.Regexp) map[string]int64 {
+// Counts the volumes in a matching pool per node, translating
+// the node id a volume records back to its node name.
+func volumeWeightedMap(zvlist []apis.ZFSVolume, nodelist []apis.ZFSNode, pattern *regexp.Regexp) map[string]int64 {
+	nodename := map[string]string{}
+	for _, node := range nodelist {
+		nodename[node.Name] = k8sNodeName(node)
+	}
+
 	nmap := map[string]int64{}
 
 	// create the map of the volume count for the matching pools
 	for _, zv := range zvlist {
-		if pattern.MatchString(poolRoot(zv.Spec.PoolName)) {
-			nmap[zv.Spec.OwnerNodeID]++
+		if !pattern.MatchString(poolRoot(zv.Spec.PoolName)) {
+			continue
 		}
+		node, ok := nodename[zv.Spec.OwnerNodeID]
+		if !ok {
+			// no ZFSNode CR for the volume's node, its node id is the best
+			// guess at the node name
+			node = zv.Spec.OwnerNodeID
+		}
+		nmap[node]++
 	}
 
 	return nmap
 }
 
-// getCapacityWeightedMap goes through the pools advertised by every node and
-// creates the node mapping of the capacity used by the pools matching the
-// pattern. It returns a map which has nodes as key and the used capacity of
-// the matching pools as corresponding value. The scheduler will use this map
-// and picks the node which is less weighted.
-//
-// The weight is the pool's real on disk usage as reported by the ZFSNode CR,
-// so it also accounts for the data which was not provisioned by this driver.
-// Every node with a matching pool gets an entry, even when the pools are empty,
-// so that the ordering is not distorted: lib-csi's scheduler moves the nodes
-// missing from the map to the front of the list.
+// Returns the node name to used capacity mapping for the
+// pools matching the pattern, as the ZFSNode CR reports it, so it also accounts
+// for data which was not provisioned by this driver.
 func getCapacityWeightedMap(pattern *regexp.Regexp) (map[string]int64, error) {
 	nodelist, err := listZFSNodes()
 	if err != nil {
@@ -153,13 +166,14 @@ func getCapacityWeightedMap(pattern *regexp.Regexp) (map[string]int64, error) {
 	return capacityWeightedMap(nodelist, pattern), nil
 }
 
+// Sums the used capacity of a node's matching pools.
 func capacityWeightedMap(nodelist []apis.ZFSNode, pattern *regexp.Regexp) map[string]int64 {
 	nmap := map[string]int64{}
 
 	for _, node := range nodelist {
 		for _, pool := range node.Pools {
 			if pattern.MatchString(pool.Name) {
-				nmap[node.Name] += pool.Used.Value()
+				nmap[k8sNodeName(node)] += pool.Used.Value()
 			}
 		}
 	}
@@ -179,20 +193,10 @@ func getNodeMap(schd string, pattern *regexp.Regexp) (map[string]int64, error) {
 	return getCapacityWeightedMap(pattern)
 }
 
-// getSuitableNodes returns the set of nodes which have a pool matching the
-// pattern with more than `size` bytes free, along with `matched`, which tells
-// whether any pool matched the pattern at all, the fit aside.
-//
-// A single pool has to hold the whole reservation, the free capacity is not
-// summed across the pools of a node. The caller intersects this set with the
-// node list returned by the scheduler for the volumes which reserve space (see
-// reservesSpace), and uses `matched` to tell an exhausted pool (matched, but
-// nothing fits) apart from a storageclass which names a pool that does not
-// exist anywhere (not matched).
-//
-// The check is best effort: the free capacity on the ZFSNode CR is a periodic
-// snapshot and two concurrent creates can both pass it, so "zfs create" stays
-// the final arbiter.
+// Returns the names of the nodes whose roomiest matching pool
+// has more than `size` bytes free, and whether any pool matched the pattern at
+// all. The fit is best effort, as the free capacity on the ZFSNode CR is a
+// periodic snapshot, so "zfs create" stays the final arbiter.
 func getSuitableNodes(pattern *regexp.Regexp, size int64) (map[string]bool, bool, error) {
 	nodelist, err := listZFSNodes()
 	if err != nil {
@@ -203,6 +207,10 @@ func getSuitableNodes(pattern *regexp.Regexp, size int64) (map[string]bool, bool
 	return suitable, matched, nil
 }
 
+// Reports which nodes have a matching pool with more than `size`
+// bytes free, and whether any pool matched the pattern at all. A single pool has
+// to hold the whole reservation, so the free capacity is not summed across the
+// pools of a node.
 func suitableNodes(nodelist []apis.ZFSNode, pattern *regexp.Regexp, size int64) (map[string]bool, bool) {
 	suitable := map[string]bool{}
 	matched := false
@@ -219,24 +227,21 @@ func suitableNodes(nodelist []apis.ZFSNode, pattern *regexp.Regexp, size int64) 
 			}
 		}
 		if maxFree > size {
-			suitable[node.Name] = true
+			suitable[k8sNodeName(node)] = true
 		}
 	}
 
 	return suitable, matched
 }
 
-// resolvePool returns the pool matching the pattern on the given node which has
-// the most free capacity, or an empty string when no pool on the node matches.
-//
-// This is how a poolpattern is turned into the concrete pool stored in
-// ZFSVolume.Spec.PoolName. It is not used for the fixed poolname case, where
-// the parameter is used as it is, since it can carry a dataset path
-// ("zpool/k8s/localpv") which the ZFSNode CR does not advertise.
-func resolvePool(node string, pattern *regexp.Regexp) (string, error) {
+// Returns the matching pool with the most free capacity on the given
+// node, or an empty string when no pool on the node matches, turning a
+// poolpattern into the concrete pool stored in ZFSVolume.Spec.PoolName. `nodeid`
+// is the node id, since the ZFSNode CR is named after it.
+func resolvePool(nodeid string, pattern *regexp.Regexp) (string, error) {
 	zfsNode, err := nodebuilder.NewKubeclient().
 		WithNamespace(zfs.OpenEBSNamespace).
-		Get(node, metav1.GetOptions{})
+		Get(nodeid, metav1.GetOptions{})
 
 	if err != nil {
 		return "", err

--- a/pkg/driver/schd_helper.go
+++ b/pkg/driver/schd_helper.go
@@ -19,6 +19,7 @@ package driver
 import (
 	"errors"
 	"fmt"
+	"math"
 	"regexp"
 	"strings"
 
@@ -38,6 +39,9 @@ const (
 	// pick the node where the matching pools have occupied less capacity
 	// this will be the default scheduler when none provided
 	CapacityWeighted = "CapacityWeighted"
+
+	// pick the node whose matching pool has the most free space
+	SpaceWeighted = "SpaceWeighted"
 )
 
 // Returns the name of the kubernetes node this ZFSNode belongs to,
@@ -181,13 +185,47 @@ func capacityWeightedMap(nodelist []apis.ZFSNode, pattern *regexp.Regexp) map[st
 	return nmap
 }
 
-// getNodeMap returns the node mapping for the given scheduling algorithm
+// Returns the node name to weight mapping which orders the
+// nodes by the free capacity of their roomiest matching pool, so that the volume
+// goes to the node with the most room left rather than the least written to.
+func getSpaceWeightedMap(pattern *regexp.Regexp) (map[string]int64, error) {
+	nodelist, err := listZFSNodes()
+	if err != nil {
+		return map[string]int64{}, err
+	}
+
+	return spaceWeightedMap(nodelist, pattern), nil
+}
+
+// Inverts the free capacity of each node's roomiest matching
+// pool into a weight.
+func spaceWeightedMap(nodelist []apis.ZFSNode, pattern *regexp.Regexp) map[string]int64 {
+	nmap := map[string]int64{}
+
+	for _, node := range nodelist {
+		pool, free := maxFreePool(node.Pools, pattern)
+		if pool == "" {
+			continue
+		}
+		// the scheduler prefers the node with the lowest weight, so the free
+		// capacity is inverted: the more space a node has left, the less loaded
+		// it looks. A node whose matching pool is full keeps its entry, at
+		// math.MaxInt64, so that it sorts last instead of being front loaded.
+		nmap[k8sNodeName(node)] = math.MaxInt64 - free
+	}
+
+	return nmap
+}
+
+// Returns the node mapping for the given scheduling algorithm
 func getNodeMap(schd string, pattern *regexp.Regexp) (map[string]int64, error) {
 	switch schd {
 	case VolumeWeighted:
 		return getVolumeWeightedMap(pattern)
 	case CapacityWeighted:
 		return getCapacityWeightedMap(pattern)
+	case SpaceWeighted:
+		return getSpaceWeightedMap(pattern)
 	}
 	// return CapacityWeighted(default) if not specified
 	return getCapacityWeightedMap(pattern)
@@ -216,17 +254,12 @@ func suitableNodes(nodelist []apis.ZFSNode, pattern *regexp.Regexp, size int64) 
 	matched := false
 
 	for _, node := range nodelist {
-		var maxFree int64
-		for _, pool := range node.Pools {
-			if !pattern.MatchString(pool.Name) {
-				continue
-			}
-			matched = true
-			if free := pool.Free.Value(); free > maxFree {
-				maxFree = free
-			}
+		pool, free := maxFreePool(node.Pools, pattern)
+		if pool == "" {
+			continue
 		}
-		if maxFree > size {
+		matched = true
+		if free > size {
 			suitable[k8sNodeName(node)] = true
 		}
 	}
@@ -247,10 +280,15 @@ func resolvePool(nodeid string, pattern *regexp.Regexp) (string, error) {
 		return "", err
 	}
 
-	return poolForNode(zfsNode.Pools, pattern), nil
+	pool, _ := maxFreePool(zfsNode.Pools, pattern)
+	return pool, nil
 }
 
-func poolForNode(pools []apis.Pool, pattern *regexp.Regexp) string {
+// Returns the pool matching the pattern with the most free capacity
+// along with that capacity, or an empty name when no pool matches. It is the one
+// definition of "the node's roomiest matching pool", shared by resolvePool,
+// suitableNodes and spaceWeightedMap.
+func maxFreePool(pools []apis.Pool, pattern *regexp.Regexp) (string, int64) {
 	var (
 		selected string
 		maxFree  int64
@@ -265,5 +303,5 @@ func poolForNode(pools []apis.Pool, pattern *regexp.Regexp) string {
 		}
 	}
 
-	return selected
+	return selected, maxFree
 }

--- a/pkg/driver/schd_helper.go
+++ b/pkg/driver/schd_helper.go
@@ -17,10 +17,16 @@ limitations under the License.
 package driver
 
 import (
-	"github.com/openebs/zfs-localpv/pkg/builder/volbuilder"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strconv"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apis "github.com/openebs/zfs-localpv/pkg/apis/openebs.io/zfs/v1"
+	"github.com/openebs/zfs-localpv/pkg/builder/nodebuilder"
+	"github.com/openebs/zfs-localpv/pkg/builder/volbuilder"
 	zfs "github.com/openebs/zfs-localpv/pkg/zfs"
 )
 
@@ -29,75 +35,230 @@ const (
 	// pick the node where less volumes are provisioned for the given pool
 	VolumeWeighted = "VolumeWeighted"
 
-	// pick the node where total provisioned volumes have occupied less capacity from the given pool
+	// pick the node where the matching pools have occupied less capacity
 	// this will be the default scheduler when none provided
 	CapacityWeighted = "CapacityWeighted"
 )
 
-// getVolumeWeightedMap goes through all the pools on all the nodes
-// and creates the node mapping of the volume for all the nodes.
+// The node keys used by all the helpers below are the node IDs (the value of
+// the openebs.io/nodeid topology label), which is what ZFSVolume records in
+// Spec.OwnerNodeID and what the ZFSNode CR is named after. Note that lib-csi's
+// scheduler works with kubernetes node *names*, so the caller has to map a node
+// name to its node ID (zfs.GetNodeID) before looking it up in the suitable set
+// or asking resolvePool for the concrete pool.
+
+// Returns the pool part of a "poolname" parameter, which may name a
+// pool ("zpool") or a dataset below it ("zpool/k8s/localpv").
+func poolRoot(poolname string) string {
+	return strings.SplitN(poolname, "/", 2)[0]
+}
+
+// Folds the "poolname" and "poolpattern" storageclass
+// parameters into one regular expression matched against pool roots. Exactly one
+// of them must be set: poolpattern compiles as given, poolname as an anchored
+// exact match.
+func compilePoolPattern(poolname, poolpattern string) (*regexp.Regexp, error) {
+	switch {
+	case poolname != "" && poolpattern != "":
+		return nil, errors.New("poolname and poolpattern are mutually exclusive, set only one of them")
+	case poolpattern != "":
+		pattern, err := regexp.Compile(poolpattern)
+		if err != nil {
+			return nil, fmt.Errorf("invalid poolpattern %q : %w", poolpattern, err)
+		}
+		return pattern, nil
+	case poolname != "":
+		// quoting is required for correctness: legal ZFS pool names contain
+		// regex metacharacters, so an unescaped "tank.prod" would also match
+		// "tankXprod" and select the wrong pool
+		return regexp.MustCompile("^" + regexp.QuoteMeta(poolRoot(poolname)) + "$"), nil
+	}
+	return nil, errors.New("either poolname or poolpattern must be set")
+}
+
+// Reports whether the volume gets a ZFS reservation and so has to
+// fit in a pool's free capacity at create time. A zvol reserves unless it is
+// created sparse; a dataset carries a quota, which is a limit and not a
+// reservation, and reserves only when thinprovision is "no".
+func reservesSpace(vtype, thinProvision string) bool {
+	if thinProvision == "no" {
+		return true
+	}
+	return vtype != zfs.VolTypeDataset && thinProvision != "yes"
+}
+
+// Returns the ZFSNode CRs, which advertise the pools present on
+// every node along with their free and used capacity.
+func listZFSNodes() ([]apis.ZFSNode, error) {
+	nodelist, err := nodebuilder.NewKubeclient().
+		WithNamespace(zfs.OpenEBSNamespace).
+		List(metav1.ListOptions{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return nodelist.Items, nil
+}
+
+// getVolumeWeightedMap goes through all the volumes provisioned into a pool
+// matching the pattern and creates the node mapping of the volume count.
 // It returns a map which has nodes as key and volumes present
 // on the nodes as corresponding value.
-func getVolumeWeightedMap(pool string) (map[string]int64, error) {
-	nmap := map[string]int64{}
-
+//
+// This is an ordering input for the scheduler only, it does not decide whether
+// a node can hold the volume, see getSuitableNodes for that.
+func getVolumeWeightedMap(pattern *regexp.Regexp) (map[string]int64, error) {
 	zvlist, err := volbuilder.NewKubeclient().
 		WithNamespace(zfs.OpenEBSNamespace).
 		List(metav1.ListOptions{})
 
 	if err != nil {
-		return nmap, err
+		return map[string]int64{}, err
 	}
 
-	// create the map of the volume count
-	// for the given pool
-	for _, zv := range zvlist.Items {
-		if zv.Spec.PoolName == pool {
+	return volumeWeightedMap(zvlist.Items, pattern), nil
+}
+
+func volumeWeightedMap(zvlist []apis.ZFSVolume, pattern *regexp.Regexp) map[string]int64 {
+	nmap := map[string]int64{}
+
+	// create the map of the volume count for the matching pools
+	for _, zv := range zvlist {
+		if pattern.MatchString(poolRoot(zv.Spec.PoolName)) {
 			nmap[zv.Spec.OwnerNodeID]++
 		}
 	}
 
-	return nmap, nil
+	return nmap
 }
 
-// getCapacityWeightedMap goes through all the pools on all the nodes
-// and creates the node mapping of the capacity for all the nodes.
-// It returns a map which has nodes as key and capacity provisioned
-// on the nodes as corresponding value. The scheduler will use this map
+// getCapacityWeightedMap goes through the pools advertised by every node and
+// creates the node mapping of the capacity used by the pools matching the
+// pattern. It returns a map which has nodes as key and the used capacity of
+// the matching pools as corresponding value. The scheduler will use this map
 // and picks the node which is less weighted.
-func getCapacityWeightedMap(pool string) (map[string]int64, error) {
-	nmap := map[string]int64{}
-
-	zvlist, err := volbuilder.NewKubeclient().
-		WithNamespace(zfs.OpenEBSNamespace).
-		List(metav1.ListOptions{})
-
+//
+// The weight is the pool's real on disk usage as reported by the ZFSNode CR,
+// so it also accounts for the data which was not provisioned by this driver.
+// Every node with a matching pool gets an entry, even when the pools are empty,
+// so that the ordering is not distorted: lib-csi's scheduler moves the nodes
+// missing from the map to the front of the list.
+func getCapacityWeightedMap(pattern *regexp.Regexp) (map[string]int64, error) {
+	nodelist, err := listZFSNodes()
 	if err != nil {
-		return nmap, err
+		return map[string]int64{}, err
 	}
 
-	// create the map of the volume capacity
-	// for the given pool
-	for _, zv := range zvlist.Items {
-		if zv.Spec.PoolName == pool {
-			volsize, err := strconv.ParseInt(zv.Spec.Capacity, 10, 64)
-			if err == nil {
-				nmap[zv.Spec.OwnerNodeID] += volsize
+	return capacityWeightedMap(nodelist, pattern), nil
+}
+
+func capacityWeightedMap(nodelist []apis.ZFSNode, pattern *regexp.Regexp) map[string]int64 {
+	nmap := map[string]int64{}
+
+	for _, node := range nodelist {
+		for _, pool := range node.Pools {
+			if pattern.MatchString(pool.Name) {
+				nmap[node.Name] += pool.Used.Value()
 			}
 		}
 	}
 
-	return nmap, nil
+	return nmap
 }
 
 // getNodeMap returns the node mapping for the given scheduling algorithm
-func getNodeMap(schd string, pool string) (map[string]int64, error) {
+func getNodeMap(schd string, pattern *regexp.Regexp) (map[string]int64, error) {
 	switch schd {
 	case VolumeWeighted:
-		return getVolumeWeightedMap(pool)
+		return getVolumeWeightedMap(pattern)
 	case CapacityWeighted:
-		return getCapacityWeightedMap(pool)
+		return getCapacityWeightedMap(pattern)
 	}
 	// return CapacityWeighted(default) if not specified
-	return getCapacityWeightedMap(pool)
+	return getCapacityWeightedMap(pattern)
+}
+
+// getSuitableNodes returns the set of nodes which have a pool matching the
+// pattern with more than `size` bytes free, along with `matched`, which tells
+// whether any pool matched the pattern at all, the fit aside.
+//
+// A single pool has to hold the whole reservation, the free capacity is not
+// summed across the pools of a node. The caller intersects this set with the
+// node list returned by the scheduler for the volumes which reserve space (see
+// reservesSpace), and uses `matched` to tell an exhausted pool (matched, but
+// nothing fits) apart from a storageclass which names a pool that does not
+// exist anywhere (not matched).
+//
+// The check is best effort: the free capacity on the ZFSNode CR is a periodic
+// snapshot and two concurrent creates can both pass it, so "zfs create" stays
+// the final arbiter.
+func getSuitableNodes(pattern *regexp.Regexp, size int64) (map[string]bool, bool, error) {
+	nodelist, err := listZFSNodes()
+	if err != nil {
+		return nil, false, err
+	}
+
+	suitable, matched := suitableNodes(nodelist, pattern, size)
+	return suitable, matched, nil
+}
+
+func suitableNodes(nodelist []apis.ZFSNode, pattern *regexp.Regexp, size int64) (map[string]bool, bool) {
+	suitable := map[string]bool{}
+	matched := false
+
+	for _, node := range nodelist {
+		var maxFree int64
+		for _, pool := range node.Pools {
+			if !pattern.MatchString(pool.Name) {
+				continue
+			}
+			matched = true
+			if free := pool.Free.Value(); free > maxFree {
+				maxFree = free
+			}
+		}
+		if maxFree > size {
+			suitable[node.Name] = true
+		}
+	}
+
+	return suitable, matched
+}
+
+// resolvePool returns the pool matching the pattern on the given node which has
+// the most free capacity, or an empty string when no pool on the node matches.
+//
+// This is how a poolpattern is turned into the concrete pool stored in
+// ZFSVolume.Spec.PoolName. It is not used for the fixed poolname case, where
+// the parameter is used as it is, since it can carry a dataset path
+// ("zpool/k8s/localpv") which the ZFSNode CR does not advertise.
+func resolvePool(node string, pattern *regexp.Regexp) (string, error) {
+	zfsNode, err := nodebuilder.NewKubeclient().
+		WithNamespace(zfs.OpenEBSNamespace).
+		Get(node, metav1.GetOptions{})
+
+	if err != nil {
+		return "", err
+	}
+
+	return poolForNode(zfsNode.Pools, pattern), nil
+}
+
+func poolForNode(pools []apis.Pool, pattern *regexp.Regexp) string {
+	var (
+		selected string
+		maxFree  int64
+	)
+
+	for _, pool := range pools {
+		if !pattern.MatchString(pool.Name) {
+			continue
+		}
+		if free := pool.Free.Value(); selected == "" || free > maxFree {
+			selected, maxFree = pool.Name, free
+		}
+	}
+
+	return selected
 }

--- a/pkg/driver/schd_helper_test.go
+++ b/pkg/driver/schd_helper_test.go
@@ -1,7 +1,9 @@
 package driver
 
 import (
+	"math"
 	"regexp"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -311,6 +313,86 @@ func TestCapacityWeightedMapCustomNodeID(t *testing.T) {
 	assert.Equal(t, map[string]int64{"node1": 10 * Gi, "node2": 30 * Gi}, nmap)
 }
 
+func TestSpaceWeightedMap(t *testing.T) {
+	nodelist := []apis.ZFSNode{
+		newZFSNode("node1", newPool("zfspv-pool-a", 90*Gi, 10*Gi), newPool("other-pool", 500*Gi, 0)),
+		// the roomiest matching pool decides, the free capacity of a node's
+		// pools is not summed: node2 has 100Gi free in total but no single pool
+		// with more than 60Gi
+		newZFSNode("node2", newPool("zfspv-pool-b", 60*Gi, 40*Gi), newPool("zfspv-pool-c", 40*Gi, 60*Gi)),
+		// a node whose only matching pool is full keeps its entry, so that the
+		// scheduler sorts it last instead of treating it as unweighted and
+		// moving it to the front
+		newZFSNode("node3", newPool("zfspv-pool-d", 0, 100*Gi)),
+		newZFSNode("node4", newPool("other-pool", 100*Gi, 0)),
+	}
+
+	tests := map[string]struct {
+		pattern  string
+		expected map[string]int64
+	}{
+		"free capacity is inverted into a weight": {
+			pattern: "^zfspv-pool-",
+			expected: map[string]int64{
+				"node1": math.MaxInt64 - 90*Gi,
+				"node2": math.MaxInt64 - 60*Gi,
+				"node3": math.MaxInt64,
+			},
+		},
+		"only the matching pool counts": {
+			pattern:  "^other-pool$",
+			expected: map[string]int64{"node1": math.MaxInt64 - 500*Gi, "node4": math.MaxInt64 - 100*Gi},
+		},
+		"no match": {
+			pattern:  "^nosuch$",
+			expected: map[string]int64{},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			nmap := spaceWeightedMap(nodelist, regexp.MustCompile(test.pattern))
+			assert.Equal(t, test.expected, nmap)
+		})
+	}
+}
+
+// the weight is only useful if lib-csi's ascending sort turns it back into
+// most-free-first, which is what the inversion is there for
+func TestSpaceWeightedMapOrdersByMostFree(t *testing.T) {
+	nodelist := []apis.ZFSNode{
+		newZFSNode("half-full", newPool("zfspv-pool-a", 50*Gi, 50*Gi)),
+		newZFSNode("full", newPool("zfspv-pool-b", 0, 100*Gi)),
+		newZFSNode("empty", newPool("zfspv-pool-c", 100*Gi, 0)),
+	}
+
+	nmap := spaceWeightedMap(nodelist, regexp.MustCompile("^zfspv-pool-"))
+
+	nodes := make([]string, 0, len(nmap))
+	for node := range nmap {
+		nodes = append(nodes, node)
+	}
+	sort.Slice(nodes, func(i, j int) bool { return nmap[nodes[i]] < nmap[nodes[j]] })
+
+	assert.Equal(t, []string{"empty", "half-full", "full"}, nodes)
+}
+
+// with a custom node id the ZFSNode CR is named after the id, but the weight
+// still has to be keyed by the node name for lib-csi to find it
+func TestSpaceWeightedMapCustomNodeID(t *testing.T) {
+	nodelist := []apis.ZFSNode{
+		newCustomIDZFSNode("node1-custom-id", "node1", newPool("zfspv-pool-a", 90*Gi, 10*Gi)),
+		newCustomIDZFSNode("node2-custom-id", "node2", newPool("zfspv-pool-b", 70*Gi, 30*Gi)),
+	}
+
+	nmap := spaceWeightedMap(nodelist, regexp.MustCompile("^zfspv-pool-"))
+
+	assert.Equal(t, map[string]int64{
+		"node1": math.MaxInt64 - 90*Gi,
+		"node2": math.MaxInt64 - 70*Gi,
+	}, nmap)
+}
+
 func TestSuitableNodes(t *testing.T) {
 	nodelist := []apis.ZFSNode{
 		newZFSNode("node1", newPool("zfspv-pool-a", 10*Gi, 90*Gi)),
@@ -383,26 +465,30 @@ func TestSuitableNodesCustomNodeID(t *testing.T) {
 	assert.True(t, matched)
 }
 
-func TestPoolForNode(t *testing.T) {
+func TestMaxFreePool(t *testing.T) {
 	tests := map[string]struct {
-		pools    []apis.Pool
-		pattern  string
-		expected string
+		pools        []apis.Pool
+		pattern      string
+		expected     string
+		expectedFree int64
 	}{
 		"the matching pool with the most free capacity wins": {
-			pools:    []apis.Pool{newPool("zfspv-pool-a", 10*Gi, 90*Gi), newPool("zfspv-pool-b", 60*Gi, 40*Gi), newPool("zfspv-pool-c", 30*Gi, 70*Gi)},
-			pattern:  "^zfspv-pool-",
-			expected: "zfspv-pool-b",
+			pools:        []apis.Pool{newPool("zfspv-pool-a", 10*Gi, 90*Gi), newPool("zfspv-pool-b", 60*Gi, 40*Gi), newPool("zfspv-pool-c", 30*Gi, 70*Gi)},
+			pattern:      "^zfspv-pool-",
+			expected:     "zfspv-pool-b",
+			expectedFree: 60 * Gi,
 		},
 		"a bigger non matching pool is ignored": {
-			pools:    []apis.Pool{newPool("zfspv-pool-a", 10*Gi, 90*Gi), newPool("other-pool", 90*Gi, 10*Gi)},
-			pattern:  "^zfspv-pool-",
-			expected: "zfspv-pool-a",
+			pools:        []apis.Pool{newPool("zfspv-pool-a", 10*Gi, 90*Gi), newPool("other-pool", 90*Gi, 10*Gi)},
+			pattern:      "^zfspv-pool-",
+			expected:     "zfspv-pool-a",
+			expectedFree: 10 * Gi,
 		},
 		"a full matching pool is still selected": {
-			pools:    []apis.Pool{newPool("zfspv-pool-a", 0, 100*Gi)},
-			pattern:  "^zfspv-pool-",
-			expected: "zfspv-pool-a",
+			pools:        []apis.Pool{newPool("zfspv-pool-a", 0, 100*Gi)},
+			pattern:      "^zfspv-pool-",
+			expected:     "zfspv-pool-a",
+			expectedFree: 0,
 		},
 		"no pool matches": {
 			pools:    []apis.Pool{newPool("other-pool", 90*Gi, 10*Gi)},
@@ -418,7 +504,9 @@ func TestPoolForNode(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, test.expected, poolForNode(test.pools, regexp.MustCompile(test.pattern)))
+			pool, free := maxFreePool(test.pools, regexp.MustCompile(test.pattern))
+			assert.Equal(t, test.expected, pool)
+			assert.Equal(t, test.expectedFree, free)
 		})
 	}
 }

--- a/pkg/driver/schd_helper_test.go
+++ b/pkg/driver/schd_helper_test.go
@@ -1,0 +1,315 @@
+package driver
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apis "github.com/openebs/zfs-localpv/pkg/apis/openebs.io/zfs/v1"
+	zfs "github.com/openebs/zfs-localpv/pkg/zfs"
+)
+
+// Builds a ZFSNode pool entry with the given free/used capacity in bytes.
+func newPool(name string, free, used int64) apis.Pool {
+	return apis.Pool{
+		Name: name,
+		UUID: name + "-uuid",
+		Free: *resource.NewQuantity(free, resource.BinarySI),
+		Used: *resource.NewQuantity(used, resource.BinarySI),
+	}
+}
+
+func newZFSNode(name string, pools ...apis.Pool) apis.ZFSNode {
+	return apis.ZFSNode{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "openebs"},
+		Pools:      pools,
+	}
+}
+
+func newZFSVolume(node, poolname string) apis.ZFSVolume {
+	return apis.ZFSVolume{
+		Spec: apis.VolumeInfo{
+			OwnerNodeID: node,
+			PoolName:    poolname,
+		},
+	}
+}
+
+func TestPoolRoot(t *testing.T) {
+	tests := map[string]struct {
+		input    string
+		expected string
+	}{
+		"pool name":            {input: "zfspv-pool", expected: "zfspv-pool"},
+		"dataset path":         {input: "zpool/k8s/localpv", expected: "zpool"},
+		"single child dataset": {input: "zpool/localpv", expected: "zpool"},
+		"empty":                {input: "", expected: ""},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, poolRoot(test.input))
+		})
+	}
+}
+
+func TestCompilePoolPattern(t *testing.T) {
+	tests := map[string]struct {
+		poolname    string
+		poolpattern string
+		matches     []string
+		notMatches  []string
+		wantErr     bool
+	}{
+		"exact poolname": {
+			poolname:   "zfspv-pool",
+			matches:    []string{"zfspv-pool"},
+			notMatches: []string{"zfspv-pool-a", "my-zfspv-pool", "zfspv"},
+		},
+		"poolname metacharacters are quoted": {
+			poolname:   "tank.prod",
+			matches:    []string{"tank.prod"},
+			notMatches: []string{"tankXprod", "tank-prod"},
+		},
+		"poolname is matched against its root": {
+			poolname:   "zpool/k8s/localpv",
+			matches:    []string{"zpool"},
+			notMatches: []string{"zpool/k8s/localpv", "zpool2"},
+		},
+		"poolpattern is unanchored": {
+			poolpattern: "zfspv-pool",
+			matches:     []string{"zfspv-pool", "zfspv-pool-a", "my-zfspv-pool"},
+			notMatches:  []string{"zfspv"},
+		},
+		"poolpattern anchored by the user": {
+			poolpattern: "^zfspv-pool-[ab]$",
+			matches:     []string{"zfspv-pool-a", "zfspv-pool-b"},
+			notMatches:  []string{"zfspv-pool", "zfspv-pool-c"},
+		},
+		"both set is rejected":    {poolname: "zfspv-pool", poolpattern: "zfspv-pool.*", wantErr: true},
+		"neither set is rejected": {wantErr: true},
+		"invalid regex":           {poolpattern: "zfspv-pool[", wantErr: true},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			pattern, err := compilePoolPattern(test.poolname, test.poolpattern)
+			if test.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			for _, p := range test.matches {
+				assert.True(t, pattern.MatchString(p), "%q should match %s", p, pattern)
+			}
+			for _, p := range test.notMatches {
+				assert.False(t, pattern.MatchString(p), "%q should not match %s", p, pattern)
+			}
+		})
+	}
+}
+
+func TestReservesSpace(t *testing.T) {
+	zvol := zfs.VolTypeZVol
+	dataset := zfs.VolTypeDataset
+
+	tests := map[string]struct {
+		vtype         string
+		thinProvision string
+		expected      bool
+	}{
+		// a zvol gets ZFS's default refreservation unless it is sparse
+		"zvol, thinprovision unset": {vtype: zvol, thinProvision: "", expected: true},
+		"zvol, thinprovision no":    {vtype: zvol, thinProvision: "no", expected: true},
+		"zvol, thinprovision yes":   {vtype: zvol, thinProvision: "yes", expected: false},
+		// a dataset only gets a reservation on top of its quota when asked for
+		"dataset, thinprovision unset": {vtype: dataset, thinProvision: "", expected: false},
+		"dataset, thinprovision no":    {vtype: dataset, thinProvision: "no", expected: true},
+		"dataset, thinprovision yes":   {vtype: dataset, thinProvision: "yes", expected: false},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, reservesSpace(test.vtype, test.thinProvision))
+		})
+	}
+}
+
+func TestVolumeWeightedMap(t *testing.T) {
+	zvlist := []apis.ZFSVolume{
+		newZFSVolume("node1", "zfspv-pool-a"),
+		newZFSVolume("node1", "zfspv-pool-a"),
+		newZFSVolume("node1", "other-pool"),
+		newZFSVolume("node2", "zfspv-pool-b"),
+		// dataset paths are counted against their pool root
+		newZFSVolume("node2", "zfspv-pool-b/k8s/localpv"),
+		newZFSVolume("node3", "other-pool"),
+	}
+
+	tests := map[string]struct {
+		pattern  string
+		expected map[string]int64
+	}{
+		"pattern spanning both pools": {
+			pattern:  "^zfspv-pool-.*",
+			expected: map[string]int64{"node1": 2, "node2": 2},
+		},
+		"exact pool": {
+			pattern:  "^zfspv-pool-a$",
+			expected: map[string]int64{"node1": 1 + 1},
+		},
+		"no match": {
+			pattern:  "^nosuch$",
+			expected: map[string]int64{},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			nmap := volumeWeightedMap(zvlist, regexp.MustCompile(test.pattern))
+			assert.Equal(t, test.expected, nmap)
+		})
+	}
+}
+
+func TestCapacityWeightedMap(t *testing.T) {
+	nodelist := []apis.ZFSNode{
+		newZFSNode("node1", newPool("zfspv-pool-a", 90*Gi, 10*Gi), newPool("other-pool", 50*Gi, 50*Gi)),
+		newZFSNode("node2", newPool("zfspv-pool-b", 70*Gi, 30*Gi), newPool("zfspv-pool-c", 95*Gi, 5*Gi)),
+		// a node with a matching but completely empty pool still gets an entry,
+		// otherwise the scheduler would move it to the front of the list
+		newZFSNode("node3", newPool("zfspv-pool-d", 100*Gi, 0)),
+		newZFSNode("node4", newPool("other-pool", 100*Gi, 0)),
+	}
+
+	tests := map[string]struct {
+		pattern  string
+		expected map[string]int64
+	}{
+		"used capacity is summed over the matching pools": {
+			pattern: "^zfspv-pool-",
+			expected: map[string]int64{
+				"node1": 10 * Gi,
+				"node2": 30*Gi + 5*Gi,
+				"node3": 0,
+			},
+		},
+		"only the matching pool counts": {
+			pattern:  "^other-pool$",
+			expected: map[string]int64{"node1": 50 * Gi, "node4": 0},
+		},
+		"no match": {
+			pattern:  "^nosuch$",
+			expected: map[string]int64{},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			nmap := capacityWeightedMap(nodelist, regexp.MustCompile(test.pattern))
+			assert.Equal(t, test.expected, nmap)
+		})
+	}
+}
+
+func TestSuitableNodes(t *testing.T) {
+	nodelist := []apis.ZFSNode{
+		newZFSNode("node1", newPool("zfspv-pool-a", 10*Gi, 90*Gi)),
+		// free capacity is not summed across the pools of a node, a single pool
+		// has to hold the whole reservation
+		newZFSNode("node2", newPool("zfspv-pool-b", 15*Gi, 85*Gi), newPool("zfspv-pool-c", 15*Gi, 85*Gi)),
+		newZFSNode("node3", newPool("zfspv-pool-d", 5*Gi, 95*Gi), newPool("zfspv-pool-e", 40*Gi, 60*Gi)),
+		newZFSNode("node4", newPool("other-pool", 100*Gi, 0)),
+	}
+
+	tests := map[string]struct {
+		pattern     string
+		size        int64
+		expected    map[string]bool
+		wantMatched bool
+	}{
+		"largest free pool of a node decides": {
+			pattern:     "^zfspv-pool-",
+			size:        20 * Gi,
+			expected:    map[string]bool{"node3": true},
+			wantMatched: true,
+		},
+		"every node fits a small volume": {
+			pattern:     "^zfspv-pool-",
+			size:        1 * Gi,
+			expected:    map[string]bool{"node1": true, "node2": true, "node3": true},
+			wantMatched: true,
+		},
+		"a pool matches but nothing fits": {
+			pattern:     "^zfspv-pool-",
+			size:        100 * Gi,
+			expected:    map[string]bool{},
+			wantMatched: true,
+		},
+		"a volume of exactly the free capacity does not fit": {
+			pattern:     "^zfspv-pool-a$",
+			size:        10 * Gi,
+			expected:    map[string]bool{},
+			wantMatched: true,
+		},
+		"no pool matches the pattern": {
+			pattern:     "^nosuch",
+			size:        1 * Gi,
+			expected:    map[string]bool{},
+			wantMatched: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			suitable, matched := suitableNodes(nodelist, regexp.MustCompile(test.pattern), test.size)
+			assert.Equal(t, test.expected, suitable)
+			assert.Equal(t, test.wantMatched, matched)
+		})
+	}
+}
+
+func TestPoolForNode(t *testing.T) {
+	tests := map[string]struct {
+		pools    []apis.Pool
+		pattern  string
+		expected string
+	}{
+		"the matching pool with the most free capacity wins": {
+			pools:    []apis.Pool{newPool("zfspv-pool-a", 10*Gi, 90*Gi), newPool("zfspv-pool-b", 60*Gi, 40*Gi), newPool("zfspv-pool-c", 30*Gi, 70*Gi)},
+			pattern:  "^zfspv-pool-",
+			expected: "zfspv-pool-b",
+		},
+		"a bigger non matching pool is ignored": {
+			pools:    []apis.Pool{newPool("zfspv-pool-a", 10*Gi, 90*Gi), newPool("other-pool", 90*Gi, 10*Gi)},
+			pattern:  "^zfspv-pool-",
+			expected: "zfspv-pool-a",
+		},
+		"a full matching pool is still selected": {
+			pools:    []apis.Pool{newPool("zfspv-pool-a", 0, 100*Gi)},
+			pattern:  "^zfspv-pool-",
+			expected: "zfspv-pool-a",
+		},
+		"no pool matches": {
+			pools:    []apis.Pool{newPool("other-pool", 90*Gi, 10*Gi)},
+			pattern:  "^zfspv-pool-",
+			expected: "",
+		},
+		"node without pools": {
+			pools:    nil,
+			pattern:  "^zfspv-pool-",
+			expected: "",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, poolForNode(test.pools, regexp.MustCompile(test.pattern)))
+		})
+	}
+}

--- a/pkg/driver/schd_helper_test.go
+++ b/pkg/driver/schd_helper_test.go
@@ -23,10 +23,27 @@ func newPool(name string, free, used int64) apis.Pool {
 	}
 }
 
+// Builds a ZFSNode CR as the node agent does without a custom node
+// id: the CR is named after the node and owned by it, so name == id.
 func newZFSNode(name string, pools ...apis.Pool) apis.ZFSNode {
+	return newCustomIDZFSNode(name, name, pools...)
+}
+
+// Builds a ZFSNode CR for a node running with a custom node
+// id: the CR is named after the id, while the owner reference still names the
+// kubernetes node, which is what the scheduler works with.
+func newCustomIDZFSNode(nodeid, nodename string, pools ...apis.Pool) apis.ZFSNode {
 	return apis.ZFSNode{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "openebs"},
-		Pools:      pools,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nodeid,
+			Namespace: "openebs",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "v1",
+				Kind:       "Node",
+				Name:       nodename,
+			}},
+		},
+		Pools: pools,
 	}
 }
 
@@ -140,7 +157,46 @@ func TestReservesSpace(t *testing.T) {
 	}
 }
 
+func TestK8sNodeName(t *testing.T) {
+	tests := map[string]struct {
+		node     apis.ZFSNode
+		expected string
+	}{
+		"no custom node id, name == id": {
+			node:     newZFSNode("node1"),
+			expected: "node1",
+		},
+		"custom node id, the owner reference names the node": {
+			node:     newCustomIDZFSNode("node1-custom-id", "node1"),
+			expected: "node1",
+		},
+		"no owner reference falls back to the CR name": {
+			node:     apis.ZFSNode{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+			expected: "node1",
+		},
+		"a non node owner reference is ignored": {
+			node: apis.ZFSNode{ObjectMeta: metav1.ObjectMeta{
+				Name:            "node1-custom-id",
+				OwnerReferences: []metav1.OwnerReference{{Kind: "Pod", Name: "some-pod"}},
+			}},
+			expected: "node1-custom-id",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, k8sNodeName(test.node))
+		})
+	}
+}
+
 func TestVolumeWeightedMap(t *testing.T) {
+	nodelist := []apis.ZFSNode{
+		newZFSNode("node1"),
+		newZFSNode("node2"),
+		newZFSNode("node3"),
+	}
+
 	zvlist := []apis.ZFSVolume{
 		newZFSVolume("node1", "zfspv-pool-a"),
 		newZFSVolume("node1", "zfspv-pool-a"),
@@ -171,10 +227,34 @@ func TestVolumeWeightedMap(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			nmap := volumeWeightedMap(zvlist, regexp.MustCompile(test.pattern))
+			nmap := volumeWeightedMap(zvlist, nodelist, regexp.MustCompile(test.pattern))
 			assert.Equal(t, test.expected, nmap)
 		})
 	}
+}
+
+// the volume count has to land under the node NAME, since that is what lib-csi's
+// scheduler looks up, while a volume records the node ID of its node
+func TestVolumeWeightedMapCustomNodeID(t *testing.T) {
+	nodelist := []apis.ZFSNode{
+		newCustomIDZFSNode("node1-custom-id", "node1"),
+		newCustomIDZFSNode("node2-custom-id", "node2"),
+	}
+	zvlist := []apis.ZFSVolume{
+		newZFSVolume("node1-custom-id", "zfspv-pool-a"),
+		newZFSVolume("node1-custom-id", "zfspv-pool-a"),
+		newZFSVolume("node2-custom-id", "zfspv-pool-b"),
+		// a volume whose node has no ZFSNode CR falls back to its node id
+		newZFSVolume("node3-custom-id", "zfspv-pool-c"),
+	}
+
+	nmap := volumeWeightedMap(zvlist, nodelist, regexp.MustCompile("^zfspv-pool-"))
+
+	assert.Equal(t, map[string]int64{
+		"node1":           2,
+		"node2":           1,
+		"node3-custom-id": 1,
+	}, nmap)
 }
 
 func TestCapacityWeightedMap(t *testing.T) {
@@ -215,6 +295,20 @@ func TestCapacityWeightedMap(t *testing.T) {
 			assert.Equal(t, test.expected, nmap)
 		})
 	}
+}
+
+// with a custom node id the ZFSNode CR is named after the id, but the weight
+// still has to be keyed by the node name, otherwise lib-csi finds no key, treats
+// every node as least loaded and the weighting silently stops working
+func TestCapacityWeightedMapCustomNodeID(t *testing.T) {
+	nodelist := []apis.ZFSNode{
+		newCustomIDZFSNode("node1-custom-id", "node1", newPool("zfspv-pool-a", 90*Gi, 10*Gi)),
+		newCustomIDZFSNode("node2-custom-id", "node2", newPool("zfspv-pool-b", 70*Gi, 30*Gi)),
+	}
+
+	nmap := capacityWeightedMap(nodelist, regexp.MustCompile("^zfspv-pool-"))
+
+	assert.Equal(t, map[string]int64{"node1": 10 * Gi, "node2": 30 * Gi}, nmap)
 }
 
 func TestSuitableNodes(t *testing.T) {
@@ -272,6 +366,21 @@ func TestSuitableNodes(t *testing.T) {
 			assert.Equal(t, test.wantMatched, matched)
 		})
 	}
+}
+
+// the suitable set is intersected with the scheduler's output, which holds node
+// names, so a custom node id must not leak into it — keying it by the id would
+// intersect to nothing and fail every space reserving volume
+func TestSuitableNodesCustomNodeID(t *testing.T) {
+	nodelist := []apis.ZFSNode{
+		newCustomIDZFSNode("node1-custom-id", "node1", newPool("zfspv-pool-a", 40*Gi, 60*Gi)),
+		newCustomIDZFSNode("node2-custom-id", "node2", newPool("zfspv-pool-b", 5*Gi, 95*Gi)),
+	}
+
+	suitable, matched := suitableNodes(nodelist, regexp.MustCompile("^zfspv-pool-"), 20*Gi)
+
+	assert.Equal(t, map[string]bool{"node1": true}, suitable)
+	assert.True(t, matched)
 }
 
 func TestPoolForNode(t *testing.T) {


### PR DESCRIPTION
## Summary

Reworks the scheduler helpers in `pkg/driver/schd_helper.go` so that a pool is
selected by a regular expression rather than an exact name, and adds a third
scheduling algorithm, `SpaceWeighted`. This is the first step towards the
`poolpattern` StorageClass parameter ([OEP-4268](https://github.com/openebs/openebs/issues/4268)); the parameter itself is not read
yet, see [Left unwired](#left-unwired).

## What this PR does

**One matching path for `poolname` and `poolpattern`.** Both fold into a single
`*regexp.Regexp` via `compilePoolPattern`, so every helper matches the same way.
`poolpattern` compiles as given (unanchored RE2, the same semantics as
lvm-localpv's `vgpattern`); `poolname` compiles as an anchored, `QuoteMeta`-quoted
exact match. The quoting is required for correctness: legal ZFS pool names contain
regex metacharacters, so an unescaped `tank.prod` would also match `tankXprod` and
select the wrong pool. Names are matched against the **pool root**, since
`poolname` may be a `pool/dataset` path while the `ZFSNode` CR advertises
pool-level names only.

**`CapacityWeighted` weighs by real pool usage.** It now reads the `ZFSNode` CRs
and sums the on-disk `Used` of a node's matching pools, instead of summing the
capacity of the volumes this driver provisioned — so the ordering also accounts
for data that did not come through the driver. Every node with a matching pool
gets an entry even when its pools are empty, because lib-csi moves a node missing
from the weight map to the *front* of the list rather than dropping it.
`VolumeWeighted` still counts `ZFSVolume`s (the `ZFSNode` CR carries no volume
count) and matches on the pool root like everything else.

**New `SpaceWeighted` algorithm, opt-in.** `VolumeWeighted` and
`CapacityWeighted` both order by what has already been put *into* a pool, which
says nothing about what is *left*: a node with a small untouched pool outranks a
node with a large, moderately used one that has far more room. `SpaceWeighted`
orders by the free capacity of a node's roomiest matching pool — the same pool the
volume would land in. lib-csi prefers the least-weighted node, so free capacity is
inverted into a weight (`math.MaxInt64 - free`). Select it with
`scheduler: "SpaceWeighted"`; `CapacityWeighted` remains the default.

Unlike lvm-localpv's `SpaceWeighted`, a node whose matching pool is full keeps its
map entry (weight `math.MaxInt64`, sorting last) instead of being dropped —
omission promotes a node to the front under lib-csi, which would prefer exactly
the nodes with no room. Deciding whether a volume fits stays the job of the
suitable-node intersection.

**Weight maps are keyed by node name, not node id.** The map handed to lib-csi was
keyed from `ZFSVolume.Spec.OwnerNodeID`, while the scheduler looks nodes up by
their Kubernetes node name. Those coincide only when no custom node id is
configured; with one, no key ever matched, so the weighting silently stopped
having any effect and nodes came back in listing order. `k8sNodeName` reads the
owner reference the node agent maintains on the `ZFSNode` CR, falling back to the
CR name. This matters more for what comes next: the suitable-node set is going to
be intersected with the scheduler's output, and a set keyed by node id would
intersect to nothing and fail every space-reserving volume on a cluster with
plenty of room.

**Three helpers for the controller to consume next.**

- `reservesSpace` — whether a volume gets a ZFS reservation and so has to fit in a
  pool's free space: a zvol does unless it is sparse; a dataset only when
  `thinprovision: "no"`, since its quota is a limit rather than a reservation.
- `getSuitableNodes` — the nodes having a matching pool with more than the
  requested bytes free (a single pool must hold the whole reservation), plus
  whether any pool matched the pattern at all, so the controller can tell an
  exhausted pool from a StorageClass naming a pool that exists nowhere.
- `resolvePool` — the matching pool with the most free space on a given node,
  turning a pattern into the concrete pool stored in `ZFSVolume.Spec.PoolName`.

All three, and `SpaceWeighted`, share one `maxFreePool` helper so the three uses of
"the node's roomiest matching pool" cannot drift apart.

## Left unwired

Deliberately out of scope here, so this PR reviews as a self-contained helper
change:

- the `poolpattern` StorageClass parameter is not read; `CreateZFSVolume` is
  touched only as far as compiling the exact-name pattern for the changed
  `getNodeMap` signature
- `getSuitableNodes`, `resolvePool` and `reservesSpace` have no callers yet
- `GetCapacity`, the clone/snapshot-restore pool guard, and
  `validateVolumeCreateReq` are untouched
- user-facing docs still describe two scheduling algorithms

## Next in the series

The controller task wires the fresh-create path: read `poolpattern`, compute
`reservesSpace` once, intersect the scheduler's ordered node list with
`getSuitableNodes` for reserving volumes, and replace the generic
`codes.Internal, "scheduler failed, node list is empty"` with a capacity-aware
verdict — `ResourceExhausted` when a matching pool exists but nothing fits
(transient; external-provisioner retries with backoff and, with capacity
tracking, reschedules), `FailedPrecondition` when the pattern matches no pool
anywhere (a misconfigured StorageClass that retrying will never fix). It then
calls `resolvePool` per candidate node in the provisioning loop so
`Spec.PoolName` always names a pool present on the assigned node.

Then, as separate tasks: `GetCapacity` under `poolpattern`; the clone/snapshot
guard, which today rejects every clone under a pattern StorageClass because
`poolname` is empty; StorageClass validation; and docs plus samples.

## Behaviour change — needs a release note

Applying the `Used`-based `CapacityWeighted` metric uniformly means **existing
`poolname` StorageClasses change behaviour on upgrade with no opt-in**: node
ordering under the default scheduler shifts from driver-provisioned-sum to the
pool's real `Used`. OEP-4268 accepts this as an improvement — the scheduler now
reflects real capacity — but records that it must be called out in the release
notes.

`SpaceWeighted` is additive and opt-in, so it changes nothing for existing
StorageClasses.

## Testing

`pkg/driver/schd_helper_test.go` is new and covers: pool-root matching;
`QuoteMeta` anchoring for `poolname` (a `.` in a pool name must not over-match);
both-set and neither-set rejection; `Used`-based weighting under both existing
algorithms; `reservesSpace` across the zvol/dataset × `yes`/`no`/unset matrix;
`maxFreePool` selection including a full matching pool; suitable-node computation
including the exhausted-pool and no-match-anywhere cases; and for `SpaceWeighted`,
that the inverted weight sorts most-free-first under an ascending sort, that a
node's largest matching pool decides rather than the sum of its pools, and that a
node with a full matching pool keeps its entry instead of being front-loaded.
Node-name keying is asserted for every map via custom-node-id cases.

`make test` and `go vet ./pkg/...` are clean.

Worth running the BDD suite with `make ci profile=custom-node-id` (or
`profile=all`): the regular profile cannot exercise the node-name fix, since node
name and node id are equal there — only the custom-node-id profile relabels the
nodes.