### PR TITLE
feat(controller): provision into a pool matching poolpattern

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -248,6 +248,7 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 	kf := parameters["keyformat"]
 	kl := parameters["keylocation"]
 	pool := parameters["poolname"]
+	poolpattern := parameters["poolpattern"]
 	tp := parameters["thinprovision"]
 	schld := parameters["scheduler"]
 	fstype := parameters["fstype"]
@@ -280,7 +281,7 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 
 	// the pool parameters are matched as a single regular expression, an exact
 	// name being an anchored, quoted one
-	pattern, err := compilePoolPattern(pool, "")
+	pattern, err := compilePoolPattern(pool, poolpattern)
 	if err != nil {
 		return "", status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -304,6 +305,51 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 		return "", status.Error(codes.Internal, "scheduler failed, node list is empty for creating the PV")
 	}
 
+	reserves := reservesSpace(vtype, tp)
+
+	// resolvePool only picks among the pools which can hold the reservation
+	var minFree int64
+	if reserves {
+		minFree = size
+	}
+
+	// only a poolpattern or a reservation needs the pools the agents reported,
+	// so a thin volume on a fixed poolname never waits on that report
+	var suitable map[string]bool
+	if poolpattern != "" || reserves {
+		var matched bool
+		var serr error
+
+		suitable, matched, serr = getSuitableNodes(pattern, size)
+		if serr != nil {
+			return "", status.Errorf(codes.Internal, "get suitable nodes failed : %s", serr.Error())
+		}
+
+		// retrying will not fix a pattern which matches no pool anywhere. Only a
+		// poolpattern is held to this, since a fixed poolname is used as it is
+		// and "zfs create" stays its arbiter even when an agent is behind.
+		if poolpattern != "" && !matched {
+			return "", status.Errorf(codes.FailedPrecondition,
+				"no pool matching %s is present on any node, volume %s",
+				poolDesc(pool, poolpattern), volName)
+		}
+	}
+
+	// the scheduler orders the nodes but never drops one, so the nodes which
+	// cannot hold the reservation are filtered out of its output here. The fit
+	// is best effort: the capacity is the pool root's, ignoring a dataset quota
+	// under a poolname, and the ZFSNode capacity is a periodic snapshot, so a
+	// create which slips through still fails on the node and CSI retries.
+	if reserves {
+		if prfList = filterKeep(prfList, suitable); len(prfList) == 0 {
+			// the pools are there but full: external-provisioner retries with a
+			// backoff and reschedules once a node has room
+			return "", status.Errorf(codes.ResourceExhausted,
+				"no pool matching %s has %d bytes free, volume %s",
+				poolDesc(pool, poolpattern), size, volName)
+		}
+	}
+
 	volObj, err := volbuilder.NewBuilder().
 		WithName(volName).
 		WithPVCName(pvcName).
@@ -312,7 +358,6 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 		WithCapacity(capacity).
 		WithRecordSize(rs).
 		WithVolBlockSize(bs).
-		WithPoolName(pool).
 		WithDedup(dedup).
 		WithEncryption(encr).
 		WithKeyFormat(kf).
@@ -332,17 +377,44 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 		return "", status.Error(codes.Internal, err.Error())
 	}
 
