### PR TITLE
fix(apis): name the property in the user property prefix error

### DIFF
--- a/buildscripts/test-cov.sh
+++ b/buildscripts/test-cov.sh
@@ -8,7 +8,7 @@ COVERAGE="$TOP_LEVEL/coverage"
 mkdir -p "$COVERAGE"
 rm "$COVERAGE"/* 2>/dev/null || :
 
-for d in $(go list ./... | grep -v 'pkg/apis\|pkg/generated\|tests'); do
+for d in $(go list ./... | grep -v 'pkg/generated\|tests'); do
     #TODO - Include -race while creating the coverage profile.
     profile="$COVERAGE/unit-coverage-$(date +%s%N).txt"
     go test -coverprofile="$profile" -covermode=atomic $d

--- a/pkg/apis/openebs.io/zfs/v1/zfsvolume.go
+++ b/pkg/apis/openebs.io/zfs/v1/zfsvolume.go
@@ -232,7 +232,7 @@ func (v *VolumeInfo) Validate() error {
 			return err
 		}
 		if !strings.HasPrefix(name, "openebs.io:") {
-			return errors.Errorf("user property '%s' does not have prefix `openebs.io:`")
+			return errors.Errorf("user property '%s' does not have prefix `openebs.io:`", name)
 		}
 	}
 	return nil


### PR DESCRIPTION
## The bug

`VolumeInfo.Validate` rejects a user property that lacks the `openebs.io:` prefix with:

```go
return errors.Errorf("user property '%s' does not have prefix `openebs.io:`")
```

The `%s` has no argument, so the message a user actually sees is:

```
user property '%!s(MISSING)' does not have prefix `openebs.io:`
```

Since `Validate` loops over a map of properties, the one thing the message needed to say was *which* property was rejected, and that is exactly what is missing.

## Why CI did not catch it

`go vet` reports it:

```
pkg/apis/openebs.io/zfs/v1/zfsvolume.go:235:41: errors.Errorf format %s reads arg #1, but call has 0 args
```

but nothing runs it over this package. CI runs `make test`, which runs `buildscripts/test-cov.sh`, and that loop excludes `pkg/apis`:

```sh
for d in $(go list ./... | grep -v 'pkg/apis\|pkg/generated\|tests'); do
```

`go test` applies the printf checks only to the packages it is given, so an excluded package is never checked at all.

This PR drops `pkg/apis` from that exclusion, keeping `pkg/generated` excluded as machine-generated. `go test` runs the printf checks even for a package with **no test files**, so this covers every format string in `pkg/apis` rather than just this call site — no test was needed to make it work. Verified both ways: the full loop passes with the argument restored, and reinstating the bug makes it fail with the vet error above.

## Related, deliberately not fixed here

Two things noticed while tracing this, both out of scope:

- `zfsutil.ValidateUserProperty` (`pkg/zfs/util/userprop.go`) reports a malformed name as `name does not contain ':'`, also without naming the property, so validating a map hits the same "which one?" problem.
- The `openebs.io:` prefix is a bare string literal repeated in `pkg/apis/openebs.io/zfs/v1/zfsvolume.go`, `pkg/builder/volbuilder/build.go` and `pkg/builder/snapbuilder/build.go`, with no shared constant tying them together. Worth one, since a rename on one side silently breaks the others.
