### PR TITLE
fix(ci): remove hard-coded HOME from Nix setup action

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -38,7 +38,6 @@ runs:
       shell: bash
       run: |
         echo "nix_path=nixpkgs=$(jq -r '.nixpkgs.url' nix/sources.json)" >> $GITHUB_OUTPUT
-        echo "home=${HOME:-/home/runner}" >> $GITHUB_OUTPUT
     - uses: cachix/install-nix-action@v31.11.0
       with:
         nix_path: "${{ steps.nixpkgs.outputs.nix_path }}"
@@ -48,7 +47,6 @@ runs:
           keep-env-derivations = true
           keep-outputs = true
       env:
-        HOME: ${{ steps.nixpkgs.outputs.home }}
         NIX_PATH: "${{ steps.nixpkgs.outputs.nix_path }}"
     - name: PreFetch Nix
       if: ${{ inputs.preFetchNix }}


### PR DESCRIPTION
The HOME override breaks on runners where the actual user doesn't match the hard-coded path. Removing it lets the OS provide the correct value for both GitHub-hosted and self-hosted runners.