-	klog.Infof("zfs: trying volume creation %s/%s on node %s", pool, volName, prfList)
+	klog.Infof("zfs: trying volume creation %s in %s on nodes %v", volName, poolDesc(pool, poolpattern), prfList)
 
 	// try volume creation sequentially on all nodes
 	for _, node := range prfList {
 		var nodeid string
 		nodeid, err = zfs.GetNodeID(node)
 		if err != nil {
+			klog.Warningf("zfs: volume %s skipping node %s, no node id : %s", volName, node, err.Error())
 			continue
 		}
 
-		vol, _ := volbuilder.BuildFrom(volObj).WithOwnerNodeID(nodeid).WithVolumeStatus(zfs.ZFSStatusPending).Build()
+		// a poolname is used as it is, since it can carry a dataset path the
+		// ZFSNode CR does not advertise. A poolpattern resolves against the
+		// pools of the node picked, so the agent finds the pool on it.
+		volPool := pool
+		if poolpattern != "" {
+			if volPool, err = resolvePool(schld, nodeid, pattern, minFree); err != nil {
+				klog.Warningf("zfs: volume %s skipping node %s, pool lookup failed : %s", volName, node, err.Error())
+				continue
+			}
+			if volPool == "" {
+				// only reachable when the volume was not fit filtered
+				err = fmt.Errorf("no pool matching poolpattern %q on node %s", poolpattern, node)
+				klog.Warningf("zfs: volume %s skipping node %s : %s", volName, node, err.Error())
+				continue
+			}
+		}
+
+		var vol *zfsapi.ZFSVolume
+		vol, err = volbuilder.BuildFrom(volObj).
+			WithOwnerNodeID(nodeid).
+			WithPoolName(volPool).
+			WithVolumeStatus(zfs.ZFSStatusPending).Build()
+		if err != nil {
+			continue
+		}
+
+		klog.Infof("zfs: creating volume %s/%s on node %s", volPool, volName, node)
 
 		timeout := false
 

--- a/pkg/driver/schd_helper.go
+++ b/pkg/driver/schd_helper.go
@@ -85,6 +85,15 @@ func compilePoolPattern(poolname, poolpattern string) (*regexp.Regexp, error) {
 	return nil, errors.New("either poolname or poolpattern must be set")
 }
 
+// Names the pool selector as the storageclass declares it, for the errors and
+// the logs, where the compiled pattern would read back as "^zpool$".
+func poolDesc(poolname, poolpattern string) string {
+	if poolpattern != "" {
+		return fmt.Sprintf("poolpattern %q", poolpattern)
+	}
+	return fmt.Sprintf("poolname %q", poolname)
+}
+
 // Reports whether the volume gets a ZFS reservation and so has to
 // fit in a pool's free capacity at create time. A zvol reserves unless it is
 // created sparse; a dataset carries a quota, which is a limit and not a
@@ -241,6 +250,13 @@ func getSuitableNodes(pattern *regexp.Regexp, size int64) (map[string]bool, bool
 		return nil, false, err
 	}
 
+	// no node has reported its pools yet, which is not the same thing as a
+	// storageclass naming a pool that is present nowhere: the caller must not
+	// report a transient state as a misconfiguration
+	if len(nodelist) == 0 {
+		return nil, false, errors.New("no ZFSNode found, the node agents have not reported their pools yet")
+	}
+
 	suitable, matched := suitableNodes(nodelist, pattern, size)
 	return suitable, matched, nil
 }
@@ -267,11 +283,26 @@ func suitableNodes(nodelist []apis.ZFSNode, pattern *regexp.Regexp, size int64) 
 	return suitable, matched
 }
 
-// Returns the matching pool with the most free capacity on the given
-// node, or an empty string when no pool on the node matches, turning a
-// poolpattern into the concrete pool stored in ZFSVolume.Spec.PoolName. `nodeid`
-// is the node id, since the ZFSNode CR is named after it.
-func resolvePool(nodeid string, pattern *regexp.Regexp) (string, error) {
+// Drops the nodes which are not in keep, preserving the order of the rest.
+// Omitting them from the weight map would not do: lib-csi takes its candidates
+// from the topology and front loads a node which the map does not mention.
+func filterKeep(nodes []string, keep map[string]bool) []string {
+	filtered := []string{}
+
+	for _, node := range nodes {
+		if keep[node] {
+			filtered = append(filtered, node)
+		}
+	}
+
+	return filtered
+}
+
+// Resolves a poolpattern to the pool stored in ZFSVolume.Spec.PoolName: the
+// one the scheduling algorithm prefers on the node, "" when none qualifies.
+// minFree is the volume size for a reserving volume and 0 otherwise. nodeid is
+// the node id, since the ZFSNode CR is named after it.
+func resolvePool(schd, nodeid string, pattern *regexp.Regexp, minFree int64) (string, error) {
 	zfsNode, err := nodebuilder.NewKubeclient().
 		WithNamespace(zfs.OpenEBSNamespace).
 		Get(nodeid, metav1.GetOptions{})
@@ -280,8 +311,89 @@ func resolvePool(nodeid string, pattern *regexp.Regexp) (string, error) {
 		return "", err
 	}
 
-	pool, _ := maxFreePool(zfsNode.Pools, pattern)
-	return pool, nil
+	pmap, err := getPoolMap(schd, nodeid, zfsNode.Pools)
+	if err != nil {
+		return "", err
+	}
+
+	return poolForNode(zfsNode.Pools, pattern, minFree, pmap), nil
+}
+
+// Returns the pool weights for the given scheduling algorithm, the per pool
+// counterpart of getNodeMap.
+func getPoolMap(schd, nodeid string, pools []apis.Pool) (map[string]int64, error) {
+	if schd == VolumeWeighted {
+		return getPoolVolumeMap(nodeid)
+	}
+
+	return poolWeightMap(schd, pools), nil
+}
+
+// Weighs each pool by its used capacity, or by its inverted free capacity
+// under SpaceWeighted, as spaceWeightedMap does for the nodes.
+func poolWeightMap(schd string, pools []apis.Pool) map[string]int64 {
+	pmap := map[string]int64{}
+
+	for _, pool := range pools {
+		// CapacityWeighted is the default, as in getNodeMap
+		weight := pool.Used.Value()
+		if schd == SpaceWeighted {
+			weight = math.MaxInt64 - pool.Free.Value()
+		}
+		pmap[pool.Name] = weight
+	}
+
+	return pmap
+}
+
+// Returns the volume count of each pool of a node.
+func getPoolVolumeMap(nodeid string) (map[string]int64, error) {
+	zvlist, err := volbuilder.NewKubeclient().
+		WithNamespace(zfs.OpenEBSNamespace).
+		List(metav1.ListOptions{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return poolVolumeMap(zvlist.Items, nodeid), nil
+}
+
+// Counts the volumes of one node per pool root.
+func poolVolumeMap(zvlist []apis.ZFSVolume, nodeid string) map[string]int64 {
+	pmap := map[string]int64{}
+
+	for _, zv := range zvlist {
+		if zv.Spec.OwnerNodeID == nodeid {
+			pmap[poolRoot(zv.Spec.PoolName)]++
+		}
+	}
+
+	return pmap
+}
+
+// Returns the matching pool with the lowest weight and more than minFree bytes
+// free, "" when none qualifies. A tie keeps the first pool, the lowest named
+// one, since the node agent lists the pools sorted by name.
+func poolForNode(pools []apis.Pool, pattern *regexp.Regexp, minFree int64, pmap map[string]int64) string {
+	var (
+		selected  string
+		selWeight int64
+	)
+
+	for _, pool := range pools {
+		if !pattern.MatchString(pool.Name) {
+			continue
+		}
+		if minFree > 0 && pool.Free.Value() <= minFree {
+			continue
+		}
+		if weight := pmap[pool.Name]; selected == "" || weight < selWeight {
+			selected, selWeight = pool.Name, weight
+		}
+	}
+
+	return selected
 }
 
 // Returns the pool matching the pattern with the most free capacity

--- a/pkg/driver/schd_helper_test.go
+++ b/pkg/driver/schd_helper_test.go
@@ -510,3 +510,198 @@ func TestMaxFreePool(t *testing.T) {
 		})
 	}
 }
