### PR TITLE
feat(formatoptions): add formatOptions storage class parameter

### DIFF
--- a/ci/ci-test.sh
+++ b/ci/ci-test.sh
@@ -184,7 +184,7 @@ helm_install() {
   sudo dd if=/dev/urandom of=/etc/zfs/keys/zfspool0.key bs=32 count=1
   sudo chmod 600 /etc/zfs/keys/zfspool0.key
 
-  helm install zfs-localpv ./deploy/helm/charts -n "$OPENEBS_NAMESPACE" --create-namespace --set zfsPlugin.image.pullPolicy=Never --set analytics.enabled=false --set backupGC.enabled=true
+  helm install zfs-localpv ./deploy/helm/charts -n "$OPENEBS_NAMESPACE" --create-namespace --set zfsPlugin.image.pullPolicy=Never --set analytics.enabled=false --set backupGC.enabled=true --set 'zfsNode.defaultFormatOptions.ext4=-b 2048'
   kubectl apply -f "$SNAP_CLASS"
 
   waitForZFSDriver

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -74,6 +74,12 @@ func main() {
 		&config.PluginType, "plugin", "csi-plugin", "Type of this driver i.e. controller or agent",
 	)
 
+	cmd.PersistentFlags().StringArrayVar(
+		&config.DefaultFormatOptions, "default-format-options", nil,
+		"Extra mkfs options as <fstype>=<space separated options>, used when the storage class "+
+			"of the volume does not set formatOptions. Can be given once per filesystem",
+	)
+
 	err := cmd.Execute()
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "%s", err.Error())
@@ -94,6 +100,14 @@ func run(config *config.Config) {
 		config.Endpoint,
 		config.Nodename,
 	)
