### PR TITLE
fix(xfs): keep new xfs volumes mountable on kernels below 5.19

### DIFF
--- a/pkg/driver/agent.go
+++ b/pkg/driver/agent.go
@@ -53,6 +53,10 @@ type node struct {
 func NewNode(d *CSIDriver) csi.NodeServer {
 	var ControllerMutex = sync.RWMutex{}
 
+	// find out how the filesystems of this node have to be formatted, the
+	// answer holds for as long as this agent runs
+	zfs.DetectMkfsOptions()
+
 	// set up signals so we handle the first shutdown signal gracefully
 	// TODO: (tech-debt) Setup signal handler more above, several files want to use stopCh and this function is only allowed to be used once (see #647)
 	// Affected files: pkg/driver/agent.go pkg/driver/controller.go pkg/driver/grpc.go

--- a/pkg/zfs/mkfs.go
+++ b/pkg/zfs/mkfs.go
@@ -1,0 +1,299 @@
+package zfs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"k8s.io/klog/v2"
+)
+
+/*
+ * mkfs.xfs from xfsprogs 6.5 onwards formats with 64-bit extent counters(the
+ * nrext64 incompatible feature) by default, and only kernel 5.19 and above can
+ * mount such a filesystem, the older ones refuse it with
+ *
+ *	XFS (zdN): Superblock has unknown incompatible features (0x20) enabled.
+ *
+ * The node agent shares the kernel that has to mount the volume, so it asks
+ * that kernel whether it takes the feature and turns it off at format time when
+ * it does not. The kernel version is only used when that probe can not be run,
+ * a custom kernel can have the feature backported or left out.
+ */
+const (
+	// first kernel that can mount xfs with nrext64
+	nrext64KernelMajor = 5
+	nrext64KernelMinor = 19
+
+	// mkfs.xfs refuses to work with anything smaller than this
+	mkfsProbeSize = 512 << 20
+
+	// size of the image the kernel probe formats and mounts
+	kernelProbeSize = 320 << 20
+)
+
+// nrext64Off is what gets added to the mkfs.xfs command line to drop nrext64.
+var nrext64Off = []string{"-i", "nrext64=0"}
+
+// xfsMkfsOptions is decided once, when the node agent starts.
+var xfsMkfsOptions []string
+
+// DetectMkfsOptions works out the mkfs options of this node and keeps them for
+// the lifetime of the agent. The kernel and the tools do not change under a
+// running agent, so nothing is probed per volume. Only the node agent needs it,
+// the controller does not format.
+func DetectMkfsOptions() {
+	xfsMkfsOptions = xfsCompatOptions()
+}
+
+// MkfsOptions returns the options the driver adds to the mkfs command for the
+// given filesystem type, on top of the ones k8s.io/mount-utils passes.
+func MkfsOptions(fstype string) []string {
+	if fstype != "xfs" {
+		return nil
+	}
+
+	return xfsMkfsOptions
+}
+
+// xfsCompatOptions returns the mkfs.xfs options that keep the filesystem
+// mountable by the kernel of this node.
+func xfsCompatOptions() []string {
+	// an mkfs.xfs that does not take the option does not set the feature either
+	if !xfsSupportsNrext64Opt() {
+		return nil
+	}
+
+	// what the kernel does with the feature beats what its version says, a
+	// custom kernel can have it backported or left out
+	if takes, conclusive := kernelTakesNrext64(); conclusive {
+		if takes {
+			klog.Infof("zfspv: this kernel mounts xfs with nrext64, formatting xfs with the mkfs defaults")
+			return nil
+		}
+
+		klog.Infof("zfspv: this kernel does not mount xfs with nrext64, formatting without it")
+
+		return nrext64Off
+	}
+
+	var uts syscall.Utsname
+	if err := syscall.Uname(&uts); err != nil {
+		klog.Warningf("zfspv: can not get the kernel version(%v), formatting xfs without nrext64", err)
+		return nrext64Off
+	}
+
+	release := utsString(uts.Release[:])
+	options := xfsOptionsForKernel(release)
+	klog.Infof("zfspv: went by the kernel version %s, formatting xfs with mkfs options %v", release, options)
+
+	return options
+}
+
+/*
+ * kernelTakesNrext64 reports whether the kernel of this node mounts an xfs
+ * filesystem that has nrext64 set. It formats a throwaway image with the
+ * feature and tries to mount it read only, which is the only answer the kernel
+ * gives for sure, there is nothing in sysfs listing the xfs features it knows.
+ *
+ * The second return value is false when the probe could not be carried out, the
+ * caller then has to fall back on the kernel version.
+ */
+func kernelTakesNrext64() (bool, bool) {
+	dir, err := os.MkdirTemp("", "zfspv-xfs-probe")
+	if err != nil {
+		klog.Warningf("zfspv: can not create the kernel probe directory: %v", err)
+		return false, false
+	}
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			klog.Warningf("zfspv: can not remove the kernel probe directory %s: %v", dir, err)
+		}
+	}()
+
+	image := filepath.Join(dir, "image")
+	if err := os.WriteFile(image, nil, 0600); err != nil {
+		klog.Warningf("zfspv: can not create the kernel probe image: %v", err)
+		return false, false
+	}
+
+	if err := os.Truncate(image, kernelProbeSize); err != nil {
+		klog.Warningf("zfspv: can not size the kernel probe image: %v", err)
+		return false, false
+	}
+
+	if out, err := exec.Command("mkfs.xfs", "-q", "-f", "-i", "nrext64=1", image).CombinedOutput(); err != nil {
+		klog.Warningf("zfspv: can not format the kernel probe image(%v: %s)", err, strings.TrimSpace(string(out)))
+		return false, false
+	}
+
+	device, err := attachLoop(image)
+	if err != nil {
+		klog.Warningf("zfspv: can not attach the kernel probe image: %v", err)
+		return false, false
+	}
+	defer detachLoop(device)
+
+	mountpoint := filepath.Join(dir, "mnt")
+	if err := os.Mkdir(mountpoint, 0750); err != nil {
+		klog.Warningf("zfspv: can not create the kernel probe mountpoint: %v", err)
+		return false, false
+	}
+
+	err = syscall.Mount(device, mountpoint, "xfs", syscall.MS_RDONLY, "")
+	switch {
+	case err == nil:
+		if err := syscall.Unmount(mountpoint, 0); err != nil {
+			klog.Warningf("zfspv: can not unmount the kernel probe %s: %v", mountpoint, err)
+		}
+
+		return true, true
+
+	case errors.Is(err, syscall.EINVAL):
+		// the superblock was written by the mkfs of this image and mkfs was
+		// happy with it, so the kernel turning it down is the feature check
+		return false, true
+
+	default:
+		klog.Warningf("zfspv: the kernel probe could not be mounted: %v", err)
+		return false, false
+	}
+}
+
+// attachLoop puts the given file behind a loop device and returns it.
+func attachLoop(image string) (string, error) {
+	out, err := exec.Command("losetup", "--find", "--show", image).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("losetup: %v: %s", err, strings.TrimSpace(string(out)))
+	}
+
+	device := strings.TrimSpace(string(out))
+	if device == "" {
+		return "", fmt.Errorf("losetup returned no device")
+	}
+
+	return device, nil
+}
+
+// detachLoop frees a loop device. Loop devices are shared with the host, so one
+// left behind is a leak.
+func detachLoop(device string) {
+	if out, err := exec.Command("losetup", "--detach", device).CombinedOutput(); err != nil {
+		klog.Warningf("zfspv: can not detach %s(%v: %s)", device, err, strings.TrimSpace(string(out)))
+	}
+}
+
+// xfsOptionsForKernel returns the mkfs.xfs options needed by the given kernel
+// release. A release that can not be read is treated as an old one.
+func xfsOptionsForKernel(release string) []string {
+	major, minor, err := parseVersion(release)
+	if err != nil {
+		klog.Warningf("zfspv: can not parse the kernel release %q(%v), formatting xfs without nrext64", release, err)
+		return nrext64Off
+	}
+
+	if versionAtLeast(major, minor, nrext64KernelMajor, nrext64KernelMinor) {
+		return nil
+	}
+
+	return nrext64Off
+}
+
+// xfsSupportsNrext64Opt asks mkfs.xfs whether it takes "-i nrext64=". mkfs.xfs
+// -N only parses the command line and prints the geometry it would use, so the
+// probe writes nothing and needs no real device, a sparse file is enough.
+func xfsSupportsNrext64Opt() bool {
+	probe, err := os.CreateTemp("", "zfspv-mkfs-probe")
+	if err != nil {
+		klog.Warningf("zfspv: can not create the mkfs.xfs probe file(%v), formatting xfs with the mkfs defaults", err)
+		return false
+	}
+
+	name := probe.Name()
+	defer func() {
+		if err := os.Remove(name); err != nil {
+			klog.Warningf("zfspv: can not remove the mkfs.xfs probe file %s: %v", name, err)
+		}
+	}()
+
+	if err := probe.Truncate(mkfsProbeSize); err != nil {
+		_ = probe.Close()
+		klog.Warningf("zfspv: can not size the mkfs.xfs probe file(%v), formatting xfs with the mkfs defaults", err)
+		return false
+	}
+
+	if err := probe.Close(); err != nil {
+		klog.Warningf("zfspv: can not close the mkfs.xfs probe file(%v), formatting xfs with the mkfs defaults", err)
+		return false
+	}
+
+	args := append([]string{"-N"}, append(nrext64Off, name)...)
+	if out, err := exec.Command("mkfs.xfs", args...).CombinedOutput(); err != nil {
+		klog.Infof("zfspv: this mkfs.xfs does not take nrext64(%v: %s), formatting xfs with the mkfs defaults",
+			err, strings.TrimSpace(string(out)))
+		return false
+	}
+
+	return true
+}
+
+// utsString turns a null terminated uname field into a string.
+func utsString(field []int8) string {
+	out := make([]byte, 0, len(field))
+	for _, c := range field {
+		if c == 0 {
+			break
+		}
+		out = append(out, byte(c))
+	}
+
+	return string(out)
+}
+
+// parseVersion picks the major and the minor version out of a version string,
+// coping with the kernel releases of the distros, "5.15.0-190-generic",
+// "4.18.0-513.9.1.el8_9.x86_64" and "6.18.0-rc4" are all valid input.
+func parseVersion(version string) (int, int, error) {
+	fields := strings.SplitN(strings.TrimSpace(version), ".", 3)
+	if len(fields) < 2 {
+		return 0, 0, fmt.Errorf("can not parse version %q", version)
+	}
+
+	major, err := strconv.Atoi(leadingDigits(fields[0]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("can not parse version %q", version)
+	}
+
+	minor, err := strconv.Atoi(leadingDigits(fields[1]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("can not parse version %q", version)
+	}
+
+	return major, minor, nil
+}
+
+// leadingDigits returns the digits at the start of a version field, the rest is
+// the distro specific part.
+func leadingDigits(field string) string {
+	for i, c := range field {
+		if c < '0' || c > '9' {
+			return field[:i]
+		}
+	}
+
+	return field
+}
+
+// versionAtLeast tells if major.minor is not older than the wanted version.
+func versionAtLeast(major, minor, wantMajor, wantMinor int) bool {
+	if major != wantMajor {
+		return major > wantMajor
+	}
+
+	return minor >= wantMinor
+}

--- a/pkg/zfs/mkfs_test.go
+++ b/pkg/zfs/mkfs_test.go
@@ -1,0 +1,242 @@
+package zfs
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// TestXfsOptionsForKernel walks the kernel releases of the distros through the
+// format decision. Everything below 5.19 has to lose nrext64, everything from
+// 5.19 keeps the mkfs defaults.
+func TestXfsOptionsForKernel(t *testing.T) {
+	tests := map[string]struct {
+		release  string
+		expected []string
+	}{
+		"rhel 8":              {release: "4.18.0-513.9.1.el8_9.x86_64", expected: nrext64Off},
+		"debian 10":           {release: "4.19.0-25-amd64", expected: nrext64Off},
+		"sles 15 sp2":         {release: "5.3.18-150300.59.87-default", expected: nrext64Off},
+		"ubuntu 20.04":        {release: "5.4.0-192-generic", expected: nrext64Off},
+		"rhel 9":              {release: "5.14.0-427.13.1.el9_4.x86_64", expected: nrext64Off},
+		"ubuntu 22.04":        {release: "5.15.0-190-generic", expected: nrext64Off},
+		"last kernel without": {release: "5.18.19-051819-generic", expected: nrext64Off},
+		"first kernel with":   {release: "5.19.17-051917-generic", expected: nil},
+		"debian 12":           {release: "6.1.0-13-amd64", expected: nil},
+		"ubuntu 24.04":        {release: "6.8.0-137-generic", expected: nil},
+		"aws 5.19":            {release: "5.19.0-1025-aws", expected: nil},
+		"talos":               {release: "6.12.13-talos", expected: nil},
+		"release candidate":   {release: "6.18.0-rc4", expected: nil},
+		"next major":          {release: "7.0.0-generic", expected: nil},
+		"unreadable release":  {release: "linux", expected: nrext64Off},
+		"empty release":       {release: "", expected: nrext64Off},
+		"major only":          {release: "6", expected: nrext64Off},
+		"non numeric":         {release: "v5.19.0", expected: nrext64Off},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := xfsOptionsForKernel(test.release)
+			if !reflect.DeepEqual(got, test.expected) {
+				t.Fatalf("kernel %q: expected %v, got %v", test.release, test.expected, got)
+			}
+		})
+	}
+}
+
+func TestParseVersion(t *testing.T) {
+	tests := map[string]struct {
+		version   string
+		major     int
+		minor     int
+		expectErr bool
+	}{
+		"ubuntu kernel":     {version: "5.15.0-190-generic", major: 5, minor: 15},
+		"rhel kernel":       {version: "4.18.0-513.9.1.el8_9.x86_64", major: 4, minor: 18},
+		"rc kernel":         {version: "6.18.0-rc4", major: 6, minor: 18},
+		"two digit minor":   {version: "5.19.0-1025-aws", major: 5, minor: 19},
+		"no patch level":    {version: "7.1", major: 7, minor: 1},
+		"trailing newline":  {version: " 6.5.0\n", major: 6, minor: 5},
+		"no minor":          {version: "6", expectErr: true},
+		"empty":             {version: "", expectErr: true},
+		"not a version":     {version: "linux", expectErr: true},
+		"no leading digits": {version: "v6.5.0", expectErr: true},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			major, minor, err := parseVersion(test.version)
+			if test.expectErr {
+				if err == nil {
+					t.Fatalf("expected an error for %q, got %d.%d", test.version, major, minor)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", test.version, err)
+			}
+			if major != test.major || minor != test.minor {
+				t.Fatalf("expected %d.%d for %q, got %d.%d",
+					test.major, test.minor, test.version, major, minor)
+			}
+		})
+	}
+}
+
+func TestVersionAtLeast(t *testing.T) {
+	tests := []struct {
+		major, minor int
+		expected     bool
+	}{
+		{4, 18, false},
+		{5, 4, false},
+		{5, 15, false},
+		{5, 18, false},
+		{5, 19, true},
+		{5, 20, true},
+		{6, 0, true},
+		{6, 12, true},
+		{7, 0, true},
+	}
+
+	for _, test := range tests {
+		got := versionAtLeast(test.major, test.minor, nrext64KernelMajor, nrext64KernelMinor)
+		if got != test.expected {
+			t.Fatalf("expected %t for kernel %d.%d, got %t", test.expected, test.major, test.minor, got)
+		}
+	}
+}
+
+func TestMkfsOptions(t *testing.T) {
+	defer func() { xfsMkfsOptions = nil }()
+	xfsMkfsOptions = nrext64Off
+
+	for _, fstype := range []string{"ext2", "ext3", "ext4", "btrfs", "zfs", ""} {
+		if got := MkfsOptions(fstype); got != nil {
+			t.Fatalf("expected no mkfs options for %q, got %v", fstype, got)
+		}
+	}
+
+	if got := MkfsOptions("xfs"); !reflect.DeepEqual(got, nrext64Off) {
+		t.Fatalf("expected %v for xfs, got %v", nrext64Off, got)
+	}
+}
+
+// TestMkfsOptionsBeforeDetect checks that a format before the detection ran,
+// which should not happen, falls back to the mkfs defaults.
+func TestMkfsOptionsBeforeDetect(t *testing.T) {
+	if got := MkfsOptions("xfs"); got != nil {
+		t.Fatalf("expected no options before the detection ran, got %v", got)
+	}
+}
+
+// TestXfsSupportsNrext64Opt runs the probe against the mkfs.xfs of the machine
+// running the test and checks that it leaves no file behind.
+func TestXfsSupportsNrext64Opt(t *testing.T) {
+	if _, err := exec.LookPath("mkfs.xfs"); err != nil {
+		t.Skip("no mkfs.xfs on this machine")
+	}
+
+	before := probeFiles(t)
+
+	if !xfsSupportsNrext64Opt() {
+		t.Log("this mkfs.xfs does not take -i nrext64=, expected only below xfsprogs 6.0")
+	}
+
+	if after := probeFiles(t); len(after) != len(before) {
+		t.Fatalf("the probe left files behind: %v", after)
+	}
+}
+
+func TestDetectMkfsOptions(t *testing.T) {
+	defer func() { xfsMkfsOptions = nil }()
+
+	DetectMkfsOptions()
+	t.Logf("detected xfs mkfs options on this machine: %v", MkfsOptions("xfs"))
+}
+
+func probeFiles(t *testing.T) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir(os.TempDir())
+	if err != nil {
+		t.Fatalf("can not read %s: %v", os.TempDir(), err)
+	}
+
+	var found []string
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), "zfspv-mkfs-probe") || strings.HasPrefix(entry.Name(), "zfspv-xfs-probe") {
+			found = append(found, filepath.Join(os.TempDir(), entry.Name()))
+		}
+	}
+
+	return found
+}
+
+// TestKernelTakesNrext64 runs the kernel probe on the machine running the test.
+// It needs mkfs.xfs, a free loop device and the right to mount, so an
+// inconclusive result is not a failure, it is what makes the driver fall back
+// on the kernel version.
+func TestKernelTakesNrext64(t *testing.T) {
+	takes, conclusive := kernelTakesNrext64()
+	if !conclusive {
+		t.Skip("the kernel probe could not run here, the version fallback takes over")
+	}
+
+	t.Logf("this kernel mounts xfs with nrext64: %t", takes)
+
+	release := probeRelease(t)
+	major, minor, err := parseVersion(release)
+	if err != nil {
+		return
+	}
+
+	// an upstream kernel has to agree with its own version
+	if byVersion := versionAtLeast(major, minor, nrext64KernelMajor, nrext64KernelMinor); byVersion != takes {
+		t.Logf("kernel %s says %t by version but %t by probe, expected only on a custom kernel",
+			release, byVersion, takes)
+	}
+}
+
+// TestProbesLeaveNothingBehind checks that neither probe leaves a file or a
+// loop device behind, loop devices are shared with the host.
+func TestProbesLeaveNothingBehind(t *testing.T) {
+	loopsBefore := attachedLoops(t)
+
+	xfsSupportsNrext64Opt()
+	kernelTakesNrext64()
+
+	if left := probeFiles(t); len(left) != 0 {
+		t.Fatalf("probe files left behind: %v", left)
+	}
+
+	if loopsAfter := attachedLoops(t); loopsAfter != loopsBefore {
+		t.Fatalf("loop devices leaked: %d before, %d after", loopsBefore, loopsAfter)
+	}
+}
+
+func probeRelease(t *testing.T) string {
+	t.Helper()
+
+	var uts syscall.Utsname
+	if err := syscall.Uname(&uts); err != nil {
+		t.Fatalf("can not get the kernel release: %v", err)
+	}
+
+	return utsString(uts.Release[:])
+}
+
+func attachedLoops(t *testing.T) int {
+	t.Helper()
+
+	out, err := exec.Command("losetup", "--list", "--noheadings").CombinedOutput()
+	if err != nil {
+		return 0
+	}
+
+	return len(strings.Fields(strings.TrimSpace(string(out))))
+}