+
+// the algorithm which orders the nodes has to order the pools of the chosen
+// node too, so that a storageclass is not given its node by one metric and its
+// pool by another
+func TestPoolForNodeByAlgorithm(t *testing.T) {
+	// pool-a is the least used, pool-c has the most free space, pool-b holds the
+	// fewest volumes, so every algorithm picks a different pool
+	pools := []apis.Pool{
+		newPool("zfspv-pool-a", 20*Gi, 10*Gi),
+		newPool("zfspv-pool-b", 40*Gi, 60*Gi),
+		newPool("zfspv-pool-c", 80*Gi, 30*Gi),
+		newPool("other-pool", 500*Gi, 0),
+	}
+	zvlist := []apis.ZFSVolume{
+		newZFSVolume("node1", "zfspv-pool-a"),
+		newZFSVolume("node1", "zfspv-pool-a"),
+		newZFSVolume("node1", "zfspv-pool-b"),
+		newZFSVolume("node1", "zfspv-pool-c"),
+		newZFSVolume("node1", "zfspv-pool-c"),
+		// another node's volumes must not weigh this node's pools
+		newZFSVolume("node2", "zfspv-pool-b"),
+		newZFSVolume("node2", "zfspv-pool-b"),
+	}
+
+	tests := map[string]struct {
+		schd     string
+		expected string
+	}{
+		"CapacityWeighted picks the least used pool":            {schd: CapacityWeighted, expected: "zfspv-pool-a"},
+		"SpaceWeighted picks the pool with the most free space": {schd: SpaceWeighted, expected: "zfspv-pool-c"},
+		"VolumeWeighted picks the pool with the fewest volumes": {schd: VolumeWeighted, expected: "zfspv-pool-b"},
+		"an unset scheduler behaves as CapacityWeighted":        {schd: "", expected: "zfspv-pool-a"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			pmap := poolWeightMap(test.schd, pools)
+			if test.schd == VolumeWeighted {
+				pmap = poolVolumeMap(zvlist, "node1")
+			}
+
+			pool := poolForNode(pools, regexp.MustCompile("^zfspv-pool-"), 0, pmap)
+			assert.Equal(t, test.expected, pool)
+		})
+	}
+}
+
+func TestPoolForNode(t *testing.T) {
+	pools := []apis.Pool{
+		newPool("zfspv-pool-a", 10*Gi, 20*Gi),
+		newPool("zfspv-pool-b", 600*Gi, 400*Gi),
+	}
+	// CapacityWeighted: pool-a is the least used, but only pool-b can hold a
+	// large reservation
+	pmap := poolWeightMap(CapacityWeighted, pools)
+
+	tests := map[string]struct {
+		pools    []apis.Pool
+		pattern  string
+		minFree  int64
+		pmap     map[string]int64
+		expected string
+	}{
+		"the lowest weighted matching pool wins": {
+			pools: pools, pattern: "^zfspv-pool-", minFree: 0, pmap: pmap,
+			expected: "zfspv-pool-a",
+		},
+		"a pool which cannot hold the reservation is skipped": {
+			pools: pools, pattern: "^zfspv-pool-", minFree: 50 * Gi, pmap: pmap,
+			expected: "zfspv-pool-b",
+		},
+		// the fit is a strict >, as it is for the nodes in suitableNodes
+		"a pool with exactly the requested free space does not qualify": {
+			pools: pools, pattern: "^zfspv-pool-a$", minFree: 10 * Gi, pmap: pmap,
+			expected: "",
+		},
+		"no matching pool can hold the reservation": {
+			pools: pools, pattern: "^zfspv-pool-", minFree: 900 * Gi, pmap: pmap,
+			expected: "",
+		},
+		"a full pool is still eligible for a volume which reserves nothing": {
+			pools:   []apis.Pool{newPool("zfspv-pool-a", 0, 100*Gi)},
+			pattern: "^zfspv-pool-", minFree: 0, pmap: map[string]int64{},
+			expected: "zfspv-pool-a",
+		},
+		// ZFSNode.Pools is sorted by name, so the first pool on a tie is the
+		// lowest named one and the choice is deterministic without a tie-break
+		"a tie keeps the first pool": {
+			pools:   []apis.Pool{newPool("zfspv-pool-a", 10*Gi, 5*Gi), newPool("zfspv-pool-b", 90*Gi, 5*Gi)},
+			pattern: "^zfspv-pool-", minFree: 0,
+			pmap:     map[string]int64{"zfspv-pool-a": 7, "zfspv-pool-b": 7},
+			expected: "zfspv-pool-a",
+		},
+		"a bigger non matching pool is ignored": {
+			pools:   []apis.Pool{newPool("zfspv-pool-a", 10*Gi, 90*Gi), newPool("other-pool", 90*Gi, 1*Gi)},
+			pattern: "^zfspv-pool-", minFree: 0,
+			pmap:     map[string]int64{"zfspv-pool-a": 90 * Gi, "other-pool": 1 * Gi},
+			expected: "zfspv-pool-a",
+		},
+		"no pool matches": {
+			pools: pools, pattern: "^nosuch", minFree: 0, pmap: pmap,
+			expected: "",
+		},
+		"node without pools": {
+			pools: nil, pattern: "^zfspv-pool-", minFree: 0, pmap: map[string]int64{},
+			expected: "",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			pool := poolForNode(test.pools, regexp.MustCompile(test.pattern), test.minFree, test.pmap)
+			assert.Equal(t, test.expected, pool)
+		})
+	}
+}
+
+func TestPoolWeightMap(t *testing.T) {
+	pools := []apis.Pool{
+		newPool("zfspv-pool-a", 10*Gi, 90*Gi),
+		newPool("zfspv-pool-b", 60*Gi, 40*Gi),
+	}
+
+	assert.Equal(t, map[string]int64{
+		"zfspv-pool-a": 90 * Gi,
+		"zfspv-pool-b": 40 * Gi,
+	}, poolWeightMap(CapacityWeighted, pools))
+
+	// free space is inverted, as the lowest weight wins
+	assert.Equal(t, map[string]int64{
+		"zfspv-pool-a": math.MaxInt64 - 10*Gi,
+		"zfspv-pool-b": math.MaxInt64 - 60*Gi,
+	}, poolWeightMap(SpaceWeighted, pools))
+}
+
+func TestPoolVolumeMap(t *testing.T) {
+	zvlist := []apis.ZFSVolume{
+		newZFSVolume("node1", "zfspv-pool-a"),
+		newZFSVolume("node1", "zfspv-pool-a"),
+		// a dataset path is counted against its pool root
+		newZFSVolume("node1", "zfspv-pool-b/k8s/localpv"),
+		newZFSVolume("node2", "zfspv-pool-a"),
+	}
+
+	assert.Equal(t, map[string]int64{
+		"zfspv-pool-a": 2,
+		"zfspv-pool-b": 1,
+	}, poolVolumeMap(zvlist, "node1"))
+
+	assert.Equal(t, map[string]int64{}, poolVolumeMap(zvlist, "node3"))
+}
+
+func TestFilterKeep(t *testing.T) {
+	tests := map[string]struct {
+		nodes    []string
+		keep     map[string]bool
+		expected []string
+	}{
+		// the scheduler hands over the nodes least loaded first, the ones which
+		// survive the filter have to stay in that order
+		"the weighted order of the survivors is preserved": {
+			nodes:    []string{"node3", "node1", "node2"},
+			keep:     map[string]bool{"node1": true, "node2": true, "node3": true},
+			expected: []string{"node3", "node1", "node2"},
+		},
+		// this is the whole point of filtering here instead of leaving the node
+		// out of the weight map, where lib-csi would move it to the front
+		"an unsuitable node is dropped, not promoted": {
+			nodes:    []string{"node3", "node1", "node2"},
+			keep:     map[string]bool{"node1": true, "node2": true},
+			expected: []string{"node1", "node2"},
+		},
+		"nothing fits": {
+			nodes:    []string{"node1", "node2"},
+			keep:     map[string]bool{},
+			expected: []string{},
+		},
+		"a suitable node outside the topology stays out": {
+			nodes:    []string{"node1"},
+			keep:     map[string]bool{"node1": true, "node2": true},
+			expected: []string{"node1"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, filterKeep(test.nodes, test.keep))
+		})
+	}
+}
+
+func TestPoolDesc(t *testing.T) {
+	assert.Equal(t, `poolname "zpool/k8s/localpv"`, poolDesc("zpool/k8s/localpv", ""))
+	assert.Equal(t, `poolpattern "zfspv-pool.*"`, poolDesc("", "zfspv-pool.*"))
+}


