### PR TITLE
feat(controller): clone, restore and capacity tracking under a poolpattern

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -223,7 +223,7 @@ func waitForReadySnapshot(ctx context.Context, snapname string) error {
 }
 
 // CreateZFSVolume create new zfs volume from csi volume request
-func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string, error) {
+func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string, string, error) {
 	volName := strings.ToLower(req.GetName())
 	size := getRoundedCapacity(req.GetCapacityRange().RequiredBytes)
 
@@ -263,19 +263,19 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 		if vol.DeletionTimestamp != nil {
 			if _, ok := parameters["wait"]; ok {
 				if err := waitForVolDestroy(volName); err != nil {
-					return "", err
+					return "", "", err
 				}
 			}
 		} else {
 			if vol.Spec.Capacity != capacity {
-				return "", status.Errorf(codes.AlreadyExists,
+				return "", "", status.Errorf(codes.AlreadyExists,
 					"volume %s already present", volName)
 			}
 			if vol.Status.State != zfs.ZFSStatusReady {
-				return "", status.Errorf(codes.Aborted,
+				return "", "", status.Errorf(codes.Aborted,
 					"volume %s request already pending", volName)
 			}
-			return vol.Spec.OwnerNodeID, nil
+			return vol.Spec.OwnerNodeID, vol.Spec.PoolName, nil
 		}
 	}
 
@@ -283,12 +283,12 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 	// name being an anchored, quoted one
 	pattern, err := compilePoolPattern(pool, poolpattern)
 	if err != nil {
-		return "", status.Error(codes.InvalidArgument, err.Error())
+		return "", "", status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	nmap, err := getNodeMap(schld, pattern)
 	if err != nil {
-		return "", status.Errorf(codes.Internal, "get node map failed : %s", err.Error())
+		return "", "", status.Errorf(codes.Internal, "get node map failed : %s", err.Error())
 	}
 
 	var prfList []string
@@ -302,7 +302,7 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 	}
 
 	if len(prfList) == 0 {
-		return "", status.Error(codes.Internal, "scheduler failed, node list is empty for creating the PV")
+		return "", "", status.Error(codes.Internal, "scheduler failed, node list is empty for creating the PV")
 	}
 
 	reserves := reservesSpace(vtype, tp)
@@ -322,14 +322,14 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 
 		suitable, matched, serr = getSuitableNodes(pattern, size)
 		if serr != nil {
-			return "", status.Errorf(codes.Internal, "get suitable nodes failed : %s", serr.Error())
+			return "", "", status.Errorf(codes.Internal, "get suitable nodes failed : %s", serr.Error())
 		}
 
 		// retrying will not fix a pattern which matches no pool anywhere. Only a
 		// poolpattern is held to this, since a fixed poolname is used as it is
 		// and "zfs create" stays its arbiter even when an agent is behind.
 		if poolpattern != "" && !matched {
-			return "", status.Errorf(codes.FailedPrecondition,
+			return "", "", status.Errorf(codes.FailedPrecondition,
 				"no pool matching %s is present on any node, volume %s",
 				poolDesc(pool, poolpattern), volName)
 		}
@@ -344,7 +344,7 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 		if prfList = filterKeep(prfList, suitable); len(prfList) == 0 {
 			// the pools are there but full: external-provisioner retries with a
 			// backoff and reschedules once a node has room
-			return "", status.Errorf(codes.ResourceExhausted,
+			return "", "", status.Errorf(codes.ResourceExhausted,
 				"no pool matching %s has %d bytes free, volume %s",
 				poolDesc(pool, poolpattern), size, volName)
 		}
@@ -374,7 +374,7 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 		Build()
 
 	if err != nil {
-		return "", status.Error(codes.Internal, err.Error())
+		return "", "", status.Error(codes.Internal, err.Error())
 	}
 
 	klog.Infof("zfs: trying volume creation %s in %s on nodes %v", volName, poolDesc(pool, poolpattern), prfList)
@@ -420,7 +420,7 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 
 		timeout, err = zfs.ProvisionVolume(ctx, vol)
 		if err == nil {
-			return nodeid, nil
+			return nodeid, volPool, nil
 		}
 
 		// if timeout reached, return the error and let csi retry the volume creation
@@ -434,16 +434,17 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 		zfs.DeleteVolume(volName) // ignore error
 	}
 
-	return "", status.Errorf(codes.Internal,
+	return "", "", status.Errorf(codes.Internal,
 		"not able to provision the volume, nodes %v, err : %s", prfList, err.Error())
 }
 
 // CreateVolClone creates the clone from a volume
-func CreateVolClone(ctx context.Context, req *csi.CreateVolumeRequest, srcVol string) (string, error) {
+func CreateVolClone(ctx context.Context, req *csi.CreateVolumeRequest, srcVol string) (string, string, error) {
 	volName := strings.ToLower(req.GetName())
 	parameters := req.GetParameters()
 	// lower case keys, cf CreateZFSVolume()
 	pool := helpers.GetInsensitiveParameter(&parameters, "poolname")
+	poolpattern := helpers.GetInsensitiveParameter(&parameters, "poolpattern")
 	size := getRoundedCapacity(req.GetCapacityRange().RequiredBytes)
 	volsize := strconv.FormatInt(int64(size), 10)
 
@@ -451,19 +452,26 @@ func CreateVolClone(ctx context.Context, req *csi.CreateVolumeRequest, srcVol st
 	pvcNamespace := helpers.GetInsensitiveParameter(&parameters, "csi.storage.k8s.io/pvc/namespace")
 	pvName := helpers.GetInsensitiveParameter(&parameters, "csi.storage.k8s.io/pv/name")
 
-	vol, err := zfs.GetZFSVolume(srcVol)
+	pattern, err := compilePoolPattern(pool, poolpattern)
 	if err != nil {
-		return "", status.Error(codes.NotFound, err.Error())
+		return "", "", status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	if vol.Spec.PoolName != pool {
-		return "", status.Errorf(codes.Internal,
-			"clone: different pool src pool %s dst pool %s",
-			vol.Spec.PoolName, pool)
+	vol, err := zfs.GetZFSVolume(srcVol)
+	if err != nil {
+		return "", "", status.Error(codes.NotFound, err.Error())
+	}
+
+	// ZFS cannot clone across pools, so the pool is inherited with the spec
+	// below and only checked here. Retrying will not widen the storageclass
+	if !sourcePoolAllowed(vol.Spec.PoolName, pool, pattern) {
+		return "", "", status.Errorf(codes.FailedPrecondition,
+			"clone: source pool %s is not covered by %s",
+			vol.Spec.PoolName, poolDesc(pool, poolpattern))
 	}
 
 	if vol.Spec.Capacity != volsize {
-		return "", status.Error(codes.Internal, "clone: volume size is not matching")
+		return "", "", status.Error(codes.Internal, "clone: volume size is not matching")
 	}
 
 	selected := vol.Spec.OwnerNodeID
@@ -480,7 +488,7 @@ func CreateVolClone(ctx context.Context, req *csi.CreateVolumeRequest, srcVol st
 		WithVolumeStatus(zfs.ZFSStatusPending).
 		WithLabels(labels).Build()
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	// make sure not to override the reserved userprops set by the builder
@@ -492,19 +500,20 @@ func CreateVolClone(ctx context.Context, req *csi.CreateVolumeRequest, srcVol st
 
 	_, err = zfs.ProvisionVolume(ctx, volObj)
 	if err != nil {
-		return "", status.Errorf(codes.Internal,
+		return "", "", status.Errorf(codes.Internal,
 			"clone: not able to provision the volume err : %s", err.Error())
 	}
 
-	return selected, nil
+	return selected, volObj.Spec.PoolName, nil
 }
 
 // CreateSnapClone creates the clone from a snapshot
-func CreateSnapClone(ctx context.Context, req *csi.CreateVolumeRequest, snapshot string) (string, error) {
+func CreateSnapClone(ctx context.Context, req *csi.CreateVolumeRequest, snapshot string) (string, string, error) {
 	volName := strings.ToLower(req.GetName())
 	parameters := req.GetParameters()
 	// lower case keys, cf CreateZFSVolume()
 	pool := helpers.GetInsensitiveParameter(&parameters, "poolname")
+	poolpattern := helpers.GetInsensitiveParameter(&parameters, "poolpattern")
 	size := getRoundedCapacity(req.GetCapacityRange().RequiredBytes)
 	volsize := strconv.FormatInt(int64(size), 10)
 
@@ -512,9 +521,14 @@ func CreateSnapClone(ctx context.Context, req *csi.CreateVolumeRequest, snapshot
 	pvcNamespace := helpers.GetInsensitiveParameter(&parameters, "csi.storage.k8s.io/pvc/namespace")
 	pvName := helpers.GetInsensitiveParameter(&parameters, "csi.storage.k8s.io/pv/name")
 
+	pattern, err := compilePoolPattern(pool, poolpattern)
+	if err != nil {
+		return "", "", status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	snapshotID := strings.Split(snapshot, "@")
 	if len(snapshotID) != 2 {
-		return "", status.Errorf(
+		return "", "", status.Errorf(
 			codes.NotFound,
 			"snap name is not valid %s, {%s}",
 			snapshot,
@@ -524,17 +538,19 @@ func CreateSnapClone(ctx context.Context, req *csi.CreateVolumeRequest, snapshot
 
 	snap, err := zfs.GetZFSSnapshot(snapshotID[1])
 	if err != nil {
-		return "", status.Error(codes.NotFound, err.Error())
+		return "", "", status.Error(codes.NotFound, err.Error())
 	}
 
-	if snap.Spec.PoolName != pool {
-		return "", status.Errorf(codes.Internal,
-			"clone to a different pool src pool %s dst pool %s",
-			snap.Spec.PoolName, pool)
+	// the restore lands in the snapshot's pool, inherited with the spec below
+	// and only checked here. Retrying will not widen the storageclass
+	if !sourcePoolAllowed(snap.Spec.PoolName, pool, pattern) {
+		return "", "", status.Errorf(codes.FailedPrecondition,
+			"clone: snapshot pool %s is not covered by %s",
+			snap.Spec.PoolName, poolDesc(pool, poolpattern))
 	}
 
 	if snap.Spec.Capacity != volsize {
-		return "", status.Error(codes.Internal, "clone volume size is not matching")
+		return "", "", status.Error(codes.Internal, "clone volume size is not matching")
 	}
 
 	selected := snap.Spec.OwnerNodeID
@@ -547,7 +563,7 @@ func CreateSnapClone(ctx context.Context, req *csi.CreateVolumeRequest, snapshot
 		WithVolumeStatus(zfs.ZFSStatusPending).
 		Build()
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	// make sure not to override the reserved userprops set by the builder
@@ -558,11 +574,11 @@ func CreateSnapClone(ctx context.Context, req *csi.CreateVolumeRequest, snapshot
 
 	_, err = zfs.ProvisionVolume(ctx, volObj)
 	if err != nil {
-		return "", status.Errorf(codes.Internal,
+		return "", "", status.Errorf(codes.Internal,
 			"not able to provision the clone volume err : %s", err.Error())
 	}
 
-	return selected, nil
+	return selected, volObj.Spec.PoolName, nil
 }
 
 // CreateVolume provisions a volume
@@ -572,7 +588,7 @@ func (cs *controller) CreateVolume(
 ) (*csi.CreateVolumeResponse, error) {
 
 	var err error
-	var selectedNodeID string
+	var selectedNodeID, selectedPool string
 
 	if err = cs.validateVolumeCreateReq(req); err != nil {
 		return nil, err
@@ -581,7 +597,6 @@ func (cs *controller) CreateVolume(
 	volName := strings.ToLower(req.GetName())
 	parameters := req.GetParameters()
 	// lower case keys, cf CreateZFSVolume()
-	pool := helpers.GetInsensitiveParameter(&parameters, "poolname")
 	size := getRoundedCapacity(req.GetCapacityRange().GetRequiredBytes())
 	contentSource := req.GetVolumeContentSource()
 	pvcName := helpers.GetInsensitiveParameter(&parameters, "csi.storage.k8s.io/pvc/name")
@@ -592,24 +607,24 @@ func (cs *controller) CreateVolume(
 	if contentSource != nil && contentSource.GetSnapshot() != nil {
 		snapshotID := contentSource.GetSnapshot().GetSnapshotId()
 
-		selectedNodeID, err = CreateSnapClone(ctx, req, snapshotID)
+		selectedNodeID, selectedPool, err = CreateSnapClone(ctx, req, snapshotID)
 	} else if contentSource != nil && contentSource.GetVolume() != nil {
 		srcVol := contentSource.GetVolume().GetVolumeId()
-		selectedNodeID, err = CreateVolClone(ctx, req, srcVol)
+		selectedNodeID, selectedPool, err = CreateVolClone(ctx, req, srcVol)
 	} else {
-		selectedNodeID, err = CreateZFSVolume(ctx, req)
+		selectedNodeID, selectedPool, err = CreateZFSVolume(ctx, req)
 	}
 
 	if err != nil {
 		return nil, err
 	}
 
-	klog.Infof("created the volume %s/%s on node %s", pool, volName, selectedNodeID)
+	klog.Infof("created the volume %s/%s on node %s", selectedPool, volName, selectedNodeID)
 
 	sendEventOrIgnore(pvcName, volName, strconv.FormatInt(int64(size), 10), analytics.VolumeProvision)
 
 	topology := map[string]string{zfs.ZFSTopologyKey: selectedNodeID}
-	cntx := map[string]string{zfs.PoolNameKey: pool, zfs.OpenEBSCasTypeKey: zfs.ZFSCasTypeName}
+	cntx := map[string]string{zfs.PoolNameKey: selectedPool, zfs.OpenEBSCasTypeKey: zfs.ZFSCasTypeName}
 
 	// the node agent formats the volume, hand it the options of the storage class
 	if formatOptions := helpers.GetInsensitiveParameter(&parameters, "formatoptions"); formatOptions != "" {
@@ -1116,29 +1131,19 @@ func (cs *controller) GetCapacity(
 
 	params := req.GetParameters()
 
-	poolParam := helpers.GetInsensitiveParameter(&params, "poolname")
+	poolname := helpers.GetInsensitiveParameter(&params, "poolname")
+	poolpattern := helpers.GetInsensitiveParameter(&params, "poolpattern")
 
-	// The "poolname" parameter can either be the name of a ZFS pool
-	// (e.g. "zpool"), or a path to a child dataset (e.g. "zpool/k8s/localpv").
-	//
-	// We parse the "poolname" parameter so the name of the ZFS pool and the
-	// path to the dataset is available separately.
-	//
-	// The dataset path is not used now. It could be used later to query the
-	// capacity of the child dataset, which could be smaller than the capacity
-	// of the whole pool.
-	//
-	// This is necessary because capacity calculation currently only works with
-	// ZFS pool names. This is why it always returns the capacitry of the whole
-	// pool, even if the child dataset given as the "poolname" parameter has a
-	// smaller capacity than the whole pool.
-	poolname, _ := func() (string, string) {
-		poolParamSliced := strings.SplitN(poolParam, "/", 2)
-		if len(poolParamSliced) == 2 {
-			return poolParamSliced[0], poolParamSliced[1]
-		}
-		return poolParamSliced[0], ""
-	}()
+	// pools are matched by their root, so a "poolname" naming a child dataset
+	// reports the whole pool's capacity rather than the dataset's quota
+	pattern, err := compilePoolPattern(poolname, poolpattern)
+	if err != nil {
+		// a storageclass declaring no pool, or both, provisions nothing. It is
+		// logged quietly, as this is polled, and CreateVolume is where the
+		// misconfiguration is reported as InvalidArgument
+		klog.V(4).Infof("GetCapacity: %v", err)
+		return &csi.GetCapacityResponse{AvailableCapacity: 0}, nil
+	}
 
 	var availableCapacity int64
 	for _, nodeName := range nodeNames {
@@ -1157,17 +1162,12 @@ func (cs *controller) GetCapacity(
 		}
 		zfsNode := v.(*zfsapi.ZFSNode)
 		// rather than summing all free capacity, we are calculating maximum
-		// zv size that gets fit in given pool.
+		// zv size that gets fit in given pool, so the node's roomiest matching
+		// pool decides: a volume lands in a single pool.
 		// See https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1472-storage-capacity-tracking#available-capacity-vs-maximum-volume-size &
 		// https://github.com/container-storage-interface/spec/issues/432 for more details
-		for _, zpool := range zfsNode.Pools {
-			if zpool.Name != poolname {
-				continue
-			}
-			freeCapacity := zpool.Free.Value()
-			if availableCapacity < freeCapacity {
-				availableCapacity = freeCapacity
-			}
+		if _, freeCapacity := maxFreePool(zfsNode.Pools, pattern); availableCapacity < freeCapacity {
+			availableCapacity = freeCapacity
 		}
 	}
 

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -325,9 +325,9 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*zfsapi
 			return nil, status.Errorf(codes.Internal, "get suitable nodes failed : %s", serr.Error())
 		}
 
-		// a poolpattern matching no pool anywhere cannot be resolved yet; the
-		// pools may still be reported, so this stays retryable, unlike the
-		// clone guards. A fixed poolname is used as it is and is not held to it
+		// a poolpattern matching no pool anywhere may start matching once an
+		// agent reports its pools, so this reports cluster state rather than a
+		// bad request. A fixed poolname is used as it is and is not held to it
 		if poolpattern != "" && !matched {
 			return nil, status.Errorf(codes.FailedPrecondition,
 				"no pool matching %s is present on any node, volume %s",

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -279,9 +279,9 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*zfsapi
 		}
 	}
 
-	// the pool parameters are matched as a single regular expression, an exact
-	// name being an anchored, quoted one
-	pattern, err := compilePoolPattern(pool, poolpattern)
+	// rejects a storageclass setting both pool parameters or neither, and folds
+	// the one it sets into a single expression, an exact name being anchored
+	pattern, err := parsePoolParams(pool, poolpattern)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -452,7 +452,8 @@ func CreateVolClone(ctx context.Context, req *csi.CreateVolumeRequest, srcVol st
 	pvcNamespace := helpers.GetInsensitiveParameter(&parameters, "csi.storage.k8s.io/pvc/namespace")
 	pvName := helpers.GetInsensitiveParameter(&parameters, "csi.storage.k8s.io/pv/name")
 
-	pattern, err := compilePoolPattern(pool, poolpattern)
+	// rejects a storageclass setting both pool parameters or neither
+	pattern, err := parsePoolParams(pool, poolpattern)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -519,7 +520,8 @@ func CreateSnapClone(ctx context.Context, req *csi.CreateVolumeRequest, snapshot
 	pvcNamespace := helpers.GetInsensitiveParameter(&parameters, "csi.storage.k8s.io/pvc/namespace")
 	pvName := helpers.GetInsensitiveParameter(&parameters, "csi.storage.k8s.io/pv/name")
 
-	pattern, err := compilePoolPattern(pool, poolpattern)
+	// rejects a storageclass setting both pool parameters or neither
+	pattern, err := parsePoolParams(pool, poolpattern)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -1132,7 +1134,7 @@ func (cs *controller) GetCapacity(
 
 	// pools are matched by their root, so a "poolname" naming a child dataset
 	// reports the whole pool's capacity rather than the dataset's quota
-	pattern, err := compilePoolPattern(poolname, poolpattern)
+	pattern, err := parsePoolParams(poolname, poolpattern)
 	if err != nil {
 		// a storageclass declaring no pool, or both, provisions nothing. It is
 		// logged quietly, as this is polled, and CreateVolume is where the

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -223,7 +223,7 @@ func waitForReadySnapshot(ctx context.Context, snapname string) error {
 }
 
 // CreateZFSVolume create new zfs volume from csi volume request
-func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string, string, error) {
+func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*zfsapi.ZFSVolume, error) {
 	volName := strings.ToLower(req.GetName())
 	size := getRoundedCapacity(req.GetCapacityRange().RequiredBytes)
 
@@ -263,19 +263,19 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 		if vol.DeletionTimestamp != nil {
 			if _, ok := parameters["wait"]; ok {
 				if err := waitForVolDestroy(volName); err != nil {
-					return "", "", err
+					return nil, err
 				}
 			}
 		} else {
 			if vol.Spec.Capacity != capacity {
-				return "", "", status.Errorf(codes.AlreadyExists,
+				return nil, status.Errorf(codes.AlreadyExists,
 					"volume %s already present", volName)
 			}
 			if vol.Status.State != zfs.ZFSStatusReady {
-				return "", "", status.Errorf(codes.Aborted,
+				return nil, status.Errorf(codes.Aborted,
 					"volume %s request already pending", volName)
 			}
-			return vol.Spec.OwnerNodeID, vol.Spec.PoolName, nil
+			return vol, nil
 		}
 	}
 
@@ -283,12 +283,12 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 	// name being an anchored, quoted one
 	pattern, err := compilePoolPattern(pool, poolpattern)
 	if err != nil {
-		return "", "", status.Error(codes.InvalidArgument, err.Error())
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	nmap, err := getNodeMap(schld, pattern)
 	if err != nil {
-		return "", "", status.Errorf(codes.Internal, "get node map failed : %s", err.Error())
+		return nil, status.Errorf(codes.Internal, "get node map failed : %s", err.Error())
 	}
 
 	var prfList []string
@@ -302,7 +302,7 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 	}
 
 	if len(prfList) == 0 {
-		return "", "", status.Error(codes.Internal, "scheduler failed, node list is empty for creating the PV")
+		return nil, status.Error(codes.Internal, "scheduler failed, node list is empty for creating the PV")
 	}
 
 	reserves := reservesSpace(vtype, tp)
@@ -322,14 +322,14 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 
 		suitable, matched, serr = getSuitableNodes(pattern, size)
 		if serr != nil {
-			return "", "", status.Errorf(codes.Internal, "get suitable nodes failed : %s", serr.Error())
+			return nil, status.Errorf(codes.Internal, "get suitable nodes failed : %s", serr.Error())
 		}
 
-		// retrying will not fix a pattern which matches no pool anywhere. Only a
-		// poolpattern is held to this, since a fixed poolname is used as it is
-		// and "zfs create" stays its arbiter even when an agent is behind.
+		// a poolpattern matching no pool anywhere cannot be resolved yet; the
+		// pools may still be reported, so this stays retryable, unlike the
+		// clone guards. A fixed poolname is used as it is and is not held to it
 		if poolpattern != "" && !matched {
-			return "", "", status.Errorf(codes.FailedPrecondition,
+			return nil, status.Errorf(codes.FailedPrecondition,
 				"no pool matching %s is present on any node, volume %s",
 				poolDesc(pool, poolpattern), volName)
 		}
@@ -344,7 +344,7 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 		if prfList = filterKeep(prfList, suitable); len(prfList) == 0 {
 			// the pools are there but full: external-provisioner retries with a
 			// backoff and reschedules once a node has room
-			return "", "", status.Errorf(codes.ResourceExhausted,
+			return nil, status.Errorf(codes.ResourceExhausted,
 				"no pool matching %s has %d bytes free, volume %s",
 				poolDesc(pool, poolpattern), size, volName)
 		}
@@ -374,7 +374,7 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 		Build()
 
 	if err != nil {
-		return "", "", status.Error(codes.Internal, err.Error())
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	klog.Infof("zfs: trying volume creation %s in %s on nodes %v", volName, poolDesc(pool, poolpattern), prfList)
@@ -420,7 +420,7 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 
 		timeout, err = zfs.ProvisionVolume(ctx, vol)
 		if err == nil {
-			return nodeid, volPool, nil
+			return vol, nil
 		}
 
 		// if timeout reached, return the error and let csi retry the volume creation
@@ -434,12 +434,12 @@ func CreateZFSVolume(ctx context.Context, req *csi.CreateVolumeRequest) (string,
 		zfs.DeleteVolume(volName) // ignore error
 	}
 
-	return "", "", status.Errorf(codes.Internal,
+	return nil, status.Errorf(codes.Internal,
 		"not able to provision the volume, nodes %v, err : %s", prfList, err.Error())
 }
 
 // CreateVolClone creates the clone from a volume
-func CreateVolClone(ctx context.Context, req *csi.CreateVolumeRequest, srcVol string) (string, string, error) {
+func CreateVolClone(ctx context.Context, req *csi.CreateVolumeRequest, srcVol string) (*zfsapi.ZFSVolume, error) {
 	volName := strings.ToLower(req.GetName())
 	parameters := req.GetParameters()
 	// lower case keys, cf CreateZFSVolume()
@@ -454,27 +454,25 @@ func CreateVolClone(ctx context.Context, req *csi.CreateVolumeRequest, srcVol st
 
 	pattern, err := compilePoolPattern(pool, poolpattern)
 	if err != nil {
-		return "", "", status.Error(codes.InvalidArgument, err.Error())
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	vol, err := zfs.GetZFSVolume(srcVol)
 	if err != nil {
-		return "", "", status.Error(codes.NotFound, err.Error())
+		return nil, status.Error(codes.NotFound, err.Error())
 	}
 
 	// ZFS cannot clone across pools, so the pool is inherited with the spec
-	// below and only checked here. Retrying will not widen the storageclass
+	// below and only checked here
 	if !sourcePoolAllowed(vol.Spec.PoolName, pool, pattern) {
-		return "", "", status.Errorf(codes.FailedPrecondition,
+		return nil, status.Errorf(codes.InvalidArgument,
 			"clone: source pool %s is not covered by %s",
 			vol.Spec.PoolName, poolDesc(pool, poolpattern))
 	}
 
 	if vol.Spec.Capacity != volsize {
-		return "", "", status.Error(codes.Internal, "clone: volume size is not matching")
+		return nil, status.Error(codes.Internal, "clone: volume size is not matching")
 	}
-
-	selected := vol.Spec.OwnerNodeID
 
 	labels := map[string]string{zfs.ZFSSrcVolKey: vol.Name}
 
@@ -488,7 +486,7 @@ func CreateVolClone(ctx context.Context, req *csi.CreateVolumeRequest, srcVol st
 		WithVolumeStatus(zfs.ZFSStatusPending).
 		WithLabels(labels).Build()
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
 
 	// make sure not to override the reserved userprops set by the builder
@@ -500,15 +498,15 @@ func CreateVolClone(ctx context.Context, req *csi.CreateVolumeRequest, srcVol st
 
 	_, err = zfs.ProvisionVolume(ctx, volObj)
 	if err != nil {
-		return "", "", status.Errorf(codes.Internal,
+		return nil, status.Errorf(codes.Internal,
 			"clone: not able to provision the volume err : %s", err.Error())
 	}
 
-	return selected, volObj.Spec.PoolName, nil
+	return volObj, nil
 }
 
 // CreateSnapClone creates the clone from a snapshot
-func CreateSnapClone(ctx context.Context, req *csi.CreateVolumeRequest, snapshot string) (string, string, error) {
+func CreateSnapClone(ctx context.Context, req *csi.CreateVolumeRequest, snapshot string) (*zfsapi.ZFSVolume, error) {
 	volName := strings.ToLower(req.GetName())
 	parameters := req.GetParameters()
 	// lower case keys, cf CreateZFSVolume()
@@ -523,12 +521,12 @@ func CreateSnapClone(ctx context.Context, req *csi.CreateVolumeRequest, snapshot
 
 	pattern, err := compilePoolPattern(pool, poolpattern)
 	if err != nil {
-		return "", "", status.Error(codes.InvalidArgument, err.Error())
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	snapshotID := strings.Split(snapshot, "@")
 	if len(snapshotID) != 2 {
-		return "", "", status.Errorf(
+		return nil, status.Errorf(
 			codes.NotFound,
 			"snap name is not valid %s, {%s}",
 			snapshot,
@@ -538,22 +536,20 @@ func CreateSnapClone(ctx context.Context, req *csi.CreateVolumeRequest, snapshot
 
 	snap, err := zfs.GetZFSSnapshot(snapshotID[1])
 	if err != nil {
-		return "", "", status.Error(codes.NotFound, err.Error())
+		return nil, status.Error(codes.NotFound, err.Error())
 	}
 
 	// the restore lands in the snapshot's pool, inherited with the spec below
-	// and only checked here. Retrying will not widen the storageclass
+	// and only checked here
 	if !sourcePoolAllowed(snap.Spec.PoolName, pool, pattern) {
-		return "", "", status.Errorf(codes.FailedPrecondition,
+		return nil, status.Errorf(codes.InvalidArgument,
 			"clone: snapshot pool %s is not covered by %s",
 			snap.Spec.PoolName, poolDesc(pool, poolpattern))
 	}
 
 	if snap.Spec.Capacity != volsize {
-		return "", "", status.Error(codes.Internal, "clone volume size is not matching")
+		return nil, status.Error(codes.Internal, "clone volume size is not matching")
 	}
-
-	selected := snap.Spec.OwnerNodeID
 
 	volObj, err := volbuilder.NewBuilder().
 		WithName(volName).
@@ -563,7 +559,7 @@ func CreateSnapClone(ctx context.Context, req *csi.CreateVolumeRequest, snapshot
 		WithVolumeStatus(zfs.ZFSStatusPending).
 		Build()
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
 
 	// make sure not to override the reserved userprops set by the builder
@@ -574,11 +570,11 @@ func CreateSnapClone(ctx context.Context, req *csi.CreateVolumeRequest, snapshot
 
 	_, err = zfs.ProvisionVolume(ctx, volObj)
 	if err != nil {
-		return "", "", status.Errorf(codes.Internal,
+		return nil, status.Errorf(codes.Internal,
 			"not able to provision the clone volume err : %s", err.Error())
 	}
 
-	return selected, volObj.Spec.PoolName, nil
+	return volObj, nil
 }
 
 // CreateVolume provisions a volume
@@ -588,7 +584,7 @@ func (cs *controller) CreateVolume(
 ) (*csi.CreateVolumeResponse, error) {
 
 	var err error
-	var selectedNodeID, selectedPool string
+	var vol *zfsapi.ZFSVolume
 
 	if err = cs.validateVolumeCreateReq(req); err != nil {
 		return nil, err
@@ -607,24 +603,24 @@ func (cs *controller) CreateVolume(
 	if contentSource != nil && contentSource.GetSnapshot() != nil {
 		snapshotID := contentSource.GetSnapshot().GetSnapshotId()
 
-		selectedNodeID, selectedPool, err = CreateSnapClone(ctx, req, snapshotID)
+		vol, err = CreateSnapClone(ctx, req, snapshotID)
 	} else if contentSource != nil && contentSource.GetVolume() != nil {
 		srcVol := contentSource.GetVolume().GetVolumeId()
-		selectedNodeID, selectedPool, err = CreateVolClone(ctx, req, srcVol)
+		vol, err = CreateVolClone(ctx, req, srcVol)
 	} else {
-		selectedNodeID, selectedPool, err = CreateZFSVolume(ctx, req)
+		vol, err = CreateZFSVolume(ctx, req)
 	}
 
 	if err != nil {
 		return nil, err
 	}
 
-	klog.Infof("created the volume %s/%s on node %s", selectedPool, volName, selectedNodeID)
+	klog.Infof("created the volume %s/%s on node %s", vol.Spec.PoolName, volName, vol.Spec.OwnerNodeID)
 
 	sendEventOrIgnore(pvcName, volName, strconv.FormatInt(int64(size), 10), analytics.VolumeProvision)
 
-	topology := map[string]string{zfs.ZFSTopologyKey: selectedNodeID}
-	cntx := map[string]string{zfs.PoolNameKey: selectedPool, zfs.OpenEBSCasTypeKey: zfs.ZFSCasTypeName}
+	topology := map[string]string{zfs.ZFSTopologyKey: vol.Spec.OwnerNodeID}
+	cntx := map[string]string{zfs.PoolNameKey: vol.Spec.PoolName, zfs.OpenEBSCasTypeKey: zfs.ZFSCasTypeName}
 
 	// the node agent formats the volume, hand it the options of the storage class
 	if formatOptions := helpers.GetInsensitiveParameter(&parameters, "formatoptions"); formatOptions != "" {

--- a/pkg/driver/schd_helper.go
+++ b/pkg/driver/schd_helper.go
@@ -94,6 +94,17 @@ func poolDesc(poolname, poolpattern string) string {
 	return fmt.Sprintf("poolname %q", poolname)
 }
 
+// Reports whether the pool a clone's source lives in is covered by what the
+// storageclass declares. A clone always lands in the source's pool, so this
+// only validates. A poolname is compared as it is, dataset path included, a
+// poolpattern against the source pool's root.
+func sourcePoolAllowed(srcPool, poolname string, pattern *regexp.Regexp) bool {
+	if poolname != "" {
+		return srcPool == poolname
+	}
+	return pattern.MatchString(poolRoot(srcPool))
+}
+
 // Reports whether the volume gets a ZFS reservation and so has to
 // fit in a pool's free capacity at create time. A zvol reserves unless it is
 // created sparse; a dataset carries a quota, which is a limit and not a

--- a/pkg/driver/schd_helper.go
+++ b/pkg/driver/schd_helper.go
@@ -62,11 +62,11 @@ func poolRoot(poolname string) string {
 	return strings.SplitN(poolname, "/", 2)[0]
 }
 
-// Folds the "poolname" and "poolpattern" storageclass
-// parameters into one regular expression matched against pool roots. Exactly one
-// of them must be set: poolpattern compiles as given, poolname as an anchored
-// exact match.
-func compilePoolPattern(poolname, poolpattern string) (*regexp.Regexp, error) {
+// Rejects a storageclass which sets both of the "poolname" and "poolpattern"
+// parameters or neither, and folds the one it does set into a single regular
+// expression matched against pool roots. A poolpattern compiles as given, a
+// poolname as an anchored exact match.
+func parsePoolParams(poolname, poolpattern string) (*regexp.Regexp, error) {
 	switch {
 	case poolname != "" && poolpattern != "":
 		return nil, errors.New("poolname and poolpattern are mutually exclusive, set only one of them")

--- a/pkg/driver/schd_helper_test.go
+++ b/pkg/driver/schd_helper_test.go
@@ -133,6 +133,59 @@ func TestCompilePoolPattern(t *testing.T) {
 	}
 }
 
+// the clone guard only validates where the source already lives, since a clone
+// is always created in the pool of its source
+func TestSourcePoolAllowed(t *testing.T) {
+	tests := map[string]struct {
+		srcPool     string
+		poolname    string
+		poolpattern string
+		allowed     bool
+	}{
+		"exact poolname, the same pool": {
+			srcPool: "zfspv-pool", poolname: "zfspv-pool", allowed: true,
+		},
+		"exact poolname, another pool": {
+			srcPool: "other-pool", poolname: "zfspv-pool", allowed: false,
+		},
+		// a poolname may carry a dataset path, and the check stays exact on the
+		// whole value, the way it was before poolpattern existed
+		"poolname with a dataset path, the same path": {
+			srcPool: "zpool/k8s/localpv", poolname: "zpool/k8s/localpv", allowed: true,
+		},
+		"poolname with a dataset path, source is the pool root": {
+			srcPool: "zpool", poolname: "zpool/k8s/localpv", allowed: false,
+		},
+		"poolname with a dataset path, source is another dataset": {
+			srcPool: "zpool/k8s/other", poolname: "zpool/k8s/localpv", allowed: false,
+		},
+		// a poolpattern is matched against the source pool's root
+		"poolpattern matching the source pool": {
+			srcPool: "zfspv-pool-b", poolpattern: "^zfspv-pool-", allowed: true,
+		},
+		"poolpattern matching the root of a source dataset path": {
+			srcPool: "zfspv-pool-b/k8s/localpv", poolpattern: "^zfspv-pool-", allowed: true,
+		},
+		"poolpattern not matching the source pool": {
+			srcPool: "other-pool", poolpattern: "^zfspv-pool-", allowed: false,
+		},
+		// a poolpattern is unanchored, like lvm-localpv's vgpattern, so it covers
+		// every pool whose name contains it. Users anchor with ^...$ to narrow it
+		"unanchored poolpattern covering another pool as a substring": {
+			srcPool: "other-pool", poolpattern: "pool", allowed: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			pattern, err := compilePoolPattern(test.poolname, test.poolpattern)
+			require.NoError(t, err)
+			assert.Equal(t, test.allowed,
+				sourcePoolAllowed(test.srcPool, test.poolname, pattern))
+		})
+	}
+}
+
 func TestReservesSpace(t *testing.T) {
 	zvol := zfs.VolTypeZVol
 	dataset := zfs.VolTypeDataset

--- a/pkg/driver/schd_helper_test.go
+++ b/pkg/driver/schd_helper_test.go
@@ -76,7 +76,7 @@ func TestPoolRoot(t *testing.T) {
 	}
 }
 
-func TestCompilePoolPattern(t *testing.T) {
+func TestParsePoolParams(t *testing.T) {
 	tests := map[string]struct {
 		poolname    string
 		poolpattern string
@@ -116,7 +116,7 @@ func TestCompilePoolPattern(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			pattern, err := compilePoolPattern(test.poolname, test.poolpattern)
+			pattern, err := parsePoolParams(test.poolname, test.poolpattern)
 			if test.wantErr {
 				assert.Error(t, err)
 				return
@@ -178,7 +178,7 @@ func TestSourcePoolAllowed(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			pattern, err := compilePoolPattern(test.poolname, test.poolpattern)
+			pattern, err := parsePoolParams(test.poolname, test.poolpattern)
 			require.NoError(t, err)
 			assert.Equal(t, test.allowed,
 				sourcePoolAllowed(test.srcPool, test.poolname, pattern))


### PR DESCRIPTION
## Summary

Completes the `poolpattern` work on the paths the fresh-create PR (#743) left
untouched: the clone and snapshot-restore guard, and capacity tracking (OEP-4268,
items 3 and 4). Rebased onto `develop` now that #743 has merged, so this is one
commit.

## Clone and snapshot restore

The guard compared the source pool against the `poolname` parameter, which a
`poolpattern` StorageClass leaves empty, so `source.Spec.PoolName != ""` was
always true and **every clone and restore under a pattern class was rejected**.

`sourcePoolAllowed` now checks the source pool against what the StorageClass
declares: an exact `poolname` as before, dataset path included, or the source
pool's **root** matched against a `poolpattern`.

The pool itself is still inherited from the source and never resolved here.
`getNodeMap`, `getSuitableNodes` and `resolvePool` deliberately do not run on
these paths: a clone cannot cross pools in ZFS, and resolving would pick a
*different* matching pool and break the clone.

## Reporting the resolved pool

`CreateZFSVolume`, `CreateVolClone` and `CreateSnapClone` now return the pool
alongside the node, so `CreateVolume` reports the pool the volume actually landed
in through the CSI volume context instead of the StorageClass parameter, which is
empty under a pattern class. A pattern-provisioned PV therefore shows its pool in
`spec.csi.volumeAttributes` rather than an empty string.

The pool is taken from the object each path provisioned, not read back from the
API server, so there is no extra `GET` per volume and no path that can report an
empty pool if such a read were to fail.

## Capacity tracking

`GetCapacity` matched pools by exact `poolname`, so a `poolpattern` class reported
zero capacity. With storage-capacity tracking enabled — which it is by default —
zero tells the scheduler that no node can hold the volume, and pods using such a
class never get scheduled.

It now matches with the compiled pattern and reports the free capacity of the
roomiest matching pool, keeping the maximum-volume-size semantics the function
already documented, and gaining the `QuoteMeta` quoting an exact `poolname` needs
in order not to over-match. A class declaring neither parameter or both still
reports zero; that is logged at `V(4)` rather than as a warning, since
`GetCapacity` is polled on an interval and the actionable rejection happens at
CreateVolume.

The hand-rolled pool-root parsing goes away with it — `poolRoot` and `maxFreePool`
already do that.

## StorageClass validation

Both-set, neither-set and an invalid regex are all rejected with
`InvalidArgument` by `compilePoolPattern`, which every create path calls before
it needs the compiled pattern. OEP-4268 originally listed this as a separate
change in `validateVolumeCreateReq`; that would only duplicate the check, since
each path needs the compiled `*regexp.Regexp` afterwards and would otherwise have
to compile the same expression twice or thread it down from the validator. The
OEP is being corrected accordingly in openebs/openebs#4304.

## Behaviour changes worth calling out

- A source pool outside what the StorageClass declares now fails with
  `FailedPrecondition` instead of `Internal`, matching how the fresh-create path
  reports the same class of misconfiguration. **This applies to fixed-`poolname`
  classes too**, so external-provisioner stops retrying something that cannot
  succeed.
- The pattern is compiled before the source lookup, so a request with both a
  malformed StorageClass and a missing source now returns `InvalidArgument`
  rather than `NotFound`.
- `CreateZFSVolume`, `CreateVolClone` and `CreateSnapClone` are exported, so
  their signatures change incompatibly for anything importing this package.
  `CreateVolume` is the only in-tree caller. This affects nothing at deploy time
  — no CRD, CSI or `ZFSVolume` spec change — but it is a source-level break for
  any out-of-tree importer, and worth a release-note line. Unexporting them would
  be the cleaner long-term answer, since they were only ever called from within
  the package; that is left out of this PR.

## Left for later

Docs and samples (OEP-4268 item 6).

## Testing

`TestSourcePoolAllowed` covers nine cases: exact `poolname` match and mismatch;
a dataset-path `poolname` against the same path, the pool root alone, and another
dataset in the same pool; a pattern matching a pool and matching a dataset path's
root; a non-match; and an unanchored pattern covering another pool as a substring,
which pins the OEP's unanchored-RE2 decision as intended rather than accidental.

`GetCapacity` itself has **no unit test** — it needs the ZFSNode informer cache
and `zfs.GetNodeID`. Its pool matching is now `maxFreePool`, which is covered, but
the parameter handling and the zero-capacity fallback are exercised only by BDD.

`gofmt`, `go vet ./pkg/driver`, `go build ./pkg/... ./cmd/...` and
`go test ./pkg/...` are clean. Note `go vet ./pkg/apis/...` already fails on
`develop`, on an `errors.Errorf` with a `%s` and no argument in `zfsvolume.go`;
unrelated to this PR.

`tests/bdd/poolname_poolpattern.feature` already specifies clone and restore under
a pattern class, that a clone inherits the source pool even when another matching
pool has more free space, and that capacity is reported non-zero per topology
segment.