+
+	if err := zfs.SetDefaultFormatOptions(config.DefaultFormatOptions); err != nil {
+		log.Fatalln(err)
+	}
+
+	if len(config.DefaultFormatOptions) > 0 {
+		klog.Infof("Default format options: %v", config.DefaultFormatOptions)
+	}
 
 	err := driver.New(config).Run()
 	if err != nil {

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -118,6 +118,7 @@ The following table lists the configurable parameters of the OpenEBS ZFS Localpv
 | `zfsController.snapshotController.image.registry`                     | string | `"registry.k8s.io/"`        | Image registry for the snapshot controller.                                                             |
 | `zfsController.snapshotController.image.repository`                   | string | `"sig-storage/snapshot-controller"` | Image repository for the snapshot controller.                                                           |
 | `zfsController.snapshotController.image.tag`                          | string | `"v8.2.0"`                  | Image tag for the snapshot controller. 
+| `zfsNode.defaultFormatOptions`                                        | map    | `{}`                        | Extra mkfs options per filesystem, used when the StorageClass of a volume does not set `formatOptions`. A StorageClass value replaces the default of its filesystem, the two are not merged. Keys are the formatted filesystem types (ext2, ext3, ext4, xfs, btrfs), values the space separated mkfs options of that filesystem as one string, e.g. `{"ext4": "-m 0", "xfs": "-i nrext64=0"}`. |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/deploy/helm/charts/templates/zfs-node.yaml
+++ b/deploy/helm/charts/templates/zfs-node.yaml
@@ -86,6 +86,11 @@ spec:
             - "--nodename=$(OPENEBS_NODE_NAME)"
             - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
             - "--plugin=$(OPENEBS_NODE_DRIVER)"
+            {{- range $fstype, $options := .Values.zfsNode.defaultFormatOptions }}
+            {{- if $options }}
+            - "--default-format-options={{ $fstype }}={{ $options }}"
+            {{- end }}
+            {{- end }}
           env:
             - name: OPENEBS_NODE_NAME
               valueFrom:

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -36,6 +36,20 @@ loggingLabels:
 # the zfs node daemonset
 zfsNode:
   componentName: openebs-zfs-node
+  # defaultFormatOptions are the extra mkfs options a node uses for a
+  # filesystem when the StorageClass of the volume does not set formatOptions.
+  # The formatOptions of a StorageClass replace the default of its filesystem,
+  # the two are not merged. Keys are the filesystem types the driver formats
+  # (ext2, ext3, ext4, xfs, btrfs), values are the space separated mkfs
+  # options of that filesystem given as one string, for example:
+  #   defaultFormatOptions:
+  #     ext4: "-m 0 -O ^orphan_file"
+  #     xfs: "-i nrext64=0"
+  # The chart sets none. One case where an option is needed: mkfs.xfs 6.5 and
+  # above set nrext64 by default and only kernel 5.19 and above can mount such
+  # a filesystem, so on a cluster with nodes running older kernels give xfs
+  # "-i nrext64=0".
+  defaultFormatOptions: {}
   driverRegistrar:
     name: "csi-node-driver-registrar"
     image:

--- a/docs/storageclasses.md
+++ b/docs/storageclasses.md
@@ -17,6 +17,18 @@ accordingly. FsType can not be modified once volume has been provisioned. If fst
 
 allowed values: "zfs", "ext2", "ext3", "ext4", "xfs", "btrfs"
 
+### formatOptions (*optional* parameter)
+
+formatOptions specifies the extra options passed to mkfs when the volume is formatted on first use, given as one space separated string. It is ignored if fstype is "zfs", where nothing is formatted. The options are used as they are, so they have to be the ones of the mkfs of the given fstype.
+
+```
+formatOptions: "-m 0 -O ^orphan_file"
+```
+
+If a StorageClass does not set it, the node agent uses the default of that fstype, given to it with the `--default-format-options=<fstype>=<options>` option, `zfsNode.defaultFormatOptions` in the helm chart. The value of a StorageClass replaces the default of its fstype, the two are not merged.
+
+The chart sets no default. One case where an option is needed: on a cluster where some nodes run a kernel older than 5.19, set `zfsNode.defaultFormatOptions.xfs` to `-i nrext64=0`, because mkfs.xfs 6.5 and above turn nrext64 on and such kernels can not mount a filesystem with it.
+
 ### recordsize (*optional* parameter)
 
 This parameter is applicable if fstype provided is "zfs" otherwise it will be ignored. It specifies a suggested block size for files in the file system.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,6 +41,11 @@ type Config struct {
 	// which node drivers are running. This is used
 	// to set the topologies for the driver
 	Nodename string
+
+	// DefaultFormatOptions holds the "<fstype>=<options>" mkfs
+	// options this node uses when the storage class of the
+	// volume does not set any
+	DefaultFormatOptions []string
 }
 
 // Default returns a new instance of config

--- a/pkg/driver/agent.go
+++ b/pkg/driver/agent.go
@@ -118,6 +118,8 @@ func GetVolAndMountInfo(
 		mountinfo.MountOptions = append(mountinfo.MountOptions, "ro")
 	}
 
+	mountinfo.FormatOptions = zfs.FormatOptions(mountinfo.FSType, req.GetVolumeContext()[zfs.FormatOptionsKey])
+
 	volName := strings.ToLower(req.GetVolumeId())
 
 	getOptions := metav1.GetOptions{}

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -611,6 +611,11 @@ func (cs *controller) CreateVolume(
 	topology := map[string]string{zfs.ZFSTopologyKey: selectedNodeID}
 	cntx := map[string]string{zfs.PoolNameKey: pool, zfs.OpenEBSCasTypeKey: zfs.ZFSCasTypeName}
 
+	// the node agent formats the volume, hand it the options of the storage class
+	if formatOptions := helpers.GetInsensitiveParameter(&parameters, "formatoptions"); formatOptions != "" {
+		cntx[zfs.FormatOptionsKey] = formatOptions
+	}
+
 	return csipayload.NewCreateVolumeResponseBuilder().
 		WithName(volName).
 		WithCapacity(size).

--- a/pkg/zfs/formatoptions.go
+++ b/pkg/zfs/formatoptions.go
@@ -1,0 +1,69 @@
+package zfs
+
+import (
+	"fmt"
+	"strings"
+)
+
+// fsTypeDefault is the filesystem an empty fstype stands for. A volume
+// capability is allowed to leave the type out, a statically provisioned volume
+// often does, and k8s.io/mount-utils formats such a volume as ext4.
+const fsTypeDefault = "ext4"
+
+// formattableFsTypes are the filesystems the driver puts on a zvol, the only
+// ones a mkfs option can be meant for. A "zfs" volume is a dataset and is never
+// formatted.
+var formattableFsTypes = map[string]bool{
+	"ext2":  true,
+	"ext3":  true,
+	"ext4":  true,
+	"xfs":   true,
+	"btrfs": true,
+}
+
+// defaultFormatOptions holds the mkfs options a node uses for a filesystem when
+// the storage class of the volume does not ask for any. It is set once, from the
+// --default-format-options flags of the node agent.
+var defaultFormatOptions = map[string][]string{}
+
+// SetDefaultFormatOptions takes the "<fstype>=<options>" entries of the node
+// agent and keeps them as the format defaults of this node.
+func SetDefaultFormatOptions(entries []string) error {
+	options := make(map[string][]string, len(entries))
+
+	for _, entry := range entries {
+		fstype, value, found := strings.Cut(entry, "=")
+		if !found {
+			return fmt.Errorf("format options %q are not in the <fstype>=<options> form", entry)
+		}
+
+		fstype = strings.ToLower(strings.TrimSpace(fstype))
+		if !formattableFsTypes[fstype] {
+			return fmt.Errorf("format options %q are for %q, which is not one of the formatted filesystems", entry, fstype)
+		}
+
+		if value := strings.Fields(value); len(value) > 0 {
+			options[fstype] = value
+		}
+	}
+
+	defaultFormatOptions = options
+
+	return nil
+}
+
+// FormatOptions returns the extra mkfs options for the given filesystem, the
+// ones asked for by the storage class if there are any, the defaults of this
+// node otherwise.
+func FormatOptions(fstype, scOptions string) []string {
+	if options := strings.Fields(scOptions); len(options) > 0 {
+		return options
+	}
+
+	fstype = strings.ToLower(strings.TrimSpace(fstype))
+	if fstype == "" {
+		fstype = fsTypeDefault
+	}
+
+	return defaultFormatOptions[fstype]
+}

--- a/pkg/zfs/formatoptions_test.go
+++ b/pkg/zfs/formatoptions_test.go
@@ -1,0 +1,141 @@
+package zfs
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSetDefaultFormatOptions(t *testing.T) {
+	tests := map[string]struct {
+		entries   []string
+		expected  map[string][]string
+		expectErr bool
+	}{
+		"one filesystem": {
+			entries:  []string{"xfs=-i nrext64=0"},
+			expected: map[string][]string{"xfs": {"-i", "nrext64=0"}},
+		},
+		"more than one filesystem": {
+			entries: []string{"xfs=-i nrext64=0", "ext4=-m 0 -O ^orphan_file"},
+			expected: map[string][]string{
+				"xfs":  {"-i", "nrext64=0"},
+				"ext4": {"-m", "0", "-O", "^orphan_file"},
+			},
+		},
+		"fstype is case insensitive": {
+			entries:  []string{"XFS=-i nrext64=0"},
+			expected: map[string][]string{"xfs": {"-i", "nrext64=0"}},
+		},
+		"extra spaces are dropped": {
+			entries:  []string{"xfs=  -i   nrext64=0  "},
+			expected: map[string][]string{"xfs": {"-i", "nrext64=0"}},
+		},
+		"empty options mean no default": {
+			entries:  []string{"xfs="},
+			expected: map[string][]string{},
+		},
+		"nothing given": {
+			entries:  nil,
+			expected: map[string][]string{},
+		},
+		"missing fstype": {
+			entries:   []string{"-i nrext64=0"},
+			expectErr: true,
+		},
+		"no separator at all": {
+			entries:   []string{"xfs -i nrext64"},
+			expectErr: true,
+		},
+		"filesystem that is never formatted": {
+			entries:   []string{"zfs=-i nrext64=0"},
+			expectErr: true,
+		},
+		"unknown filesystem": {
+			entries:   []string{"reiserfs=-q"},
+			expectErr: true,
+		},
+		"empty fstype": {
+			entries:   []string{"=-i nrext64=0"},
+			expectErr: true,
+		},
+	}
+
+	defer func() { defaultFormatOptions = map[string][]string{} }()
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			defaultFormatOptions = map[string][]string{}
+
+			err := SetDefaultFormatOptions(test.entries)
+			if test.expectErr {
+				if err == nil {
+					t.Fatalf("expected an error for %v", test.entries)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error for %v: %v", test.entries, err)
+			}
+
+			if !reflect.DeepEqual(defaultFormatOptions, test.expected) {
+				t.Fatalf("expected %v, got %v", test.expected, defaultFormatOptions)
+			}
+		})
+	}
+}
+
+func TestFormatOptions(t *testing.T) {
+	defer func() { defaultFormatOptions = map[string][]string{} }()
+
+	if err := SetDefaultFormatOptions([]string{"xfs=-i nrext64=0", "ext4=-m 0"}); err != nil {
+		t.Fatalf("can not set the defaults: %v", err)
+	}
+
+	tests := map[string]struct {
+		fstype   string
+		sc       string
+		expected []string
+	}{
+		"default of the filesystem": {
+			fstype: "xfs", sc: "", expected: []string{"-i", "nrext64=0"},
+		},
+		"storage class replaces the default": {
+			fstype: "xfs", sc: "-b size=2048", expected: []string{"-b", "size=2048"},
+		},
+		"default of another filesystem": {
+			fstype: "ext4", sc: "", expected: []string{"-m", "0"},
+		},
+		"filesystem without a default": {
+			fstype: "btrfs", sc: "", expected: nil,
+		},
+		"storage class on a filesystem without a default": {
+			fstype: "btrfs", sc: "-M", expected: []string{"-M"},
+		},
+		"fstype is case insensitive": {
+			fstype: "XFS", sc: "", expected: []string{"-i", "nrext64=0"},
+		},
+		"blank storage class value falls back to the default": {
+			fstype: "xfs", sc: "   ", expected: []string{"-i", "nrext64=0"},
+		},
+		// an empty fstype in the volume capability is formatted as ext4 by
+		// k8s.io/mount-utils, so it has to pick up the ext4 default
+		"no fstype means ext4": {
+			fstype: "", sc: "", expected: []string{"-m", "0"},
+		},
+		"padded fstype": {
+			fstype: "  xfs  ", sc: "", expected: []string{"-i", "nrext64=0"},
+		},
+		"no fstype with a storage class value": {
+			fstype: "", sc: "-b size=2048", expected: []string{"-b", "size=2048"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := FormatOptions(test.fstype, test.sc); !reflect.DeepEqual(got, test.expected) {
+				t.Fatalf("expected %v, got %v", test.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/zfs/mount.go
+++ b/pkg/zfs/mount.go
@@ -51,13 +51,24 @@ type MountInfo struct {
 	// MountOptions specifies the options with
 	// which mount needs to be attempted
 	MountOptions []string `json:"mountOptions"`
+
+	// FormatOptions specifies the extra options passed to mkfs when the
+	// volume is formatted on first use
+	FormatOptions []string `json:"formatOptions"`
 }
 
 // FormatAndMountZvol formats and mounts the created volume to the desired mount path
 func FormatAndMountZvol(devicePath string, mountInfo *MountInfo) error {
 	mounter := &mount.SafeFormatAndMount{Interface: mount.New(""), Exec: utilexec.New()}
 
-	err := mounter.FormatAndMount(devicePath, mountInfo.MountPath, mountInfo.FSType, mountInfo.MountOptions)
+	err := mounter.FormatAndMountSensitiveWithFormatOptions(
+		devicePath,
+		mountInfo.MountPath,
+		mountInfo.FSType,
+		mountInfo.MountOptions,
+		nil, // sensitiveOptions
+		mountInfo.FormatOptions,
+	)
 	if err != nil {
 		klog.Errorf(
 			"zfspv: failed to mount volume %s [%s] to %s, error %v",

--- a/pkg/zfs/volume.go
+++ b/pkg/zfs/volume.go
@@ -64,6 +64,10 @@ const (
 	ZFSStatusReady string = "Ready"
 	// OpenEBSCasTypeKey for the cas-type label
 	OpenEBSCasTypeKey string = "openebs.io/cas-type"
+
+	// FormatOptionsKey carries the extra mkfs options of the storage class
+	// from the controller to the node agent
+	FormatOptionsKey string = "openebs.io/format-options"
 	// ZFSCasTypeName for the name of the cas-type
 	ZFSCasTypeName string = "localpv-zfs"
 )

--- a/tests/provision_test.go
+++ b/tests/provision_test.go
@@ -30,6 +30,7 @@ var _ = Describe("[zfspv] TEST VOLUME PROVISIONING", func() {
 		It("Running zfs volume Creation Test with custom node id", Label("custom-node-id"), volumeCreationTest)
 		It("Running encrypted volume creation test", encryptedVolCreationTest)
 		It("Running shared volume tests", fsVolCreationWithSharedParameterTest)
+		It("Running format options test", formatOptionsTest)
 	})
 })
 
@@ -38,6 +39,47 @@ func fsVolCreationTest() {
 	for _, params := range storageClass {
 		exhaustiveVolumeTests(params)
 	}
+}
+
+/*
+ * formatOptionsTest provisions two volumes, with ext4, whose block size option
+ * needs nothing of the kernel. The storage class of the first leaves
+ * formatOptions out, so the filesystem has to be made with the ext4 node
+ * default that ci-test.sh gives the agent. The storage class of the second
+ * asks mkfs for another block size, which has to replace that default.
+ */
+func formatOptionsTest() {
+	// the block size of the ext4 entry ci-test.sh sets
+	// zfsNode.defaultFormatOptions to
+	const defaultBlockSize = "2048"
+	// the block size asked for by the storage class, replacing the default
+	const scBlockSize = "1024"
+
+	parameters := map[string]string{
+		"fstype": "ext4",
+	}
+
+	By(fmt.Sprintf("####### Creating the storage class without formatOptions : %s #######", formatParams(parameters)))
+	By("Creating Storage Class", func() { createFstypeStorageClass(parameters) })
+	By("creating and verifying PVC bound status", func() { createAndVerifyPVC(pvcNameFormatOptionsDefault) })
+	By("verifying the filesystem was made with the block size of the node default", func() {
+		verifyFormatOptions(appNameFormatOptionsDefault, pvcNameFormatOptionsDefault, defaultBlockSize)
+	})
+	By("Deleting the checker pod", func() { deleteFormatOptionsCheckerPod(appNameFormatOptionsDefault) })
+	By("Deleting pvc", func() { deletePVC(pvcNameFormatOptionsDefault) })
+	By("Deleting storage class", deleteStorageClass)
+
+	parameters["formatOptions"] = "-b " + scBlockSize
+
+	By(fmt.Sprintf("####### Creating the storage class with formatOptions : %s #######", formatParams(parameters)))
+	By("Creating Storage Class", func() { createFstypeStorageClass(parameters) })
+	By("creating and verifying PVC bound status", func() { createAndVerifyPVC(pvcNameFormatOptions) })
+	By("verifying the filesystem was made with the block size of the storage class, not the node default", func() {
+		verifyFormatOptions(appNameFormatOptions, pvcNameFormatOptions, scBlockSize)
+	})
+	By("Deleting the checker pod", func() { deleteFormatOptionsCheckerPod(appNameFormatOptions) })
+	By("Deleting pvc", func() { deletePVC(pvcNameFormatOptions) })
+	By("Deleting storage class", deleteStorageClass)
 }
 
 func fsVolCreationWithSharedParameterTest() {

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -57,6 +57,12 @@ var (
 	pvcNameFS    = "zfspv-pvc-fs"
 	pvcNameBlock = "zfspv-pvc-block"
 
+	pvcNameFormatOptions = "zfspv-pvc-format-options"
+	appNameFormatOptions = "busybox-zfspv-format-options"
+
+	pvcNameFormatOptionsDefault = "zfspv-pvc-format-options-default"
+	appNameFormatOptionsDefault = "busybox-zfspv-format-options-default"
+
 	appNameFS       = "busybox-zfspv-fs"
 	appNameBlock    = "busybox-zfspv-block"
 	appNameFSShared = "busybox-zfspv-fs-shared"

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -612,6 +612,89 @@ func createAndDeployAppPod(appname string, pvcname string) {
 	)
 }
 
+/*
+ * verifyFormatOptions runs a pod that compares the block size of the mounted
+ * filesystem with the one asked for with formatOptions in the storage class.
+ * The pod exits 0 on a match and 1 otherwise and is not restarted, so its phase
+ * carries the result: a wrong block size means the options never reached mkfs.
+ */
+func verifyFormatOptions(podName, pvcName, blockSize string) {
+	check := fmt.Sprintf(
+		"got=$(stat -fc %%s /mnt/datadir); "+
+			"echo \"block size $got, expected %s\"; "+
+			"test \"$got\" = \"%s\"",
+		blockSize, blockSize,
+	)
+
+	checkerPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: OpenEBSNamespace,
+			Labels:    map[string]string{"role": "test", "appName": podName},
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:            "busybox",
+					Image:           "busybox",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command:         []string{"sh", "-c", check},
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "datavol1", MountPath: "/mnt/datadir"},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "datavol1",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: pvcName,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := PodClient.WithNamespace(OpenEBSNamespace).Create(checkerPod)
+	gomega.Expect(err).ShouldNot(
+		gomega.HaveOccurred(),
+		"while creating pod {%s} in namespace {%s}",
+		podName,
+		OpenEBSNamespace,
+	)
+
+	var phase corev1.PodPhase
+	gomega.Eventually(func() corev1.PodPhase {
+		p, err := PodClient.WithNamespace(OpenEBSNamespace).Get(podName, metav1.GetOptions{})
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "while getting pod {%s}", podName)
+
+		phase = p.Status.Phase
+
+		return phase
+	},
+		300, 5).
+		Should(gomega.Or(gomega.Equal(corev1.PodSucceeded), gomega.Equal(corev1.PodFailed)),
+			"while waiting for pod {%s} to finish", podName)
+
+	gomega.Expect(phase).To(gomega.Equal(corev1.PodSucceeded),
+		"while checking the block size of the volume of pvc {%s}, the expected format options did not reach mkfs",
+		pvcName)
+}
+
+// deleteFormatOptionsCheckerPod removes the pod of verifyFormatOptions
+func deleteFormatOptionsCheckerPod(podName string) {
+	err := PodClient.WithNamespace(OpenEBSNamespace).Delete(podName, &metav1.DeleteOptions{})
+	gomega.Expect(err).ShouldNot(
+		gomega.HaveOccurred(),
+		"while deleting pod {%s} in namespace {%s}",
+		podName,
+		OpenEBSNamespace,
+	)
+}
+
 func createAndDeployBlockAppPod(appName, pvcName string) {
 	var err error
 	labels := map[string]string{


### PR DESCRIPTION
Adds a `formatOptions` StorageClass parameter, the way lvm-localpv has it: the controller puts the value in the volume context and the node agent passes it to mkfs when the volume is formatted on first use.

A node also takes a default per filesystem, `--default-format-options=<fstype>=<options>`, used when the StorageClass does not set `formatOptions`. In the chart it is `zfsNode.defaultFormatOptions`, set to `-i nrext64=0` for xfs, because mkfs.xfs 6.5 and above set nrext64 while only kernel 5.19 and above can mount such a filesystem. A StorageClass value replaces the default of its filesystem.

Tested on kernels 5.15 and 6.8: the default alone, a StorageClass adding `-b size=2048`, and a StorageClass asking nrext64 back on 6.8.