### PR DESCRIPTION
## Summary

Wires the pool-pattern-aware scheduler helpers merged in #739 into the
fresh-create path of `CreateZFSVolume`, so the `poolpattern` StorageClass parameter (OEP-4268)
actually selects a pool. Clone/snapshot-restore, `GetCapacity` and StorageClass
validation are untouched and follow in later tasks.

## What this PR does

**Reads `poolpattern`** and compiles it, together with `poolname`, into the single
`*regexp.Regexp` the helpers match pool roots against.

**Filters the scheduler's output for volumes that reserve space.** lib-csi's
scheduler only *orders* nodes — it takes its candidates from the cluster topology
and moves a node missing from the weight map to the front of the list rather than
dropping it — so nodes that cannot hold the reservation are removed from its
output via `filterKeep`, preserving the weighted order of the survivors. When the
intersection goes empty, the request fails immediately instead of attempting a
create that cannot succeed:

- a matching pool exists but nothing fits → `ResourceExhausted`, which
  external-provisioner retries with backoff and, under capacity tracking,
  reschedules onto a node with room
- the pattern matches no pool on any node → `FailedPrecondition`, since a
  StorageClass naming a pool that exists nowhere will not start working on a retry

Both replace today's generic `codes.Internal, "scheduler failed, node list is
empty"`.