--- a/pkg/zfs/mount.go
+++ b/pkg/zfs/mount.go
@@ -57,7 +57,8 @@ type MountInfo struct {
 func FormatAndMountZvol(devicePath string, mountInfo *MountInfo) error {
 	mounter := &mount.SafeFormatAndMount{Interface: mount.New(""), Exec: utilexec.New()}
 
-	err := mounter.FormatAndMount(devicePath, mountInfo.MountPath, mountInfo.FSType, mountInfo.MountOptions)
+	err := mounter.FormatAndMountSensitiveWithFormatOptions(devicePath, mountInfo.MountPath,
+		mountInfo.FSType, mountInfo.MountOptions, nil, MkfsOptions(mountInfo.FSType))
 	if err != nil {
 		klog.Errorf(
 			"zfspv: failed to mount volume %s [%s] to %s, error %v",


### PR DESCRIPTION
mkfs.xfs from xfsprogs 6.5, which the alpine based image ships, turns on nrext64 by default. Only kernel 5.19 and above can mount such a filesystem, so on older nodes the xfs volume fails to mount with `Superblock has unknown incompatible features (0x20) enabled`.

The kernel does not list the xfs features it knows anywhere, so at startup the node agent formats a throwaway image with nrext64 and tries to mount it. If the kernel turns it down, the volumes of that node are formatted with `-i nrext64=0`. A custom kernel is then taken as it is, whether the feature is backported or left out. The kernel version is only used when the probe can not run.

Tested on kernels 5.15, 5.18, 5.19 and 6.8, with xfsprogs 5.16, 6.2 and 6.17.