**Resolves the concrete pool per candidate node** in the provisioning loop, so
`ZFSVolume.Spec.PoolName` always names a pool present on the node the volume was
assigned to. A fixed `poolname` keeps being used as-is, since it can carry a
dataset path the `ZFSNode` CR does not advertise.

## Behaviour change — needs a release note

The fit filter applies to the existing fixed-`poolname` path as well as to
`poolpattern`: a full or absent pool now fails fast instead of retrying a create
that cannot succeed. OEP-4268 accepts this as an improvement but records that it
must be called out in the release notes.

## Left for later tasks

- clone / snapshot-restore: the pool guard currently rejects every clone under a
  `poolpattern` StorageClass, since `poolname` is empty there — fixed in the
  next PR, together with `GetCapacity`
- `GetCapacity` under `poolpattern`
- `validateVolumeCreateReq` rejection of both-set / neither-set / invalid regex
- docs and samples

## Testing

`TestFilterKeep` covers that survivors keep the scheduler's weighted order, that
an unsuitable node is dropped rather than promoted to the front, the nothing-fits
case, and a suitable node outside the topology staying out. `TestPoolDesc` covers
the error-message rendering for both parameter forms.

`go build ./pkg/... ./cmd/...`, `go vet ./pkg/...` and `go test ./pkg/...` are
clean, and `gofmt` reports nothing.

Worth running `make ci profile=custom-node-id` (or `profile=all`): the regular
profile cannot exercise the node-name keying the intersection depends on, since
node name and node id are equal there.

